### PR TITLE
Fix alias warning in IDE

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,7 @@ export default {
 </script>
 
 <style lang="scss">
-  @import '@/styles/index.scss';
+  @import '~@/styles/index.scss';
 
   /* Remove in 1.2 */
   .v-datatable thead th.column.sortable i {


### PR DESCRIPTION
Close #20 

Solution found [here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000903779-vue-scss-file-cannot-resolve-) fixed the issue.

`npm run build` and the IDE automatic build are both happy now.

![Screenshot_2019-05-13_14-18-05](https://user-images.githubusercontent.com/304786/57592312-2187df00-758a-11e9-95bd-490f99df16f7.png)
