### PR TITLE
Mount component once at test, avoiding timeouts

### DIFF
--- a/tests/unit/graph/graph.spec.js
+++ b/tests/unit/graph/graph.spec.js
@@ -15,43 +15,37 @@ Vue.use(
 )
 
 describe('Graph', () => {
+  const wrapper = mount(Graph)
+
   it('should mount for testing', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[id="holder"]'))
   })
 
   it('should create the cytoscape element', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[id="cytoscape"]'))
   })
 
   it('should create the loading spinner', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[id="spinner"]'))
   })
 
   it('should create the switch layout buttons div', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[class="switchlayout"]'))
   })
 
   it('should create the cytoscape-navigator-view', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[class="cytoscape-navigatorView"]'))
   })
 
   it('should create the cytoscape-navigator-overlay', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[class="cytoscape-navigatorOverlay"]'))
   })
 
   it('should create the cytoscape-navigatorView', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[class="cytoscape-navigatorView"]'))
   })
 
   it('should load the panzoom extension', () => {
-    const wrapper = mount(Graph)
     expect(wrapper.find('[class="cy-panzoom"]'))
   })
 })


### PR DESCRIPTION
Fix unit tests by avoiding timeouts in tests by mounting the component just once.

There are warnings about canvas not available, but the tests are passing locally. I think we will need to review the tests later.

Feel free to merge if the build is passing on Travis :+1: 