### PR TITLE
Run data returned from GraphQL through vue-ads-table-tree transformer

### DIFF
--- a/src/services/suite.service.js
+++ b/src/services/suite.service.js
@@ -2,6 +2,7 @@ import Alert from '@/model/Alert.model'
 import { createApolloClient } from '@/utils/graphql'
 import gql from 'graphql-tag'
 import store from '@/store/'
+import VueAdsTableTreeTransformer from '@/transformers/vueadstabletree.transformer'
 
 // query to retrieve all suites
 const suitesQuery = gql`{
@@ -85,6 +86,7 @@ export class SuiteService {
 
   constructor() {
     this.apolloClient = this.createGraphqlClient()
+    this.transformer = new VueAdsTableTreeTransformer()
   }
 
   createGraphqlClient() {
@@ -132,7 +134,8 @@ export class SuiteService {
       },
       fetchPolicy: 'no-cache'
     }).then((response) => {
-      const tasks = response.data.familyProxies;
+      const familyProxies = response.data.familyProxies;
+      const tasks = this.transformer.transform(familyProxies);
       return store.dispatch('suites/setTree', tasks);
     }).catch((error) => { // error is an ApolloError object
       const alert = new Alert(error.message, null, 'error');


### PR DESCRIPTION
Hi,

I had written a transformer for the component we are using for the suite tree view, vue-ads-table-tree. But I used it only in the mocked data, when running the system in offline mode (i.e. `NODE_ENV=offline`).

Luckily, simply applying the transformer in the service with the real data seems to fix the current suite tree view, allowing others to see the tasks being updated in short intervals (we are polling the data in 3 seconds I believe).

@hjoliver let me know if this one works for you too, please.

Cheers
Bruno