### PR TITLE
Fix URIError to display favicon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,300italic,400italic' rel="stylesheet" type="text/css">
-    <link rel="icon" href="<%= BASE_URL %>favicon.png">
+    <link rel="icon" href="favicon.png">
     <title>Cylc Web</title>
   </head>
   <body>


### PR DESCRIPTION
When running the UI (using the Cylc UI Server), amongst other log messages to the terminal STDOUT I get, repeatedly:

```console
16:37:41.752 [ConfigProxy] error: Error in handler for GET /user/sbarth/%3C%=%20BASE_URL%20%3Efavicon.png: URIError: URI malformed
```

On investigation, there seems to be some placeholder field ``<%= BASE_URL %>`` which I imagine was added & intended to be replaced at a later stage, but the replacement stage was missed. Playing around, the relative path to use so that the favicon is found & shown is simply the current directory, so that the whole placeholder string can simply be removed.

It's obviously not a crucial problem to have resolved at this early stage of the UI development, but the fix is trivial so I thought I would put in a PR!