### PR TITLE
theme: job icons

### DIFF
--- a/src/components/cylc/Job.vue
+++ b/src/components/cylc/Job.vue
@@ -15,7 +15,6 @@
     -->
     <svg
       class="job"
-      v-bind:class="[status]"
       viewBox="0 0 100 100"
     >
       <!-- the job status icon
@@ -23,6 +22,7 @@
            * let height = 100 - y - stroke-width
       -->
       <rect
+        v-bind:class="[status]"
         x="10" y="10"
         width="80" height="80"
         rx="20" ry="20"

--- a/src/components/cylc/Job.vue
+++ b/src/components/cylc/Job.vue
@@ -33,44 +33,13 @@
 </template>
 
 <style lang="scss">
-    .c-job {
-        svg.job {
-            /* scale the icon to the font-size */
-            width: 1em;
-            height: 1em;
-
-            rect {
-                /* if no job status display nothing */
-                fill: transparent;
-                stroke: transparent;
-            }
-
-            &.submitted rect {
-                fill: rgb(125,207,212);
-                stroke: rgb(125,207,212);
-            }
-
-            &.running rect {
-                fill: rgb(106,164,241);
-                stroke: rgb(106,164,241);
-            }
-
-            &.succeeded rect {
-                fill: rgb(81,175,81);
-                stroke: rgb(81,175,81);
-            }
-
-            &.failed rect {
-                fill: rgb(207,72,72);
-                stroke: rgb(207,72,72);
-            }
-
-            &.submit-failed rect {
-                fill: rgb(190,106,192);
-                stroke: rgb(190,106,192);
-            }
-        }
+  .c-job {
+    svg.job {
+      /* scale the icon to the font-size */
+      width: 1em;
+      height: 1em;
     }
+  }
 </style>
 
 <script>

--- a/src/styles/cylc/_job.scss
+++ b/src/styles/cylc/_job.scss
@@ -1,127 +1,112 @@
-.job_theme--normal {
+/* css namespace for job element */
+$cjob: ".c-job svg.job rect";
 
+
+#{$cjob} {
+    /* if no job status display nothing */
+    fill: transparent;
+    stroke: transparent;
+}
+
+
+.job_theme--normal {
     $teal: rgb(125,207,212);
     $blue: rgb(106,164,241);
     $green: rgb(81,175,81);
     $red: rgb(207,72,72);
     $pink: rgb(190,106,192);
 
-    .c-job {
-        svg.job {
-            rect {
-                /* if no job status display nothing */
-                fill: transparent;
-                stroke: transparent;
-            }
+    #{$cjob} {
+        &.submitted {
+            fill: $teal;
+            stroke: $teal;
+        }
 
-            &.submitted rect {
-                fill: $teal;
-                stroke: $teal;
-            }
+        &.running {
+            fill: $blue;
+            stroke: $blue;
+        }
 
-            &.running rect {
-                fill: $blue;
-                stroke: $blue;
-            }
+        &.succeeded {
+            fill: $green;
+            stroke: $green;
+        }
 
-            &.succeeded rect {
-                fill: $green;
-                stroke: $green;
-            }
+        &.failed {
+            fill: $red;
+            stroke: $red;
+        }
 
-            &.failed rect {
-                fill: $red;
-                stroke: $red;
-            }
-
-            &.submit-failed rect {
-                fill: $pink;
-                stroke: $pink;
-            }
+        &.submit-failed {
+            fill: $pink;
+            stroke: $pink;
         }
     }
 }
 
-.job_theme--greyscale {
 
+.job_theme--greyscale {
     $light: rgb(208,208,208);
     $medium: rgb(133,133,133);
     $dark: rgb(0,0,0);
 
-    .c-job {
-        svg.job {
-            rect {
-                /* if no job status display nothing */
-                fill: transparent;
-                stroke: transparent;
-            }
+    #{$cjob} {
+        &.submitted {
+            fill: transparent;
+            stroke: $light;
+        }
 
-            &.submitted rect {
-                fill: transparent;
-                stroke: $light;
-            }
+        &.running {
+            fill: $light;
+            stroke: $light;
+        }
 
-            &.running rect {
-                fill: $light;
-                stroke: $light;
-            }
+        &.succeeded {
+            fill: $medium;
+            stroke: $medium;
+        }
 
-            &.succeeded rect {
-                fill: $medium;
-                stroke: $medium;
-            }
+        &.failed {
+            fill: $dark;
+            stroke: $dark;
+        }
 
-            &.failed rect {
-                fill: $dark;
-                stroke: $dark;
-            }
-
-            &.submit-failed rect {
-                fill: transparent;
-                stroke: $dark;
-            }
+        &.submit-failed {
+            fill: transparent;
+            stroke: $dark;
         }
     }
 }
 
 .job_theme--colour_blind {
-
     $grey: rgb(152,152,152);
     $success: rgb(108,218,255);
     $error: rgb(146,0,0);
 
-    .c-job {
-        svg.job {
-            rect {
-                /* if no job status display nothing */
-                fill: transparent;
-                stroke: transparent;
-            }
+    #{$cjob} {
+        &.submitted {
+            fill: transparent;
+            stroke: $grey;
+        }
 
-            &.submitted rect {
-                fill: transparent;
-                stroke: $grey;
-            }
+        &.running {
+            fill: $grey;
+            stroke: $grey;
+        }
 
-            &.running rect {
-                fill: $grey;
-                stroke: $grey;
-            }
+        &.succeeded {
+            fill: $success;
+            stroke: $success;
+        }
 
-            &.succeeded rect {
-                fill: $success;
-                stroke: $success;
-            }
+        &.failed {
+            fill: $error;
+            stroke: $error;
+        }
 
-            &.failed rect {
-                fill: $error;
-                stroke: $error;
-            }
-
-            &.submit-failed rect {
-                fill: transparent;
-                stroke: $error;
-            }
+        &.submit-failed {
+            fill: transparent;
+            stroke: $error;
         }
     }
 }

--- a/src/styles/cylc/_job.scss
+++ b/src/styles/cylc/_job.scss
@@ -1,0 +1,127 @@
+.job_theme--normal {
+
+    $teal: rgb(125,207,212);
+    $blue: rgb(106,164,241);
+    $green: rgb(81,175,81);
+    $red: rgb(207,72,72);
+    $pink: rgb(190,106,192);
+
+    .c-job {
+        svg.job {
+            rect {
+                /* if no job status display nothing */
+                fill: transparent;
+                stroke: transparent;
+            }
+
+            &.submitted rect {
+                fill: $teal;
+                stroke: $teal;
+            }
+
+            &.running rect {
+                fill: $blue;
+                stroke: $blue;
+            }
+
+            &.succeeded rect {
+                fill: $green;
+                stroke: $green;
+            }
+
+            &.failed rect {
+                fill: $red;
+                stroke: $red;
+            }
+
+            &.submit-failed rect {
+                fill: $pink;
+                stroke: $pink;
+            }
+        }
+    }
+}
+
+.job_theme--greyscale {
+
+    $light: rgb(208,208,208);
+    $medium: rgb(133,133,133);
+    $dark: rgb(0,0,0);
+
+    .c-job {
+        svg.job {
+            rect {
+                /* if no job status display nothing */
+                fill: transparent;
+                stroke: transparent;
+            }
+
+            &.submitted rect {
+                fill: transparent;
+                stroke: $light;
+            }
+
+            &.running rect {
+                fill: $light;
+                stroke: $light;
+            }
+
+            &.succeeded rect {
+                fill: $medium;
+                stroke: $medium;
+            }
+
+            &.failed rect {
+                fill: $dark;
+                stroke: $dark;
+            }
+
+            &.submit-failed rect {
+                fill: transparent;
+                stroke: $dark;
+            }
+        }
+    }
+}
+
+.job_theme--colour_blind {
+
+    $grey: rgb(152,152,152);
+    $success: rgb(108,218,255);
+    $error: rgb(146,0,0);
+
+    .c-job {
+        svg.job {
+            rect {
+                /* if no job status display nothing */
+                fill: transparent;
+                stroke: transparent;
+            }
+
+            &.submitted rect {
+                fill: transparent;
+                stroke: $grey;
+            }
+
+            &.running rect {
+                fill: $grey;
+                stroke: $grey;
+            }
+
+            &.succeeded rect {
+                fill: $success;
+                stroke: $success;
+            }
+
+            &.failed rect {
+                fill: $error;
+                stroke: $error;
+            }
+
+            &.submit-failed rect {
+                fill: transparent;
+                stroke: $error;
+            }
+        }
+    }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -5,6 +5,7 @@
 @import "cylc/toolbar";
 @import "cylc/drawer";
 @import "cylc/footer";
+@import "cylc/job";
 
 .theme--light.v-application {
   background-color: transparent;


### PR DESCRIPTION
Address theme component of #109.

#### Description

Add theme support for Job icons:

* Normal
* Colour-blind
* Greyscale

These respond to the `job_theme--<name>` class of a containing element intended to match the application `theme--<name>` class.

At present we don't have a way to toggle themes or for storing user preferences.

#### Example application to demmonstrate:

i.e. `App.vue`.

```vue
<template>
  <v-app>
    <div v-for="theme in themes" :class="['job_theme--' + theme]">
      <h2>{{theme}}</h2>
      <ul v-for="state in states">
        <li>
          <task :status="state" progress="0" />
          foo
          <job :status="state" />
        </li>
      </ul>
    </div>
  </v-app>
</template>

<script>
const defaultLayout = 'empty'

  import Task from '@/components/cylc/Task'
  import Job from '@/components/cylc/Job'

export default {
  computed: {
    layout () {
      return (this.$route.meta.layout || defaultLayout) + '-layout'
    }
  },
  components: {
    task: Task,
    job: Job
  },
  data: () => ({
    states: [
      'waiting',
      'submitted',
      'running',
      'succeeded',
      'failed',
      'submit-failed'
    ],
    themes: [
      'normal',
      'greyscale',
      'colour_blind'
    ]
  })
}
</script>

<style lang="scss">
  @import '~@/styles/index.scss';

  /* Remove in 1.2 */
  .v-datatable thead th.column.sortable i {
    vertical-align: unset;
  }

  div {
    margin-left: 20px;
    float: left;
  }
</style>
```

#### Example Output

![Screenshot from 2019-07-17 16-09-55](https://user-images.githubusercontent.com/16705946/61387090-5d526400-a8ad-11e9-8b71-c6e346582068.png)
