### PR TITLE
Create view control toolbar

### DIFF
--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -24,7 +24,7 @@
     </div>
 
     <!-- control bar elements displayed only when a suite has been positioned -->
-    <template v-if="suite">
+    <template v-if="tree && tree.length > 0">
       <a @click="onClickPause">
         <v-icon color="#5E5E5E">mdi-pause</v-icon>
       </a>
@@ -77,17 +77,10 @@
 
   computed: {
     ...mapState('app', ['title']),
-    ...mapState('suites', ['suite'])
-  },
-
-  watch: {
-    '$route' (val) {
-      this.$store.commit('app/setTitle', val.name);
-    }
+    ...mapState('suites', ['tree'])
   },
 
   mounted () {
-    this.$store.commit('app/setTitle', this.$route.name);
     this.onResponsiveInverted()
     window.addEventListener('resize', this.onResponsiveInverted)
   },

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -1,0 +1,157 @@
+<template>
+  <v-toolbar
+    flat
+    dense
+    class="c-toolbar"
+  >
+    <div class="v-toolbar-title">
+      <v-toolbar-title
+        class="tertiary--text font-weight-light"
+      >
+        <!-- burger button for mobile -->
+        <v-btn
+          v-if="responsive"
+          class="default v-btn--simple"
+          dark
+          icon
+          @click.stop="onClickBtn"
+        >
+          <v-icon>mdi-view-list</v-icon>
+        </v-btn>
+        <!-- title -->
+        <span class="c-toolbar-title">{{ title }}</span>
+      </v-toolbar-title>
+    </div>
+
+    <!-- control bar elements displayed only when a suite has been positioned -->
+    <template v-if="suite">
+      <a @click="onClickPause">
+        <v-icon color="#5E5E5E">mdi-pause</v-icon>
+      </a>
+
+      <a @click="onClickStop">
+        <v-icon color="#5E5E5E">mdi-stop</v-icon>
+      </a>
+
+      <a>
+        <v-chip color="#E7E7E7" @click="toggleExtended">Control</v-chip>
+      </a>
+
+      <span>Running, will stop at 30000101T0000 cycle</span>
+
+      <v-spacer />
+
+      <a class="add-view" @click="onClickAddView">
+        Add View <v-icon color="#5995EB">mdi-plus-circle</v-icon>
+      </a>
+    </template>
+
+    <!-- displayed only when extended===true -->
+    <template v-slot:extension v-if="extended">
+      <span style="margin-left: 260px;">
+        <a @click="onClickPause">
+          <v-icon color="#5E5E5E">mdi-pause</v-icon>
+        </a>
+
+        <a @click="onClickStop">
+          <v-icon color="#5E5E5E">mdi-stop</v-icon>
+        </a>
+
+        <span>Other controls added in the future</span>
+      </span>
+    </template>
+
+  </v-toolbar>
+</template>
+
+<script>
+
+  import { mapMutations, mapState } from 'vuex'
+
+  export default {
+  data: () => ({
+    responsive: false,
+    responsiveInput: false,
+    extended: false
+  }),
+
+  computed: {
+    ...mapState('app', ['title']),
+    ...mapState('suites', ['suite'])
+  },
+
+  watch: {
+    '$route' (val) {
+      this.$store.commit('app/setTitle', val.name);
+    }
+  },
+
+  mounted () {
+    this.$store.commit('app/setTitle', this.$route.name);
+    this.onResponsiveInverted()
+    window.addEventListener('resize', this.onResponsiveInverted)
+  },
+  beforeDestroy () {
+    window.removeEventListener('resize', this.onResponsiveInverted)
+  },
+
+  methods: {
+    ...mapMutations('app', ['setDrawer', 'toggleDrawer']),
+    onClickBtn () {
+      this.setDrawer(!this.$store.state.app.drawer)
+    },
+    onResponsiveInverted () {
+      if (window.innerWidth < 991) {
+        this.responsive = true
+        this.responsiveInput = false
+      } else {
+        this.responsive = false
+        this.responsiveInput = true
+      }
+    },
+    onClickPause () {
+      console.log("Pausing workflows has not been implemented yet")
+    },
+    onClickStop () {
+      console.log("Stopping workflows has not been implemented yet")
+    },
+    toggleExtended () {
+      this.extended = !this.extended
+    },
+    onClickAddView () {
+      console.log("Adding views has not been implemented yet")
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+  .v-toolbar {
+    min-height: inherit !important;
+    .v-toolbar__content {
+      min-height: inherit !important;
+    }
+  }
+
+  .c-toolbar {
+    background-color: #E7E7E7;
+    border-bottom: 3px solid #ccc;
+
+    .c-toolbar-title, .add-view {
+      font-size: 22px;
+      color: #5995EB;
+      font-weight: 500;
+    }
+
+    .c-toolbar-title {
+      padding-right: 13px;
+    }
+
+    span {
+      color: #7D878F;
+    }
+
+    .add-view {
+    }
+  }
+</style>

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -120,34 +120,3 @@
   }
 }
 </script>
-
-<style lang="scss">
-  .v-toolbar {
-    min-height: inherit !important;
-    .v-toolbar__content {
-      min-height: inherit !important;
-    }
-  }
-
-  .c-toolbar {
-    background-color: #E7E7E7;
-    border-bottom: 3px solid #ccc;
-
-    .c-toolbar-title, .add-view {
-      font-size: 22px;
-      color: #5995EB;
-      font-weight: 500;
-    }
-
-    .c-toolbar-title {
-      padding-right: 13px;
-    }
-
-    span {
-      color: #7D878F;
-    }
-
-    .add-view {
-    }
-  }
-</style>

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -103,15 +103,18 @@
       }
     },
     onClickPause () {
+      // TODO: implement the pause action
       console.log("Pausing workflows has not been implemented yet")
     },
     onClickStop () {
+      // TODO: implement the stop action
       console.log("Stopping workflows has not been implemented yet")
     },
     toggleExtended () {
       this.extended = !this.extended
     },
     onClickAddView () {
+      // TODO: implement adding views action
       console.log("Adding views has not been implemented yet")
     }
   }

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import Toolbar from '@/components/core/Toolbar'
+import Toolbar from '@/components/cylc/Toolbar'
 import Alert from "@/components/core/Alert"
 import Drawer from '@/components/core/Drawer'
 import Footer from '@/components/core/Footer'

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -52,6 +52,12 @@ Vue.use(Meta);
 
 router.beforeResolve((to, from, next) => {
   if (to.name) {
+    if (to.name === 'Suite') {
+      // We treat the suite differently for the toolbar title
+      store.commit('app/setTitle', to.params.name)
+    } else {
+      store.commit('app/setTitle', to.name)
+    }
     NProgress.start();
     store.dispatch('clearAlerts');
   }

--- a/src/styles/cylc/_toolbar.scss
+++ b/src/styles/cylc/_toolbar.scss
@@ -1,0 +1,32 @@
+@import "../material-dashboard/colors";
+@import "../material-dashboard/variables";
+
+.v-toolbar {
+  min-height: inherit !important;
+
+  .v-toolbar__content {
+    min-height: inherit !important;
+  }
+}
+
+.c-toolbar {
+  background-color: $grey-200;
+  border-bottom: 3px solid $grey-300;
+
+  .c-toolbar-title, .add-view {
+    font-size: 22px;
+    color: $blue-A200;
+    font-weight: $font-weight-bolder;
+  }
+
+  .c-toolbar-title {
+    padding-right: 12px;
+  }
+
+  span {
+    color: $blue-grey-400;
+  }
+
+  .add-view {
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -15,3 +15,5 @@
 @import "material-dashboard/alerts";
 @import "material-dashboard/fixed-plugin";
 @import "material-dashboard/dropdown";
+
+@import "cylc/toolbar";

--- a/src/styles/material-dashboard/_variables.scss
+++ b/src/styles/material-dashboard/_variables.scss
@@ -92,7 +92,7 @@ $toolbar-min-height:                70px !default;
 $toolbar-margin-left:               260px !default;
 
 //  Body Background Color
-$body-color:                        #eee !default;
+$body-color:                        #fff !default;
 
 // Black Color
 $black-color:                       #495057 !default;

--- a/src/views/Suite.vue
+++ b/src/views/Suite.vue
@@ -125,6 +125,7 @@
     },
     beforeDestroy() {
       clearInterval(this.polling)
+      this.$store.dispatch('suites/setTree', [])
     },
     computed: {
       // namespace: module suites, and property suites, hence these repeated tokens...


### PR DESCRIPTION
Closes #114 

Adds initial version of our new toolbar. This toolbar component is actually based on Vuetify's [toolbar](https://vuetifyjs.com/en/components/toolbars).

With the difference that it 

- overrides a few CSS styles
- has extra CSS styles
- has extra control over the extended feature

Icons are using material design icons, and typography and layout & spacing are also material's default, hence a few differences if you look closely and compare with @oliver-sanders ' sketches.