### PR TITLE
Task job icons

### DIFF
--- a/src/components/cylc/Job.vue
+++ b/src/components/cylc/Job.vue
@@ -1,0 +1,82 @@
+<!--
+  Job - The job status icon implemented as an inline-block level object
+        which can sit in text.
+-->
+
+<template>
+  <span style="display:inline-block; vertical-align:middle">
+    <!-- the task icon SVG
+           * comments prefixed `let` are instructions for changing style
+           * contain in a 100x100 viewBox so pixels and percent are equal
+           * bind the job status here, respond to styling in the CSS
+    -->
+    <svg 
+      class="job"
+      v-bind:class="[status]"
+      viewBox="0 0 100 100"
+    >
+      <!-- the job status icon
+           * let width = 100 - x - stroke-width
+           * let height = 100 - y - stroke-width
+      -->
+      <rect
+        x="10" y="10"
+        width="80" height="80"
+        rx="20" ry="20"
+        stroke-width="10"
+      />
+    </svg>
+  </span>
+</template>
+
+
+<style lang="scss">
+    svg.job {
+        /* scale the icon to the font-size */
+        width: 1em;
+        height: 1em;
+
+        rect {
+            /* if no job status display nothing */
+            fill: transparent;
+            stroke: transparent;
+        }
+
+        &.submitted rect {
+            fill: rgb(125,207,212);
+            stroke: rgb(125,207,212);
+        }
+
+        &.running rect {
+            fill: rgb(106,164,241);
+            stroke: rgb(106,164,241);
+        }
+
+        &.succeeded rect {
+            fill: rgb(81,175,81);
+            stroke: rgb(81,175,81);
+        }
+
+        &.failed rect {
+            fill: rgb(207,72,72);
+            stroke: rgb(207,72,72);
+        }
+
+        &.submit-failed rect {
+            fill: rgb(190,106,192);
+            stroke: rgb(190,106,192);
+        }
+    }
+</style>
+
+
+<script>
+    export default {
+        name: 'Job',
+        data: function () {
+            return {
+                'status': 'running'
+            }
+        }
+    }
+</script>

--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -1,0 +1,176 @@
+<!--
+  Task - The task status icon implemented as an inline-block level object
+         which can sit in text.
+-->
+
+<template>
+  <span style="display:inline-block; vertical-align:middle">
+    <!-- the task icon SVG
+           * comments prefixed `let` are instructions for changing style
+           * contain in a 100x100 viewBox so pixels and percent are equal
+           * bind the task status here, respond to styling in the CSS
+    -->
+    <svg 
+      class="task"
+      v-bind:class="[status]"
+      viewBox="0 0 100 100"
+    >
+      <!-- progress pie chart:
+             * position in the middle
+             * let radius = 25% radius
+             * let stroke-width = 100% - (2*radius) = 50%
+             * let stroke-dasharray ~= 2 * pi * radius
+             * use dashes as the line style to turn this into a pie chart
+      -->
+      <circle
+        id="progress"
+        cx="50" cy="50"
+        r="25"
+        stroke-width="50"
+        stroke-dasharray="157"
+        v-bind:style="progressStyle"
+      ></circle>
+      <!-- circle in the middle
+             * position in the middle
+             * radius can be changed independently
+      -->
+      <circle
+        id="hub"
+        cx="50" cy="50"
+        r="12">
+      </circle>
+      <!-- outer circle
+             * position in the middle
+             * let radius = 50% - (2*stroke-width)
+      -->
+      <circle
+        id="outline"
+        cx="50" cy="50"
+        r="46"
+        stroke-width="8">
+      </circle>
+      <!-- cross (failure)
+             * create a plus and rotate it 45 deg around the origin
+             * let rx ~= max(width, height) * 0.1
+      -->
+      <g
+        id="cross"
+        transform="rotate(45, 50, 50)"
+      >
+        <rect
+          x=15 y=45
+          width="70" height="10"
+          rx="7" ry="7"
+        ></rect>
+        <rect
+          x=45 y=15
+          width="10" height="70"
+          rx="7" ry="7"
+        ></rect>
+      </g>
+    </svg>
+  </span>
+</template>
+
+
+<style lang="scss">
+    $colour: rgb(90,90,90);
+
+    @mixin disk() {
+        #outline {
+            stroke: $colour;
+            fill: $colour;
+        }
+    }
+
+    @mixin outline() {
+        #outline {
+            stroke: $colour;
+        }
+    }
+
+    @mixin hub() {
+        #hub {
+            fill: $colour;
+        }
+    }
+
+    @mixin progress() {
+        #progress {
+            fill: transparent;
+            stroke: $colour;
+            transform-origin: 50% 50%;
+            transform: rotate(-90deg);
+            opacity: 0.4;
+        }
+    }
+
+    @mixin cross() {
+        #cross rect {
+            fill: $colour;
+        }
+    }
+
+    svg.task {
+        /* scale the icon to the font-size */
+        width: 1em;
+        height: 1em;
+
+        circle, rect {
+            /* if no task status display nothing */
+            fill: transparent;
+            stroke: transparent;
+        }
+
+        &.waiting {
+            @include outline();
+        }
+
+        &.submitted {
+            @include outline();
+            @include hub();
+        }
+
+        &.running {
+            @include outline();
+            @include hub();
+            @include progress();
+        }
+
+        &.succeeded {
+            @include disk();
+        }
+
+        &.failed {
+            @include outline();
+            @include cross();
+        }
+
+        &.submit-failed {
+            @include outline();
+            @include hub();
+            @include cross();
+        }
+    }
+</style>
+
+
+<script>
+    export default {
+        name: 'Task',
+        data: function () {
+            return {
+                'status': 'running',
+                'progress': 25
+            }
+        },
+        computed: {
+            progressStyle: function () {
+                return {
+                    'stroke-dashoffset':
+                        `calc(157 - (157 * ${this.progress/100} + ))`
+                }
+            }
+        }
+    }
+</script>


### PR DESCRIPTION
close #100 

Add components for the task an job status icons.

* One component for tasks and one for jobs, respond to state changes ala Vue.
* `inline-block` level components `1em x 1em` which can sit in text without disrupting the baseline (much).

### Integration

I'm not sure how best to incorporate these components into a Vue view. We want these components to feed off of the data model of the component which uses them, are `props` good enough for this?

For the moment these are standalone components.

### Example

```vue
<template>
  <span>
    <Task />
    foo
    <Job />
  </span>
</template>
```

Fiddling the `data` in the components you will get something like this:

![Screenshot from 2019-07-03 16-41-28](https://user-images.githubusercontent.com/16705946/60605821-1f841480-9db2-11e9-9c00-27e71c3d06ff.png)

### TODO (future work)

* Incorporate into views.
    * Work out how we are going to feed data into these components (e.g. props or whatever).
* Animate state changes.
    * Pure CSS probably wont be enough.
* Add the more eccentric task states (expired, queued, retrying) and the held icon.
    * Expired and queued are easy, the rest will require a dig into the Cylc Flow code to see what separation is possible with the current internals of Cylc.
* Extract the `<style>` from the Job component to make it theme-able.