### PR TITLE
Local user settings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,8 @@
 </template>
 
 <script>
+import { UserService } from 'user-service'
+
 const defaultLayout = 'empty'
 
 export default {
@@ -14,6 +16,12 @@ export default {
     layout () {
       return (this.$route.meta.layout || defaultLayout) + '-layout'
     }
+  },
+  mounted () {
+    // Global values created when the application is mounted, such as global application settings, and
+    // the user object. Values are set in Vuex stores to be accessed by other components.
+    UserService.fetchSettings()
+    UserService.getUserProfile()
   }
 }
 </script>

--- a/src/components/core/Alert.vue
+++ b/src/components/core/Alert.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-container v-if="alert !== null" :key="alert.text">
+    <v-container v-if="alert !== null" :key="alert.created">
       <v-alert :value="true" :color="alert.getColor()" :icon="alert.getIcon()" dismissible>
         {{ alert.getText() }}
       </v-alert>

--- a/src/lang/en-GB/Settings.json
+++ b/src/lang/en-GB/Settings.json
@@ -1,0 +1,3 @@
+{
+  "title": "Settings"
+}

--- a/src/lang/pt-BR/Settings.json
+++ b/src/lang/pt-BR/Settings.json
@@ -1,0 +1,3 @@
+{
+  "title": "Configurações"
+}

