### PR TITLE
Wait for set null before populating again

### DIFF
--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -76,8 +76,11 @@
       ...mapState('user', ['user'])
     },
     beforeCreate() {
-      this.$store.dispatch('user/setUser', null);
-      UserService.getUserProfile()
+      this.$store
+              .dispatch('user/setUser', null)
+              .then(() => {
+                UserService.getUserProfile()
+              });
     },
     metaInfo() {
       return {


### PR DESCRIPTION
Fixing linter error. Waiting on the set user = null before populating it now, to keep order of actions as expected.