### PR TITLE
Add missing dot for class name

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -77,7 +77,7 @@
 
 
 <style lang="scss">
-    c-task {
+    .c-task {
 
         $colour: rgb(90,90,90);
 


### PR DESCRIPTION
The Task scss file is missing a dot in the class name (the Job one looks OK). Resulting in a much larger than expected icon.
