### PR TITLE
Use a local isLoading flag for the suites view table

### DIFF
--- a/src/views/Suites.vue
+++ b/src/views/Suites.vue
@@ -78,6 +78,7 @@ export default {
     }
   },
   data: () => ({
+    isLoading: true,
     pagination: {
       rowsPerPage: 10
     },
@@ -114,10 +115,11 @@ export default {
   computed: {
     // namespace: module suites, and property suites, hence these repeated tokens...
     ...mapState('suites', ['suites']),
-    ...mapState(['isLoading'])
   },
   beforeCreate() {
-    suiteService.getSuites()
+    suiteService
+      .getSuites()
+      .finally(() => { this.isLoading = false })
     // TODO: to be replaced by websockets
     this.polling = setInterval(() => {
       suiteService.getSuites()


### PR DESCRIPTION
Closes #104 

The suites view displays a table with the suites (workflows). When the page is being loaded, there is a loading indicator at the very top of the page (before it's loaded, you should see a quick bar at the top).

Then, once loaded, there is another asynchronous task to retrieve the list of suites (calling the `SuiteService.getSuites`). That task is using Axios, and we have a [global interceptor](https://github.com/cylc/cylc-ui/blob/78f802e5713f6b33bb904f91a5cd4eb9ed4eb445/src/plugins/axios.js#L7) in Axios to set a global flag `isLoading` to `true` whenever there is a request in action.

The table of suites is a component from Vuetify, that [supports a loading indicator](https://vuetifyjs.com/en/components/data-tables#api). The loading indicator was attached to the global `isLoading` status. So as there is a polling happening every 5 seconds to retrieve the list of suites - to be replaced by WebSockets in the future - we see the loading indicator in the table component.

Which is annoying, I agree :grimacing: 

What this pull request does, is to create a local `isLoading` flag, that is set to `true`, and after the request to load the suites is done (whether success or not) the loading flag is set back to `false`.

This way, the loading indicator should be displayed just once, when loading the view :+1: 

Tested locally on Firefox.