### PR TITLE
Display single error message

### DIFF
--- a/src/components/core/Alert.vue
+++ b/src/components/core/Alert.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-container v-for="alert in alerts" :key="alert.text">
+    <v-container v-if="alert !== null" :key="alert.text">
       <v-alert :value="true" :color="alert.getColor()" :icon="alert.getIcon()" dismissible>
         {{ alert.getText() }}
       </v-alert>
@@ -16,11 +16,7 @@
     name: "Alert",
 
     computed: {
-      ...mapState(['alerts']),
+      ...mapState(['alert'])
     }
   }
 </script>
-
-<style scoped>
-
-</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,7 +53,7 @@ Vue.use(Meta);
 router.beforeResolve((to, from, next) => {
   if (to.name) {
     NProgress.start();
-    store.dispatch('clearAlerts');
+    store.dispatch('setAlert', null);
   }
   next();
 });

--- a/src/services/suite.service.js
+++ b/src/services/suite.service.js
@@ -102,7 +102,7 @@ export class SuiteService {
       return store.dispatch('suites/setSuites', suites);
     }).catch((error) => {
       const alert = new Alert(error.message, null, 'error');
-      return store.dispatch('addAlert', alert);
+      return store.dispatch('setAlert', alert);
     })
   }
 
@@ -120,7 +120,7 @@ export class SuiteService {
       return store.dispatch('suites/setTasks', tasks);
     }).catch((error) => { // error is an ApolloError object
       const alert = new Alert(error.message, null, 'error');
-      return store.dispatch('addAlert', alert);
+      return store.dispatch('setAlert', alert);
     })
   }
 
@@ -139,7 +139,7 @@ export class SuiteService {
       return store.dispatch('suites/setTree', tasks);
     }).catch((error) => { // error is an ApolloError object
       const alert = new Alert(error.message, null, 'error');
-      return store.dispatch('addAlert', alert);
+      return store.dispatch('setAlert', alert);
     });
   }
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -11,7 +11,7 @@ export const UserService = {
       return store.dispatch('user/setUser', user);
     }).catch((error) => {
       const alert = new Alert(error.response.statusText, null, 'error');
-      return store.dispatch('addAlert', alert);
+      return store.dispatch('setAlert', alert);
     });
   }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -19,7 +19,7 @@ const state = {
   packageJson: JSON.parse(unescape(process.env.PACKAGE_JSON || '%7B%7D')),
   isLoading: false,
   refCount: 0,
-  alerts: []
+  alert: null
 };
 
 // Actions
@@ -27,14 +27,10 @@ const actions = {
   setLoading({commit}, isLoading) {
     commit('SET_LOADING', isLoading);
   },
-  addAlert({commit}, alert) {
-    commit('ADD_ALERT', alert);
-  },
-  removeAlert({commit}, alertText) {
-    commit('REMOVE_ALERT', alertText);
-  },
-  clearAlerts({commit}) {
-    commit('CLEAR_ALERTS');
+  setAlert({state, commit}, alert) {
+    if (alert === null || state.alert === null || state.alert.getText() !== alert.getText()) {
+      commit('SET_ALERT', alert);
+    }
   }
 };
 
@@ -49,19 +45,8 @@ const mutations = {
       state.isLoading = (state.refCount > 0)
     }
   },
-  ADD_ALERT(state, alert) {
-    state.alerts.push(alert);
-  },
-  REMOVE_ALERT(state, alertText) {
-    for (var i = 0; i < state.alerts.length; i++) {
-      if (state.alerts[i].text === alertText) {
-        state.alerts.splice(i, 1);
-        break;
-      }
-    }
-  },
-  CLEAR_ALERTS(state) {
-    state.alerts = []
+  SET_ALERT(state, alert) {
+    state.alert = alert
   }
 };
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -28,6 +28,10 @@ const actions = {
     commit('SET_LOADING', isLoading);
   },
   setAlert({state, commit}, alert) {
+    // log to console when the alert is not null (null can mean to remove the alert)
+    if (alert !== null) {
+      console.log(alert)
+    }
     if (alert === null || state.alert === null || state.alert.getText() !== alert.getText()) {
       commit('SET_ALERT', alert);
     }

--- a/src/views/Suites.vue
+++ b/src/views/Suites.vue
@@ -121,9 +121,7 @@ export default {
       .getSuites()
       .finally(() => { this.isLoading = false })
     // TODO: to be replaced by websockets
-    this.polling = setInterval(() => {
-      suiteService.getSuites()
-    }, 5000)
+    this.polling = setInterval(() => suiteService.getSuites(), 5000)
   },
   beforeDestroy() {
     clearInterval(this.polling)

--- a/tests/unit/services/suite.service.spec.js
+++ b/tests/unit/services/suite.service.spec.js
@@ -7,7 +7,7 @@ describe('SuiteService', () => {
   const suiteService = new SuiteService()
   beforeEach(() => {
     store.dispatch("suites/setSuites", [])
-    store.dispatch('clearAlerts')
+    store.dispatch('setAlert', null)
   })
   describe('getSuites returns the list of suites', () => {
     it('should return list of suites', () => {
@@ -48,7 +48,7 @@ describe('SuiteService', () => {
       })
     })
     it('should add an alert on error', () => {
-      expect(store.state.alerts.length).to.equal(0)
+      expect(store.state.alert).to.equal(null)
       const e = new Error('mock error')
       suiteService.apolloClient = {
         uri: null,
@@ -57,7 +57,7 @@ describe('SuiteService', () => {
         }
       }
       return suiteService.getSuites().finally(() => {
-        expect(store.state.alerts.length).to.equal(1)
+        expect(store.state.alert.getText()).to.equal('mock error')
       })
     })
   })
@@ -91,7 +91,7 @@ describe('SuiteService', () => {
       })
     })
     it('should add an alert on error', () => {
-      expect(store.state.alerts.length).to.equal(0)
+      expect(store.state.alert).to.equal(null)
       const e = new Error('mock error')
       suiteService.apolloClient = {
         uri: null,
@@ -100,7 +100,7 @@ describe('SuiteService', () => {
         }
       }
       return suiteService.getSuiteTasks(new Suite("suitename", "root", "localhost", 8080)).finally(() => {
-        expect(store.state.alerts.length).to.equal(1)
+        expect(store.state.alert.getText()).to.equal('mock error')
       })
     })
   })
@@ -136,7 +136,7 @@ describe('SuiteService', () => {
       })
     })
     it('should add an alert on error', () => {
-      expect(store.state.alerts.length).to.equal(0)
+      expect(store.state.alert).to.equal(null)
       const e = new Error('mock error')
       suiteService.apolloClient = {
         uri: null,
@@ -145,7 +145,7 @@ describe('SuiteService', () => {
         }
       }
       return suiteService.fetchSuiteTree(3).finally(() => {
-        expect(store.state.alerts.length).to.equal(1)
+        expect(store.state.alert.getText()).to.equal('mock error')
       })
     })
   })

