### PR TITLE
Show application mode in footer

### DIFF
--- a/src/components/core/Footer.vue
+++ b/src/components/core/Footer.vue
@@ -25,6 +25,7 @@
     </div>
     <v-spacer/>
     <span class="font-weight-light copyright">
+      <strong v-if="env !== 'PRODUCTION'">{{ env }}</strong>
       Cylc UI {{ $store.getters.appVersion }} &copy; 2008-{{ (new Date()).getFullYear() }} NIWA &amp; British Crown (Met Office) &amp; contributors
     </span>
   </v-footer>
@@ -36,7 +37,8 @@ export default {
     links: [
       { name: 'Website', Link: 'https://cylc.github.io/', route: false },
       { name: 'About', Link: '/about', route: true }
-    ]
+    ],
+    env: process.env.NODE_ENV.toUpperCase()
   })
 }
 </script>


### PR DESCRIPTION
Display the application mode in the footer, when it is not equal to `PRODUCTION`. This is useful for troubleshooting and development.

I am planning to use a different response in the services in an mode (e.g. `offline`, for #75 and #77 ). This way we will be able to run the UI completely offline, with some mocked data. But also use other modes like `development` that could still point to development UI servers.