--- a/src/model/Alert.model.js
+++ b/src/model/Alert.model.js
@@ -3,6 +3,7 @@ export default class Alert {
     this.text = text
     this.icon = icon
     this.color = color
+    this.created = new Date().getTime()
   }
 
   getText () {

--- a/src/model/Settings.model.js
+++ b/src/model/Settings.model.js
@@ -1,0 +1,9 @@
+class Settings {
+  constructor (applicationTheme = 'default', jobStatesTheme = 'default', language = 'en-GB') {
+    this.applicationTheme = applicationTheme
+    this.jobStatesTheme = jobStatesTheme
+    this.language = language
+  }
+}
+
+export default Settings

--- a/src/services/mock/user.service.js
+++ b/src/services/mock/user.service.js
@@ -1,0 +1,53 @@
+import Alert from '@/model/Alert.model'
+import User from '@/model/User.model'
+import Settings from '@/model/Settings.model'
+import store from '@/store/index'
+
+export const UserService = {
+
+  /**
+   * Fetch the user, and set the value returned in the user store.
+   * @returns {Promise<any>}
+   */
+  getUserProfile () {
+    const user = new User('guest', [], new Date().toISOString(), false)
+    return store.dispatch('user/setUser', user)
+  },
+
+  /**
+   * Fetch the settings from the backend (for now using LocalStorage), and set the value returned in the
+   * user store.
+   * @returns {Promise<any>}
+   */
+  async fetchSettings () {
+    // TODO: move to the backend later (probably?)
+    let settings = null
+    const localSettings = localStorage.getItem('user/settings')
+    if (localSettings) {
+      settings = JSON.parse(localSettings)
+    } else {
+      settings = new Settings()
+    }
+    return store.dispatch('user/setSettings', settings)
+  },
+
+  /**
+   * Save the settings to the backend (for now using LocalStorage). The value saved in the local storage area
+   * is actually the object passed through JSON.stringify. So users/developers can also inspect the values
+   * from their browsers.
+   * @param settings {Object} the settings object
+   * @returns {Promise<any>}
+   */
+  async saveSettings (settings) {
+    try {
+      await store.dispatch('setLoading', true)
+      localStorage.setItem('user/settings', JSON.stringify(settings))
+      await store.dispatch('user/setSettings', settings)
+      return store.dispatch('setAlert', new Alert('Settings updated', null, 'success'))
+    } catch (error) {
+      return store.dispatch('setAlert', new Alert(error.message, null, 'error'))
+    } finally {
+      await store.dispatch('setLoading', false)
+    }
+  }
+}

--- a/src/services/mock/user.service.js
+++ b/src/services/mock/user.service.js
@@ -2,6 +2,7 @@ import Alert from '@/model/Alert.model'
 import User from '@/model/User.model'
 import Settings from '@/model/Settings.model'
 import store from '@/store/index'
+import i18n from '@/i18n/index'
 
 export const UserService = {
 
@@ -28,6 +29,7 @@ export const UserService = {
     } else {
       settings = new Settings()
     }
+    i18n.locale = settings.language
     return store.dispatch('user/setSettings', settings)
   },
 
@@ -42,6 +44,7 @@ export const UserService = {
     try {
       await store.dispatch('setLoading', true)
       localStorage.setItem('user/settings', JSON.stringify(settings))
+      i18n.locale = settings.language
       await store.dispatch('user/setSettings', settings)
       return store.dispatch('setAlert', new Alert('Settings updated', null, 'success'))
     } catch (error) {

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -3,8 +3,7 @@ import { set, toggle } from '@/utils/vuex'
 const state = {
   drawer: null,
   color: 'success',
-  title: null,
-  theme: 'normal'
+  title: null
 }
 
 const mutations = {
@@ -12,8 +11,7 @@ const mutations = {
   setImage: set('image'),
   setColor: set('color'),
   toggleDrawer: toggle('drawer'),
-  setTitle: set('title'),
-  setTheme: set('theme')
+  setTitle: set('title')
 }
 
 const actions = {}

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -3,7 +3,8 @@ import { set, toggle } from '@/utils/vuex'
 const state = {
   drawer: null,
   color: 'success',
-  title: null
+  title: null,
+  theme: 'normal'
 }
 
 const mutations = {
@@ -11,7 +12,8 @@ const mutations = {
   setImage: set('image'),
   setColor: set('color'),
   toggleDrawer: toggle('drawer'),
-  setTitle: set('title')
+  setTitle: set('title'),
+  setTheme: set('theme')
 }
 
 const actions = {}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@
  */
 
 // Lib imports
+import _ from 'lodash'
 import Vue from 'vue'
 import Vuex from 'vuex'
 // Modules
@@ -32,7 +33,7 @@ const actions = {
     if (alert !== null) {
       console.log(alert)
     }
-    if (alert === null || state.alert === null || state.alert.getText() !== alert.getText()) {
+    if (alert === null || state.alert === null || !_.isEqual(state.alert, alert)) {
       commit('SET_ALERT', alert)
     }
   }

--- a/src/store/user.module.js
+++ b/src/store/user.module.js
@@ -1,16 +1,36 @@
+import Settings from '@/model/Settings.model'
+
 export const state = {
-  user: null
+  user: null,
+  settings: new Settings(),
+  // TODO: These properties need be moved and loaded dynamically once we have server-side user-settings
+  applicationThemes: [
+    'default'
+  ],
+  jobStatesThemes: [
+    'default'
+  ],
+  languages: [
+    'en-GB',
+    'pt-BR'
+  ]
 }
 
 export const mutations = {
   SET_USER (state, user) {
     state.user = user
+  },
+  SET_SETTINGS (state, settings) {
+    state.settings = settings
   }
 }
 
 export const actions = {
   setUser ({ commit }, user) {
     commit('SET_USER', user)
+  },
+  setSettings ({ commit }, settings) {
+    commit('SET_SETTINGS', settings)
   }
 }
 

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -3,7 +3,7 @@
     <v-layout justify-center wrap>
       <v-flex xs12 md12>
         <material-card
-          title="Settings">
+          :title="$t('Settings.title')">
           <v-form>
             <v-dialog fullscreen full-width persistent :value=isLoading>
               <v-container fluid fill-height style="background-color: rgba(255, 255, 255, 0.5)">

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script>
-import { UserService } from '@/services/user.service'
+import { UserService } from 'user-service'
 import { mapState } from 'vuex'
 export default {
   computed: {

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -3,6 +3,39 @@
     <v-layout justify-center wrap>
       <v-flex xs12 md12>
         <material-card
+          title="Settings">
+          <v-form>
+            <v-dialog fullscreen full-width persistent :value=isLoading>
+              <v-container fluid fill-height style="background-color: rgba(255, 255, 255, 0.5)">
+                <v-layout justify-center align-center>
+                  <v-progress-circular
+                    indeterminate
+                    color="primary"
+                    />
+                </v-layout>
+              </v-container>
+            </v-dialog>
+            <v-combobox
+              :items="applicationThemes"
+              v-model="applicationTheme"
+              label="Application Theme"
+            />
+            <v-combobox
+              :items="jobStatesThemes"
+              v-model="jobStatesTheme"
+              label="Job States Theme"
+            />
+            <v-combobox
+              :items="languages"
+              v-model="language"
+              label="Language"
+            />
+            <v-btn color="success" @click="onSaveSettings" :disabled="isLoading">Save</v-btn>
+          </v-form>
+        </material-card>
+      </v-flex>
+      <v-flex xs12 md12>
+        <material-card
             color="green"
             title="Your Profile"
             text="This is a read-only view of your user"
@@ -71,20 +104,33 @@
 <script>
 import { UserService } from 'user-service'
 import { mapState } from 'vuex'
+import Settings from '@/model/Settings.model'
 export default {
   computed: {
-    ...mapState('user', ['user'])
+    ...mapState('user', ['user', 'settings', 'applicationThemes', 'jobStatesThemes', 'languages']),
+    ...mapState(['isLoading'])
   },
-  beforeCreate () {
-    this.$store
-      .dispatch('user/setUser', null)
-      .then(() => {
-        UserService.getUserProfile()
-      })
+  mounted () {
+    this.applicationTheme = this.settings.applicationTheme
+    this.jobStatesTheme = this.settings.jobStatesTheme
+    this.language = this.settings.language
+  },
+  data: () => {
+    return {
+      applicationTheme: null,
+      jobStatesTheme: null,
+      language: null
+    }
   },
   metaInfo () {
     return {
       title: 'Cylc UI | User Profile'
+    }
+  },
+  methods: {
+    onSaveSettings () {
+      const settings = new Settings(this.applicationTheme, this.jobStatesTheme, this.language)
+      UserService.saveSettings(settings)
     }
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -24,5 +24,10 @@ module.exports = {
       ? '@/services/mock/suite.service'
       : '@/services/suite.service'
     config.resolve.alias.set('suite-service', suiteService)
+
+    const userService = process.env.NODE_ENV === 'offline'
+      ? '@/services/mock/user.service'
+      : '@/services/user.service'
+    config.resolve.alias.set('user-service', userService)
   }
 }


### PR DESCRIPTION
WIP example of storing user settings locally (client-side) using the `LocalStorage`. Not sure if we wouldn't still use it later, or if we would replace it entirely by backend stored settings (see #53, #59, for example).

This allows users (mainly developers for now) to store locally in their browsers the following settings:

- applicationTheme
- jobStatesTheme (#134 #9) 
- language

Right now only language is being used with our i18n Vue plugin. But we could hook up the job state theme name, and try to use it with CSS/SCSS/Stylys/JS/etc (see #134).