--- a/tests/unit/services/user.service.spec.js
+++ b/tests/unit/services/user.service.spec.js
@@ -8,7 +8,7 @@ describe('UserService', () => {
   let sandbox;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    store.dispatch('clearAlerts');
+    store.dispatch('setAlert', null);
   });
   afterEach(() => sandbox.restore());
   describe('getUserProfile returns the logged-in user profile information', () => {
@@ -30,14 +30,14 @@ describe('UserService', () => {
       });
     });
     it('should add an alert on error', () => {
-      expect(store.state.alerts.length).to.equal(0);
+      expect(store.state.alert).to.equal(null);
       const e = new Error('mock error');
       e.response = {
         statusText: 'Test Status'
       };
       sandbox.stub(axios, 'get').rejects(e);
       return UserService.getUserProfile().finally(() => {
-        expect(store.state.alerts.length).to.equal(1);
+        expect(store.state.alert.getText()).to.equal('Test Status');
       });
     });
   })

--- a/tests/unit/store/store.spec.js
+++ b/tests/unit/store/store.spec.js
@@ -4,29 +4,24 @@ import Alert from "@/model/Alert.model";
 
 describe('store', () => {
   beforeEach(() => {
-    store.dispatch('clearAlerts');
+    store.dispatch('setAlert', null);
   });
   describe('alerts', () => {
-    it('should start with an empty list', () => {
-      expect(store.state.alerts.length).to.equal(0);
+    it('should start with no alert', () => {
+      expect(store.state.alert).to.equal(null);
     });
-    it('should add alerts', () => {
-      store.dispatch('addAlert', new Alert('my-alert', '', ''));
-      store.dispatch('addAlert', new Alert('my-alert', '', ''));
-      expect(store.state.alerts.length).to.equal(2);
-    });
-    it('should remove alerts', () => {
-      store.dispatch('addAlert', new Alert('my-alert', '', ''));
-      store.dispatch('addAlert', new Alert('my-alert', '', ''));
-      store.dispatch('clearAlerts');
-      expect(store.state.alerts.length).to.equal(0);
-    });
-    it('should remove alert by text', () => {
-      store.dispatch('addAlert', new Alert('my-alert', '', ''));
-      store.dispatch('addAlert', new Alert('my-alert', '', ''));
-      // For now removes just the first occurrence
-      store.dispatch('removeAlert', 'my-alert');
-      expect(store.state.alerts.length).to.equal(1);
+    it('should set alert', () => {
+      store.dispatch('setAlert', new Alert('my-alert', '', ''));
+      expect(store.state.alert.getText()).to.equal('my-alert');
+      // repeating an alert with same text does not change anything
+      store.dispatch('setAlert', new Alert('my-alert', '', ''));
+      expect(store.state.alert.getText()).to.equal('my-alert');
+      // but if the text is different, it will use the new value
+      store.dispatch('setAlert', new Alert('my-alert-2', '', ''));
+      expect(store.state.alert.getText()).to.equal('my-alert-2');
+      // and we can reset the state
+      store.dispatch('setAlert', null);
+      expect(store.state.alert).to.equal(null);
     });
   });
   describe('loading', () => {


### PR DESCRIPTION
Instead of accumulating the error messages in a list, after this PR we will have just one alert. If, for any reason, the alert changes (e.g. you get a "Network error", and then something causes a "Unknown error"), then the latest message will be displayed.

Users can still dismiss the error. And when moving to a different route, it should be correctly removed, and no more alert/error should be displayed in the new page/view.