### PR TITLE
Introduce mode offline with mocked data for testing/development

### DIFF
--- a/src/model/Family.model.js
+++ b/src/model/Family.model.js
@@ -1,0 +1,13 @@
+import Task from '@/model/Task.model'
+
+export default class Family {
+  constructor (name, cyclePoint, state, depth, childTasks) {
+    this.name = name
+    this.cyclePoint = cyclePoint
+    this.state = state
+    this.depth = depth
+    this.childTasks = childTasks !== undefined ? childTasks.map((childTask) => {
+      return new Task(childTask.id, childTask.state, childTask.latestMessage, childTask.depth, childTask.jobs)
+    }) : []
+  }
+}

--- a/src/model/Task.model.js
+++ b/src/model/Task.model.js
@@ -1,0 +1,16 @@
+export default class Task {
+  constructor (id, state, latestMessage, depth, jobs) {
+    this.id = id
+    this.state = state
+    this.latestMessage = latestMessage
+    this.depth = depth
+    this.jobs = jobs
+  }
+
+  get jobId () {
+    if (this.jobs !== undefined && this.jobs.length > 0) {
+      return this.jobs.slice(-1)[0].batchSysJobId
+    }
+    return null
+  }
+}

--- a/src/services/mock/suite.service.js
+++ b/src/services/mock/suite.service.js
@@ -1,0 +1,257 @@
+import store from '@/store/'
+
+export const SuiteService = {
+  getSuites() {
+    // https://github.com/kinow/cylc-cassettes/tree/master/cassettes/five/suite.yaml
+    const suites = [
+        {
+          "id": "kinow/five",
+          "name": "five",
+          "host": "kinow-VirtualBox",
+          "owner": "kinow",
+          "port": 43027
+        }
+      ]
+    ;
+    return store.dispatch('suites/setSuites', suites);
+  },
+  getSuiteTasks() {
+    // https://github.com/kinow/cylc-cassettes/tree/master/cassettes/five/tasks-?.yaml
+    const tasks = [
+      [],
+      [],
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 0.0,
+              "namespace": ["root", "prep"],
+              "proxies": [{"id": "kinow/five/20130808T0000Z/prep"}]
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 0.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130808T0000Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 0.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130808T0000Z/bar"}]
+            }]
+          }]
+        }
+      },
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "prep"],
+              "proxies": []
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130808T0000Z/foo"}, {"id": "kinow/five/20130808T1200Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 0.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130808T0000Z/bar"}]
+            }]
+          }]
+        }
+      },
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "prep"],
+              "proxies": []
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130808T1200Z/foo"}, {"id": "kinow/five/20130809T0000Z/foo"}, {"id": "kinow/five/20130809T1200Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130808T1200Z/bar"}, {"id": "kinow/five/20130809T0000Z/bar"}]
+            }]
+          }]
+        }
+      },
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "prep"],
+              "proxies": []
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130810T1200Z/foo"}, {"id": "kinow/five/20130809T1200Z/foo"}, {"id": "kinow/five/20130810T0000Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130810T0000Z/bar"}, {"id": "kinow/five/20130809T1200Z/bar"}]
+            }]
+          }]
+        }
+      },
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "prep"],
+              "proxies": []
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130810T1200Z/foo"}, {"id": "kinow/five/20130811T0000Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130810T1200Z/bar"}]
+            }]
+          }]
+        }
+      },
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "prep"],
+              "proxies": []
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130811T0000Z/foo"}, {"id": "kinow/five/20130811T1200Z/foo"}, {"id": "kinow/five/20130812T0000Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130811T0000Z/bar"}, {"id": "kinow/five/20130811T1200Z/bar"}]
+            }]
+          }]
+        }
+      },
+      {
+        "data": {
+          "workflows": [{
+            "id": "kinow/five",
+            "owner": "kinow",
+            "name": "five",
+            "host": "ranma",
+            "port": 43006,
+            "tasks": [{
+              "id": "kinow/five/prep",
+              "name": "prep",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "prep"],
+              "proxies": []
+            }, {
+              "id": "kinow/five/foo",
+              "name": "foo",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "foo"],
+              "proxies": [{"id": "kinow/five/20130812T1200Z/foo"}, {"id": "kinow/five/20130812T0000Z/foo"}]
+            }, {
+              "id": "kinow/five/bar",
+              "name": "bar",
+              "meta": {"title": "", "description": "", "URL": ""},
+              "meanElapsedTime": 1.0,
+              "namespace": ["root", "bar"],
+              "proxies": [{"id": "kinow/five/20130812T1200Z/bar"}, {"id": "kinow/five/20130812T0000Z/bar"}]
+            }]
+          }]
+        }
+      }
+    ];
+    return store.dispatch('suites/setTasks', tasks);
+  }
+};

