### PR TITLE
Set menu active colour, and remove dashboard alias

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -88,7 +88,7 @@ export default {
   data: () => ({
     links: [
       {
-        to: '/dashboard',
+        to: '/',
         icon: 'mdi-view-dashboard',
         text: 'Dashboard',
         view: false

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -49,6 +49,13 @@ export default [
     }
   },
   {
+    path: '/',
+    view: 'Dashboard',
+    meta: {
+      layout: 'default'
+    }
+  },
+  {
     path: '*',
     view: 'NotFound',
     meta: {

--- a/src/styles/cylc/_variables.scss
+++ b/src/styles/cylc/_variables.scss
@@ -1,0 +1,1 @@
+$brand-success: #BDD5F7;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,5 +1,6 @@
 @import "material-dashboard/mixins";
 @import "material-dashboard/variables";
+@import "cylc/variables";
 @import "material-dashboard/typography";
 @import "material-dashboard/sidebar";
 @import "material-dashboard/toolbar";


### PR DESCRIPTION
Replaces the green colour by the colour defined in the sketches PDF.

Also removes the alias for dashboard, this way we have a single link and the active menu works when you load the landing page.

![Screen Shot 2019-07-26 at 22 44 33-fullpage](https://user-images.githubusercontent.com/304786/61946537-f7758300-aff6-11e9-933b-7dfb8b6e931d.png)
