### PR TITLE
Display view title even after refresh, and include suite name as example

### DIFF
--- a/src/components/core/Toolbar.vue
+++ b/src/components/core/Toolbar.vue
@@ -81,11 +81,9 @@
 
 <script>
 
-import {
-  mapMutations
-} from 'vuex'
+  import { mapMutations, mapState } from 'vuex'
 
-export default {
+  export default {
   data: () => ({
     notifications: [
       'Mike, John responded to your email',
@@ -94,18 +92,22 @@ export default {
       'Another Notification',
       'Another One'
     ],
-    title: null,
     responsive: false,
     responsiveInput: false
   }),
 
+  computed: {
+    ...mapState('app', ['title'])
+  },
+
   watch: {
     '$route' (val) {
-      this.title = val.name
+      this.$store.commit('app/setTitle', val.name);
     }
   },
 
   mounted () {
+    this.$store.commit('app/setTitle', this.$route.name);
     this.onResponsiveInverted()
     window.addEventListener('resize', this.onResponsiveInverted)
   },

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -2,14 +2,16 @@ import { set, toggle } from '@/utils/vuex'
 
 const state = {
   drawer: null,
-  color: 'success'
+  color: 'success',
+  title: null
 };
 
 const mutations = {
   setDrawer: set('drawer'),
   setImage: set('image'),
   setColor: set('color'),
-  toggleDrawer: toggle('drawer')
+  toggleDrawer: toggle('drawer'),
+  setTitle: set('title')
 };
 
 const actions = {};
@@ -18,5 +20,5 @@ export const app = {
   namespaced: true,
   state,
   actions,
-  mutations
+  mutations,
 };

--- a/src/views/Suite.vue
+++ b/src/views/Suite.vue
@@ -115,6 +115,10 @@
           }
         }
       });
+    },
+    mounted() {
+      const title = `Suite ${this.$route.params.name}`;
+      this.$store.commit('app/setTitle', title);
     }
   }
 </script>


### PR DESCRIPTION
Close #88 

Moves the View title from the Toolbar component data section to a global Vuex (`title` property of the `app` module).

The Suite view now works even after refreshing, and as the data is global, the Suite View is able to set the title to "Suite five", for instance.

Cheers
Bruno