--- a/src/services/mock/suite.service.js
+++ b/src/services/mock/suite.service.js
@@ -1,257 +1,1049 @@
 import store from '@/store/'
+import Family from '@/model/Family.model'
 
-export const SuiteService = {
-  getSuites() {
-    // https://github.com/kinow/cylc-cassettes/tree/master/cassettes/five/suite.yaml
-    const suites = [
-        {
-          "id": "kinow/five",
-          "name": "five",
-          "host": "kinow-VirtualBox",
-          "owner": "kinow",
-          "port": 43027
-        }
-      ]
-    ;
-    return store.dispatch('suites/setSuites', suites);
-  },
-  getSuiteTasks() {
-    // https://github.com/kinow/cylc-cassettes/tree/master/cassettes/five/tasks-?.yaml
-    const tasks = [
-      [],
-      [],
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 0.0,
-              "namespace": ["root", "prep"],
-              "proxies": [{"id": "kinow/five/20130808T0000Z/prep"}]
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 0.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130808T0000Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 0.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130808T0000Z/bar"}]
-            }]
-          }]
-        }
-      },
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "prep"],
-              "proxies": []
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130808T0000Z/foo"}, {"id": "kinow/five/20130808T1200Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 0.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130808T0000Z/bar"}]
-            }]
-          }]
-        }
-      },
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "prep"],
-              "proxies": []
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130808T1200Z/foo"}, {"id": "kinow/five/20130809T0000Z/foo"}, {"id": "kinow/five/20130809T1200Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130808T1200Z/bar"}, {"id": "kinow/five/20130809T0000Z/bar"}]
-            }]
-          }]
-        }
-      },
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "prep"],
-              "proxies": []
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130810T1200Z/foo"}, {"id": "kinow/five/20130809T1200Z/foo"}, {"id": "kinow/five/20130810T0000Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130810T0000Z/bar"}, {"id": "kinow/five/20130809T1200Z/bar"}]
-            }]
-          }]
-        }
-      },
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "prep"],
-              "proxies": []
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130810T1200Z/foo"}, {"id": "kinow/five/20130811T0000Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130810T1200Z/bar"}]
-            }]
-          }]
-        }
-      },
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "prep"],
-              "proxies": []
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130811T0000Z/foo"}, {"id": "kinow/five/20130811T1200Z/foo"}, {"id": "kinow/five/20130812T0000Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130811T0000Z/bar"}, {"id": "kinow/five/20130811T1200Z/bar"}]
-            }]
-          }]
-        }
-      },
-      {
-        "data": {
-          "workflows": [{
-            "id": "kinow/five",
-            "owner": "kinow",
-            "name": "five",
-            "host": "ranma",
-            "port": 43006,
-            "tasks": [{
-              "id": "kinow/five/prep",
-              "name": "prep",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "prep"],
-              "proxies": []
-            }, {
-              "id": "kinow/five/foo",
-              "name": "foo",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "foo"],
-              "proxies": [{"id": "kinow/five/20130812T1200Z/foo"}, {"id": "kinow/five/20130812T0000Z/foo"}]
-            }, {
-              "id": "kinow/five/bar",
-              "name": "bar",
-              "meta": {"title": "", "description": "", "URL": ""},
-              "meanElapsedTime": 1.0,
-              "namespace": ["root", "bar"],
-              "proxies": [{"id": "kinow/five/20130812T1200Z/bar"}, {"id": "kinow/five/20130812T0000Z/bar"}]
-            }]
-          }]
-        }
-      }
-    ];
-    return store.dispatch('suites/setTasks', tasks);
+export class SuiteService {
+
+  constructor(currentTaskIndex = 0) {
+    this.currentTaskIndex = currentTaskIndex;
   }
-};
+
+  getSuites() {
+    return store.dispatch('suites/setSuites', SuiteService.MOCKED_SUITES);
+  }
+
+  // suppressing because it is not used in the mock
+  // eslint-disable-next-line no-unused-vars
+  getSuiteTasks(suiteId) {
+    const mockedFamilyProxies = SuiteService.MOCKED_SUITE_TASKS[this.currentTaskIndex].data.familyProxies;
+    const familyProxies = mockedFamilyProxies.map((mockedFamilyProxy) => {
+      return new Family(mockedFamilyProxy.name, mockedFamilyProxy.cyclePoint, mockedFamilyProxy.state, mockedFamilyProxy.depth, mockedFamilyProxy.childTasks);
+    });
+    return store.dispatch('suites/setTasks', familyProxies);
+  }
+
+  // Mocked data, recorded with vcrpy
+
+  // https://github.com/kinow/cylc-cassettes/tree/master/cassettes/five/suite.yaml
+  static MOCKED_SUITES = [
+    {
+      "id": "kinow/five",
+      "name": "five",
+      "host": "kinow-VirtualBox",
+      "owner": "kinow",
+      "port": 43027
+    }
+  ]
+
+  // https://github.com/kinow/cylc-cassettes/tree/master/cassettes/kinow/five/tasks-?.yaml
+  static MOCKED_SUITE_TASKS = [
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"held",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":0,
+              "held":3,
+              "queued":0,
+              "expired":0,
+              "ready":0,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":0,
+              "failed":0,
+              "succeeded":0
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"held",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130808T0000Z/prep",
+                "state":"held",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              },
+              {
+                "id":"kinow/five/20130808T0000Z/foo",
+                "state":"held",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              },
+              {
+                "id":"kinow/five/20130808T0000Z/bar",
+                "state":"held",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"running to stop at 20130812T0000Z",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":1,
+              "held":0,
+              "queued":0,
+              "expired":0,
+              "ready":1,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":0,
+              "failed":0,
+              "succeeded":1
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"ready",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130808T0000Z/prep",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130808T0000Z/prep/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"11841",
+                    "submittedTime":"2019-05-29T23:21:37Z",
+                    "startedTime":"2019-05-29T23:21:37Z",
+                    "finishedTime":"2019-05-29T23:21:37Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130808T0000Z/foo",
+                "state":"ready",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130808T0000Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"",
+                    "submittedTime":"",
+                    "startedTime":"",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130808T0000Z/bar",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"running to stop at 20130812T0000Z",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":2,
+              "held":0,
+              "queued":0,
+              "expired":0,
+              "ready":0,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":0,
+              "failed":0,
+              "succeeded":4
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130808T0000Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130808T0000Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"11883",
+                    "submittedTime":"2019-05-29T23:21:40Z",
+                    "startedTime":"2019-05-29T23:21:40Z",
+                    "finishedTime":"2019-05-29T23:21:40Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130808T0000Z/bar",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130808T0000Z/bar/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"11923",
+                    "submittedTime":"2019-05-29T23:21:43Z",
+                    "startedTime":"2019-05-29T23:21:43Z",
+                    "finishedTime":"2019-05-29T23:21:43Z",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130808T1200Z",
+            "state":"waiting",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130808T1200Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130808T1200Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"11924",
+                    "submittedTime":"2019-05-29T23:21:43Z",
+                    "startedTime":"2019-05-29T23:21:43Z",
+                    "finishedTime":"2019-05-29T23:21:43Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130808T1200Z/bar",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T0000Z",
+            "state":"waiting",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130809T0000Z/foo",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"running to stop at 20130812T0000Z",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":2,
+              "held":0,
+              "queued":0,
+              "expired":0,
+              "ready":0,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":2,
+              "failed":0,
+              "succeeded":6
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130808T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T0000Z",
+            "state":"running",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130809T0000Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130809T0000Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"11996",
+                    "submittedTime":"2019-05-29T23:21:46Z",
+                    "startedTime":"2019-05-29T23:21:46Z",
+                    "finishedTime":"2019-05-29T23:21:46Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130809T0000Z/bar",
+                "state":"running",
+                "latestMessage":"started",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130809T0000Z/bar/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12067",
+                    "submittedTime":"2019-05-29T23:21:49Z",
+                    "startedTime":"2019-05-29T23:21:49Z",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T1200Z",
+            "state":"running",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130809T1200Z/bar",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              },
+              {
+                "id":"kinow/five/20130809T1200Z/foo",
+                "state":"running",
+                "latestMessage":"started",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130809T1200Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12068",
+                    "submittedTime":"2019-05-29T23:21:49Z",
+                    "startedTime":"2019-05-29T23:21:49Z",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T0000Z",
+            "state":"waiting",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130810T0000Z/foo",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"running to stop at 20130812T0000Z",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":0,
+              "held":0,
+              "queued":0,
+              "expired":0,
+              "ready":2,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":0,
+              "failed":0,
+              "succeeded":10
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130808T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T0000Z",
+            "state":"ready",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130810T0000Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130810T0000Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12140",
+                    "submittedTime":"2019-05-29T23:21:52Z",
+                    "startedTime":"2019-05-29T23:21:52Z",
+                    "finishedTime":"2019-05-29T23:21:52Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130810T0000Z/bar",
+                "state":"ready",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130810T0000Z/bar/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"",
+                    "submittedTime":"",
+                    "startedTime":"",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T1200Z",
+            "state":"ready",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130810T1200Z/foo",
+                "state":"ready",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130810T1200Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"",
+                    "submittedTime":"",
+                    "startedTime":"",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"running to stop at 20130812T0000Z",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":2,
+              "held":0,
+              "queued":0,
+              "expired":0,
+              "ready":0,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":0,
+              "failed":0,
+              "succeeded":14
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130808T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130810T1200Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130810T1200Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12212",
+                    "submittedTime":"2019-05-29T23:21:55Z",
+                    "startedTime":"2019-05-29T23:21:55Z",
+                    "finishedTime":"2019-05-29T23:21:55Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130810T1200Z/bar",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130810T1200Z/bar/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12283",
+                    "submittedTime":"2019-05-29T23:21:58Z",
+                    "startedTime":"2019-05-29T23:21:58Z",
+                    "finishedTime":"2019-05-29T23:21:58Z",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130811T0000Z",
+            "state":"waiting",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130811T0000Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130811T0000Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12284",
+                    "submittedTime":"2019-05-29T23:21:58Z",
+                    "startedTime":"2019-05-29T23:21:58Z",
+                    "finishedTime":"2019-05-29T23:21:58Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130811T0000Z/bar",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130811T1200Z",
+            "state":"waiting",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130811T1200Z/foo",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "data":{
+        "workflows":[
+          {
+            "id":"kinow/five",
+            "name":"five",
+            "status":"running to stop at 20130812T0000Z",
+            "stateTotals":{
+              "runahead":0,
+              "waiting":2,
+              "held":0,
+              "queued":0,
+              "expired":0,
+              "ready":0,
+              "submitFailed":0,
+              "submitRetrying":0,
+              "submitted":0,
+              "retrying":0,
+              "running":2,
+              "failed":0,
+              "succeeded":16
+            },
+            "treeDepth":1
+          }
+        ],
+        "familyProxies":[
+          {
+            "name":"root",
+            "cyclePoint":"20130808T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130808T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130809T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130810T1200Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130811T0000Z",
+            "state":"succeeded",
+            "depth":0,
+            "childTasks":[
+
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130811T1200Z",
+            "state":"running",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130811T1200Z/foo",
+                "state":"succeeded",
+                "latestMessage":"succeeded",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130811T1200Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12356",
+                    "submittedTime":"2019-05-29T23:22:01Z",
+                    "startedTime":"2019-05-29T23:22:01Z",
+                    "finishedTime":"2019-05-29T23:22:01Z",
+                    "submitNum":1
+                  }
+                ]
+              },
+              {
+                "id":"kinow/five/20130811T1200Z/bar",
+                "state":"running",
+                "latestMessage":"started",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130811T1200Z/bar/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12429",
+                    "submittedTime":"2019-05-29T23:22:04Z",
+                    "startedTime":"2019-05-29T23:22:04Z",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130812T0000Z",
+            "state":"running",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130812T0000Z/bar",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              },
+              {
+                "id":"kinow/five/20130812T0000Z/foo",
+                "state":"running",
+                "latestMessage":"started",
+                "depth":1,
+                "jobs":[
+                  {
+                    "id":"kinow/five/20130812T0000Z/foo/01",
+                    "host":"localhost",
+                    "batchSysName":"background",
+                    "batchSysJobId":"12430",
+                    "submittedTime":"2019-05-29T23:22:04Z",
+                    "startedTime":"2019-05-29T23:22:04Z",
+                    "finishedTime":"",
+                    "submitNum":1
+                  }
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          },
+          {
+            "name":"root",
+            "cyclePoint":"20130812T1200Z",
+            "state":"waiting",
+            "depth":0,
+            "childTasks":[
+              {
+                "id":"kinow/five/20130812T1200Z/foo",
+                "state":"waiting",
+                "latestMessage":"",
+                "depth":1,
+                "jobs":[
+
+                ]
+              }
+            ],
+            "childFamilies":[
+
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/services/suite.service.js
+++ b/src/services/suite.service.js
@@ -19,10 +19,12 @@ const tasksQuery = gql`query {
 }
 `;
 
-export const SuiteService = {
+export class SuiteService {
+
   createGraphqlClient() {
     return createApolloClient(`${window.location.pathname}/graphql`);
-  },
+  }
+
   getSuites() {
     const apolloClient =  this.createGraphqlClient();
     return apolloClient.query({
@@ -34,8 +36,9 @@ export const SuiteService = {
       const alert = new Alert(error.message, null, 'error');
       return store.dispatch('addAlert', alert);
     });
-  },
-  getSuiteTasks() {
+  }
+
+  getSuiteTasks(suiteId) {
     const apolloClient =  this.createGraphqlClient();
     return apolloClient.query({
       query: tasksQuery
@@ -45,6 +48,6 @@ export const SuiteService = {
     }).catch((error) => { // error is an ApolloError object
       const alert = new Alert(error.message, null, 'error');
       return store.dispatch('addAlert', alert);
-    });
+    })
   }
-};
+}

--- a/src/services/suite.service.js
+++ b/src/services/suite.service.js
@@ -35,13 +35,18 @@ export class SuiteService {
     }).catch((error) => {
       const alert = new Alert(error.message, null, 'error');
       return store.dispatch('addAlert', alert);
-    });
+    })
   }
 
   getSuiteTasks(suiteId) {
     const apolloClient =  this.createGraphqlClient();
     return apolloClient.query({
-      query: tasksQuery
+      query: tasksQuery,
+      variables: {
+        wIds: [suiteId],
+        minDepth: 0,
+        maxDepth: 4
+      }
     }).then((response) => {
       const tasks = response.data.tasks;
       return store.dispatch('suites/setTasks', tasks);

--- a/src/views/Suite.vue
+++ b/src/views/Suite.vue
@@ -44,10 +44,11 @@
                 slot="items"
                 slot-scope="{ item }"
             >
-              <td>{{ item.id }}</td>
               <td>{{ item.name }}</td>
-              <td>{{ item.meanElapsedTime }}</td>
-              <td>{{ item.namespace }}</td>
+              <td>{{ item.state }}</td>
+              <td>{{ item.host }}</td>
+              <td>{{ item.jobId }}</td>
+              <td>{{ item.latestMessage }}</td>
               <td>{{ item.depth }}</td>
             </template>
           </v-data-table>
@@ -58,8 +59,10 @@
 </template>
 
 <script>
-  import {SuiteService} from '@/services/suite.service'
+  import { SuiteService } from 'suite-service'
   import {mapState} from 'vuex'
+
+  const suiteService = new SuiteService();
 
   export default {
     metaInfo() {
@@ -74,23 +77,28 @@
       headers: [
         {
           sortable: true,
-          text: 'ID',
-          value: 'id'
-        },
-        {
-          sortable: true,
-          text: 'Name',
+          text: 'Task',
           value: 'name'
         },
         {
-          sortable: false,
-          text: 'Elapsed Time',
-          value: 'meanElapsedTime'
+          sortable: true,
+          text: 'State',
+          value: 'state'
+        },
+        {
+          sortable: true,
+          text: 'Host',
+          value: 'host'
         },
         {
           sortable: false,
-          text: 'Namespace',
-          value: 'namespace'
+          text: 'Job ID',
+          value: 'jobId'
+        },
+        {
+          sortable: false,
+          text: 'Latest Message',
+          value: 'latestMessage'
         },
         {
           sortable: false,
@@ -105,20 +113,8 @@
       ...mapState(['isLoading'])
     },
     beforeCreate() {
-      // TBD: normally here we would have an ID, then query by ID...
-      SuiteService.getSuites().then(() => {
-        const suites = this.$store.getters['suites/suites'];
-        for (let i = 0; i < suites.length; i++) {
-          if (suites[i].name === this.$route.params.name) {
-            SuiteService.getSuiteTasks(suites[i]);
-            break;
-          }
-        }
-      });
-    },
-    mounted() {
-      const title = `Suite ${this.$route.params.name}`;
-      this.$store.commit('app/setTitle', title);
+      const suiteId = this.$route.params.name
+      suiteService.getSuiteTasks(suiteId)
     }
   }
 </script>

--- a/src/views/Suites.vue
+++ b/src/views/Suites.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script>
-import { SuiteService } from '@/services/suite.service'
+import { SuiteService } from 'suite-service'
 import { mapState } from 'vuex'
 
 

--- a/src/views/Suites.vue
+++ b/src/views/Suites.vue
@@ -69,6 +69,7 @@
 import { SuiteService } from 'suite-service'
 import { mapState } from 'vuex'
 
+const suiteService = new SuiteService();
 
 export default {
   metaInfo () {
@@ -114,7 +115,7 @@ export default {
     ...mapState(['isLoading'])
   },
   beforeCreate() {
-    SuiteService.getSuites()
+    suiteService.getSuites()
   },
   methods: {
     viewSuite(suite) {

--- a/tests/unit/services/suite.service.spec.js
+++ b/tests/unit/services/suite.service.spec.js
@@ -5,6 +5,7 @@ import store from '@/store'
 import Suite from "@/model/Suite.model";
 
 describe('SuiteService', () => {
+  let suiteService = new SuiteService()
   let sandbox;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -42,8 +43,8 @@ describe('SuiteService', () => {
           return Promise.resolve(suitesReturned);
         }
       };
-      sandbox.stub(SuiteService, 'createGraphqlClient').returns(stubClient);
-      return SuiteService.getSuites().then(function() {
+      sandbox.stub(suiteService, 'createGraphqlClient').returns(stubClient);
+      return suiteService.getSuites().then(function() {
         const suites = store.getters['suites/suites'];
         expect(suites.length).to.equal(2);
         expect(suites[0].name).to.equal("suite 1");
@@ -58,8 +59,8 @@ describe('SuiteService', () => {
           return Promise.reject(e);
         }
       };
-      sandbox.stub(SuiteService, 'createGraphqlClient').returns(stubClient);
-      return SuiteService.getSuites().finally(() => {
+      sandbox.stub(suiteService, 'createGraphqlClient').returns(stubClient);
+      return suiteService.getSuites().finally(() => {
         expect(store.state.alerts.length).to.equal(1);
       });
     });
@@ -86,9 +87,9 @@ describe('SuiteService', () => {
           return Promise.resolve(tasksReturned);
         }
       };
-      sandbox.stub(SuiteService, 'createGraphqlClient').returns(stubClient);
+      sandbox.stub(suiteService, 'createGraphqlClient').returns(stubClient);
 
-      return SuiteService.getSuiteTasks(new Suite("suitename", "root", "localhost", 8080)).then(function() {
+      return suiteService.getSuiteTasks(new Suite("suitename", "root", "localhost", 8080)).then(function() {
         const tasks = store.getters['suites/tasks'];
         expect(tasks.length).to.equal(2);
         expect(tasks[0].name).to.equal("speaker 1");
@@ -103,8 +104,8 @@ describe('SuiteService', () => {
           return Promise.reject(e);
         }
       };
-      sandbox.stub(SuiteService, 'createGraphqlClient').returns(stubClient);
-      return SuiteService.getSuiteTasks(new Suite("suitename", "root", "localhost", 8080)).finally(() => {
+      sandbox.stub(suiteService, 'createGraphqlClient').returns(stubClient);
+      return suiteService.getSuiteTasks(new Suite("suitename", "root", "localhost", 8080)).finally(() => {
         expect(store.state.alerts.length).to.equal(1);
       });
     });

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,5 +18,9 @@ module.exports = {
 
       config.devtool('inline-cheap-module-source-map')
     }
+
+    // set up aliases for mock services, used when the offline mode is used
+    const suiteService = process.env.NODE_ENV === 'offline' ? '@/services/mock/suite.service' : '@/services/suite.service';
+    config.resolve.alias.set('suite-service', suiteService)
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -20,7 +20,9 @@ module.exports = {
     }
 
     // set up aliases for mock services, used when the offline mode is used
-    const suiteService = process.env.NODE_ENV === 'offline' ? '@/services/mock/suite.service' : '@/services/suite.service';
+    const suiteService = process.env.NODE_ENV === 'offline'
+      ? '@/services/mock/suite.service'
+      : '@/services/suite.service'
     config.resolve.alias.set('suite-service', suiteService)
   }
 }


### PR DESCRIPTION
Close #77 

The only important change for now in this PR is `vue.config.js`, which gets an __alias__ `suite-service`, used in JavaScript when importing the `SuiteService`.

When a developer specifies `NODE_ENV=?`, that value will be used, and if the value is equal to `offline`, then the returned value will be `@/services/mock/suite.service`. Otherwise it will use the real service `@/services/suite.service`, that instead of using the mocked data, it will pull from the GraphQL endpoint.

Other changes here include some new classes that will be used in #78 , with some changes to accommodate the required data structure of the Vue.js component used to render the tree view.