### PR TITLE
Use a proxy (npm) for the devServer to serve live graphql data

### DIFF
--- a/src/services/gquery.js
+++ b/src/services/gquery.js
@@ -78,9 +78,11 @@ class GQuery {
    */
 
   constructor () {
-    this.apolloClient = createApolloClient(
-      `${window.location.pathname}/graphql`
-    )
+    // window.location.pathname will have the URL path, such as /user/foo/, or /user/foo/index.html
+    // so here we just drop the file name such as index.html if present.
+    const baseUrl = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/') + 1)
+    const url = `${baseUrl}graphql`
+    this.apolloClient = createApolloClient(url)
     this.query = null
     this.subscriptions = []
     this.views = []

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,8 +2,12 @@
 const webpack = require('webpack')
 const path = require('path')
 
-const USERNAME = process.env.CYLC_USER
-const GRAPHQL_REWRITE = '/user/' + USERNAME + '/graphql'
+/**
+ * GraphQL URL used to rewrite requests when running a devServer. This will be used by a proxy in the devServer.
+ * @type {string}
+ */
+const user = process.env.CYLC_USER || process.env.USER
+const GRAPHQL_REWRITE = `/user/${user}/graphql`
 
 module.exports = {
   publicPath: '',

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,9 @@
 const webpack = require('webpack')
 const path = require('path')
 
+const USERNAME = process.env.CYLC_USER
+const GRAPHQL_REWRITE = '/user/' + USERNAME + '/graphql'
+
 module.exports = {
   publicPath: '',
   outputDir: 'dist',
@@ -45,5 +48,17 @@ module.exports = {
       ? '@/services/mock/user.service.mock'
       : '@/services/user.service'
     config.resolve.alias.set('user-service', userService)
+  },
+  devServer: {
+    proxy:
+    {
+      // will match even if there is text before, like /user/name/graphql
+      '/graphql': {
+        target: 'http://localhost:8000',
+        pathRewrite: {
+          '.*': GRAPHQL_REWRITE
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Close #126 

@oliver-sanders could you take a look, and see if that works for you, please? You will have to do the following:

1. Start `jupyterhub`, which means it will start `cylc-singleuser` and will need a valid location for the static files... it can be the output of a previously run `npm run build:watch` or perhaps even a fake directory. If you didn't change anything, the Cylc Hub should be available at http://localhost:8000
2. Check out this branch
3. Create `.env.local`, which is a file used by Vue - gitignore'd already - to [specify environment variables](https://cli.vuejs.org/guide/mode-and-env.html#environment-variables) (important to avoid adding it to our Git repository)
4. Add `CYLC_USER=oliver-sanders` (or whatever is your operating system user, same as in Cylc Hub` to the `.env.local` file.
5. Run `npm run serve`

Now the `devServer` initiated by npm/vue, will locate the proxy that is matching anything that contains `/graphql` and a) redirecting to http://localhost:8000 and b) rewriting the URL to be `/user/${VALUE_OF_CYLC_USER/graphql`.

Which means that _you do not need to use the http://localhost:8000` URL, even though you started at step 1, that's only to get the Cylc Hub up running and serving the live data. Instead, use http://localhost:8080, from `npm run serve` (even better if you do `npm run serve -- --open` to get your default browser opened... works better/faster with Chrome for me).

And then you should be able to change files, wait for the browser to auto-magically refresh, and see your changes using live data.

Let me know if that works. 

Cheers
Bruno