### PR TITLE
Use UI Server GraphQL endpoint for suites

### DIFF
--- a/src/model/Suite.model.js
+++ b/src/model/Suite.model.js
@@ -1,17 +1,22 @@
 export default class Suite {
-  constructor(name, user, host, port) {
+  constructor(id, name, owner, host, port) {
+    this.id = id;
     this.name = name;
-    this.user = user;
+    this.owner = owner;
     this.host = host;
     this.port = port
+  }
+
+  getId() {
+    return this.id;
   }
 
   getName() {
     return this.name
   }
 
-  getUser() {
-    return this.user
+  getOwner() {
+    return this.owner
   }
 
   getHost() {

--- a/src/views/Suites.vue
+++ b/src/views/Suites.vue
@@ -45,7 +45,7 @@
               slot-scope="{ item }"
             >
               <td>{{ item.name }}</td>
-              <td>{{ item.user }}</td>
+              <td>{{ item.owner }}</td>
               <td>{{ item.host }}</td>
               <td>{{ item.port }}</td>
               <td class="justify-center">

--- a/tests/unit/model/suite.model.spec.js
+++ b/tests/unit/model/suite.model.spec.js
@@ -4,13 +4,15 @@ import Suite from '@/model/Suite.model.js'
 describe('SuiteModel', () => {
   describe('constructor', () => {
     it('should be created', () => {
+      const id = 'john/localhost';
       const name = 'john-suite';
-      const user = 'john';
+      const owner = 'john';
       const host = 'localhost';
       const port = 1234;
-      const suite = new Suite(name, user, host, port);
+      const suite = new Suite(id, name, owner, host, port);
+      expect(suite.getId()).to.equal('john/localhost');
       expect(suite.getName()).to.equal('john-suite');
-      expect(suite.getUser()).to.equal('john');
+      expect(suite.getOwner()).to.equal('john');
       expect(suite.getHost()).to.equal('localhost');
       expect(suite.getPort()).to.equal(1234)
     })


### PR DESCRIPTION
Close #71 

In the past during our first experiments with GraphQL, the endpoint was in `cylc/cylc-flow`. Now it resides in `cylc/cylc-uiserver`. The `cylc scan` was executed actually in a REST endpoint, that was executing the process locally in Python.

So this pull request removes the need to maintain that REST endpoint in `cylc-uiserver` (follow up PR after this one), and changes the Vue.js app to send a GraphQL query to the UI Server instead. The query used is:

```graphql
query {
  tasks {
    id, name, meanElapsedTime, namespace, depth
  }
}
```

This change is based on the pull request by @dwsutherland to `cylc-uiserver`, which is [still pending review](https://github.com/cylc/cylc-uiserver/pull/34). And while I believe we may have code changes, the data model proposed by @dwsutherland has received little negative feedback. So I believe it is safe now to start work on the Vue.js app based on that data model - furthermore, once we are pointing GraphQL queries to the right endpoint, changing the query and model is a 5 minutes job.