### PR TITLE
Update landing page / dashboard

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -24,6 +24,17 @@
         />
       </v-list-tile>
 
+      <v-list-tile
+          to="/dashboard"
+          :active-class="color"
+          avatar
+          class="v-list-item"
+      >
+        <v-list-tile-action>
+          <v-icon>mdi-home</v-icon>
+        </v-list-tile-action>
+        <v-list-tile-title>Dashboard</v-list-tile-title>
+      </v-list-tile>
       <v-subheader>Views</v-subheader>
       <v-list-tile
         v-for="(link, index) in viewLinks"

--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -51,35 +51,6 @@
           v-text="link.text"
         />
       </v-list-tile>
-
-      <v-subheader>Other Links</v-subheader>
-      <v-list-tile
-        v-for="(link, index) in nonViewLinks"
-        :key="index+link.text"
-        :to="link.to"
-        :active-class="color"
-        avatar
-        class="v-list-item"
-      >
-        <v-list-tile-action>
-          <v-icon>{{ link.icon }}</v-icon>
-        </v-list-tile-action>
-        <v-list-tile-title
-          v-text="link.text"
-        />
-      <!-- Add Hub route separately as it lives under root not /user/USER/ -->
-      </v-list-tile>
-      <v-list-tile
-              href="/hub/home"
-              :active-class="color"
-              avatar
-              class="v-list-item"
-      >
-        <v-list-tile-action>
-          <v-icon>mdi-server-network</v-icon>
-        </v-list-tile-action>
-        <v-list-tile-title>Hub</v-list-tile-title>
-      </v-list-tile>
     </v-layout>
   </v-navigation-drawer>
 </template>
@@ -116,12 +87,6 @@ export default {
         icon: 'mdi-vector-polyline',
         text: i18n.t('App.graph'),
         view: true
-      },
-      {
-        to: '/user-profile',
-        icon: 'mdi-account',
-        text: i18n.t('App.userProfile'),
-        view: false
       }
     ],
     responsive: false

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -37,9 +37,13 @@
     <v-layout row wrap>
       <v-flex xs6 md6 lg2>
         <v-list two-line>
-          <v-list-tile avatar>
+          <v-list-tile
+              avatar
+              to="/user-profile"
+              :active-class="color"
+          >
             <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="succeeded" />
+              <task status="succeeded" id="settings-node" />
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
@@ -50,13 +54,17 @@
               </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
-          <v-list-tile avatar>
+          <v-list-tile
+              avatar
+              href="https://cylc.github.io/doc/built-sphinx/index.html"
+              :active-class="color"
+          >
             <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="waiting" />
+              <task status="waiting" id="guide-node" />
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
-                Cylc Hub
+                Suite User Guide
               </v-list-tile-title>
             </v-list-tile-content>
           </v-list-tile>
@@ -66,7 +74,7 @@
         <v-list two-line>
           <v-list-tile avatar>
             <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="succeeded" />
+              <task status="succeeded" id="quickstart-node" />
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
@@ -77,9 +85,13 @@
               </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
-          <v-list-tile avatar>
+          <v-list-tile
+              avatar
+              href="https://cylc.github.io/documentation.html"
+              :active-class="color"
+          >
             <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="running" :progress=25 />
+              <task status="running" :progress=25 id="documentation-node" />
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
@@ -92,33 +104,25 @@
               </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
-          <v-list-tile avatar>
-            <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="waiting" />
-            </v-list-tile-avatar>
-            <v-list-tile-content>
-              <v-list-tile-title class="title font-weight-thin">
-                Suite Design Guide
-              </v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
         </v-list>
       </v-flex>
     </v-layout>
     <v-layout row wrap>
-      <v-flex xs12 md12 lg4>
-        <v-list align-center>
-          <v-list-tile>
-            <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="failed" />
-            </v-list-tile-avatar>
-            <v-list-tile-content>
-              <v-list-tile-title class="title font-weight-thin">
-                Stop Server
-              </v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
-        </v-list>
+      <v-flex xs12 md12 lg2 offset-lg1>
+        <v-list-tile
+            avatar
+            href="/hub/home"
+            :active-class="color"
+        >
+          <v-list-tile-avatar size="80" style="font-size: 2em;">
+            <task status="failed" id="hub-node" />
+          </v-list-tile-avatar>
+          <v-list-tile-content>
+            <v-list-tile-title class="title font-weight-thin">
+              Cylc Hub
+            </v-list-tile-title>
+          </v-list-tile-content>
+        </v-list-tile>
       </v-flex>
     </v-layout>
   </v-container>
@@ -126,8 +130,13 @@
 
 <script>
 import { mixin } from '@/mixins/index'
+import { mapState } from 'vuex'
 import Task from '@/components/cylc/Task'
 import Job from '@/components/cylc/Job'
+
+function connectNodes (fromNode, toNode) {
+  console.log('TODO?')
+}
 
 export default {
   mixins: [mixin],
@@ -147,6 +156,14 @@ export default {
       { text: 'Stopped', count: 0 }
     ],
     events: []
-  })
+  }),
+  computed: {
+    ...mapState('app', ['color'])
+  },
+  mounted: function () {
+    const settingsNode = document.getElementById('settings-node').children[0]
+    const suiteDesignGuideNode = document.getElementById('guide-node').children[0]
+    connectNodes(settingsNode, suiteDesignGuideNode)
+  }
 }
 </script>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,9 +1,39 @@
 <template>
   <v-container
-    fill-height
     fluid
-    grid-list-xl
+    grid-list
+    class="c-dashboard"
   >
+    <v-layout row wrap>
+      <v-flex xs6 md6 lg3>
+        <p class="display-1">Workflows</p>
+        <!-- TODO: link with data from the query -->
+        <v-data-table
+            :items="workflows"
+            hide-actions
+            hide-headers>
+          <template v-slot:items="props">
+            <td class="headline">{{ props.item.count }}</td>
+            <td class="title">{{ props.item.text }}</td>
+          </template>
+        </v-data-table>
+      </v-flex>
+      <v-flex xs6 md6 lg9>
+        <p class="display-1">Events</p>
+        <v-data-table
+            :items="events"
+            hide-actions
+            hide-headers>
+          <template v-slot:items="props">
+            <td class="headline">{{ props.item.id }}</td>
+            <td class="title">{{ props.item.text }}</td>
+          </template>
+          <template v-slot:no-data>
+            <td class="title">No events</td>
+          </template>
+        </v-data-table>
+      </v-flex>
+    </v-layout>
   </v-container>
 </template>
 
@@ -16,6 +46,20 @@ export default {
     return {
       title: this.getPageTitle('App.dashboard')
     }
-  }
+  },
+  data: () => ({
+    workflows: [
+      { text: 'Running', count: 0 },
+      { text: 'Held', count: 0 },
+      { text: 'Stopped', count: 0 }
+    ],
+    events: []
+  })
 }
 </script>
+
+<style>
+.c-dashboard {
+  font-size: 120%;
+}
+</style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -37,7 +37,7 @@
     <v-divider />
     <v-layout row wrap>
       <v-flex xs12 md6 lg6>
-        <v-list two-line>
+        <v-list three-line>
           <v-list-tile
               avatar
               to="/user-profile"
@@ -75,7 +75,7 @@
         </v-list>
       </v-flex>
       <v-flex xs12 md6 lg6>
-        <v-list two-line>
+        <v-list three-line>
           <v-list-tile
               avatar
               href="#"
@@ -200,6 +200,6 @@ export default {
 
 /* to left align items in the dashboard */
 .v-list__tile {
-  padding: 0 0;
+  padding: 10px 0;
 }
 </style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -34,54 +34,79 @@
         </v-data-table>
       </v-flex>
     </v-layout>
+    <v-divider />
     <v-layout row wrap>
-      <v-flex xs6 md6 lg2>
+      <v-flex xs12 md6 lg6>
         <v-list two-line>
           <v-list-tile
               avatar
               to="/user-profile"
               :active-class="color"
           >
-            <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="succeeded" id="settings-node" />
+            <v-list-tile-avatar size="60" style="font-size: 2em;">
+              <v-icon medium>mdi-settings</v-icon>
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
                 Settings
               </v-list-tile-title>
               <v-list-tile-sub-title>
-                <job status="succeeded" />
+                View your Hub permissions, and alter user preferences
               </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
           <v-list-tile
               avatar
-              href="https://cylc.github.io/doc/built-sphinx/index.html"
+              href="/hub/home"
               :active-class="color"
           >
-            <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="waiting" id="guide-node" />
+            <v-list-tile-avatar size="60" style="font-size: 2em;">
+              <v-icon medium>mdi-hubspot</v-icon>
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
-                Suite User Guide
+                Cylc Hub
               </v-list-tile-title>
+              <v-list-tile-sub-title>
+                Visit the Hub to manage your running UI Servers
+              </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
         </v-list>
       </v-flex>
-      <v-flex xs6 md6 lg2>
+      <v-flex xs12 md6 lg6>
         <v-list two-line>
-          <v-list-tile avatar>
-            <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="succeeded" id="quickstart-node" />
+          <v-list-tile
+              avatar
+              href="#"
+              :active-class="color"
+          >
+            <v-list-tile-avatar size="60" style="font-size: 2em;">
+              <v-icon medium>mdi-book</v-icon>
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
                 Cylc UI Quickstart
               </v-list-tile-title>
               <v-list-tile-sub-title>
-                <job status="succeeded" />
+                Learn how to use the Cylc UI
+              </v-list-tile-sub-title>
+            </v-list-tile-content>
+          </v-list-tile>
+          <v-list-tile
+              avatar
+              href="https://cylc.github.io/doc/built-sphinx/suite-design-guide/suite-design-guide-master.html"
+              :active-class="color"
+          >
+            <v-list-tile-avatar size="60" style="font-size: 2em;">
+              <v-icon medium>mdi-book-open-variant</v-icon>
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Suite Design Guide
+              </v-list-tile-title>
+              <v-list-tile-sub-title>
+                How to make complex Cylc and Rose workflows simpler and easier to maintain
               </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
@@ -90,39 +115,19 @@
               href="https://cylc.github.io/documentation.html"
               :active-class="color"
           >
-            <v-list-tile-avatar size="80" style="font-size: 2em;">
-              <task status="running" :progress=25 id="documentation-node" />
+            <v-list-tile-avatar size="60" style="font-size: 2em;">
+              <v-icon medium>mdi-file-document-box-multiple</v-icon>
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title class="title font-weight-thin">
                 Documentation
               </v-list-tile-title>
               <v-list-tile-sub-title>
-                <job status="submitted"/>
-                <job status="submitted"/>
-                <job status="submitted"/>
+                The complete Cylc documentation
               </v-list-tile-sub-title>
             </v-list-tile-content>
           </v-list-tile>
         </v-list>
-      </v-flex>
-    </v-layout>
-    <v-layout row wrap>
-      <v-flex xs12 md12 lg2 offset-lg1>
-        <v-list-tile
-            avatar
-            href="/hub/home"
-            :active-class="color"
-        >
-          <v-list-tile-avatar size="80" style="font-size: 2em;">
-            <task status="failed" id="hub-node" />
-          </v-list-tile-avatar>
-          <v-list-tile-content>
-            <v-list-tile-title class="title font-weight-thin">
-              Cylc Hub
-            </v-list-tile-title>
-          </v-list-tile-content>
-        </v-list-tile>
       </v-flex>
     </v-layout>
   </v-container>
@@ -131,8 +136,6 @@
 <script>
 import { mixin } from '@/mixins/index'
 import { mapState } from 'vuex'
-import Task from '@/components/cylc/Task'
-import Job from '@/components/cylc/Job'
 
 function connectNodes (fromNode, toNode) {
   console.log('TODO?')
@@ -140,10 +143,6 @@ function connectNodes (fromNode, toNode) {
 
 export default {
   mixins: [mixin],
-  components: {
-    task: Task,
-    job: Job
-  },
   metaInfo () {
     return {
       title: this.getPageTitle('App.dashboard')
@@ -167,3 +166,40 @@ export default {
   }
 }
 </script>
+
+<style>
+.c-dashboard {
+  padding: 0 24px;
+}
+
+/* Items in the bottom menu are left-aligned with the top Workflows&Events
+   entries, so we are required to override some styles from Vuetify components
+   in here.*/
+
+/* to left align items in the dashboard */
+.v-avatar .v-icon {
+  width: auto;
+  height: auto;
+}
+.v-list__tile__action, .v-list__tile__avatar {
+  min-width: auto;
+  margin-left: -10px;
+}
+
+/* otherwise avatar does not left align with component above,
+   !important as the attributes are set in the tag element -->
+.v-avatar {
+  height: auto !important;
+  width: auto !important;
+}
+
+/* otherwise responsive UI ends up with extra space between vertical menu items */
+.v-list {
+  padding: 0 0;
+}
+
+/* to left align items in the dashboard */
+.v-list__tile {
+  padding: 0 0;
+}
+</style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -34,14 +34,107 @@
         </v-data-table>
       </v-flex>
     </v-layout>
+    <v-layout row wrap>
+      <v-flex xs6 md6 lg2>
+        <v-list two-line>
+          <v-list-tile avatar>
+            <v-list-tile-avatar size="80" style="font-size: 2em;">
+              <task status="succeeded" />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Settings
+              </v-list-tile-title>
+              <v-list-tile-sub-title>
+                <job status="succeeded" />
+              </v-list-tile-sub-title>
+            </v-list-tile-content>
+          </v-list-tile>
+          <v-list-tile avatar>
+            <v-list-tile-avatar size="80" style="font-size: 2em;">
+              <task status="waiting" />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Cylc Hub
+              </v-list-tile-title>
+            </v-list-tile-content>
+          </v-list-tile>
+        </v-list>
+      </v-flex>
+      <v-flex xs6 md6 lg2>
+        <v-list two-line>
+          <v-list-tile avatar>
+            <v-list-tile-avatar size="80" style="font-size: 2em;">
+              <task status="succeeded" />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Cylc UI Quickstart
+              </v-list-tile-title>
+              <v-list-tile-sub-title>
+                <job status="succeeded" />
+              </v-list-tile-sub-title>
+            </v-list-tile-content>
+          </v-list-tile>
+          <v-list-tile avatar>
+            <v-list-tile-avatar size="80" style="font-size: 2em;">
+              <task status="running" :progress=25 />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Documentation
+              </v-list-tile-title>
+              <v-list-tile-sub-title>
+                <job status="submitted"/>
+                <job status="submitted"/>
+                <job status="submitted"/>
+              </v-list-tile-sub-title>
+            </v-list-tile-content>
+          </v-list-tile>
+          <v-list-tile avatar>
+            <v-list-tile-avatar size="80" style="font-size: 2em;">
+              <task status="waiting" />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Suite Design Guide
+              </v-list-tile-title>
+            </v-list-tile-content>
+          </v-list-tile>
+        </v-list>
+      </v-flex>
+    </v-layout>
+    <v-layout row wrap>
+      <v-flex xs12 md12 lg4>
+        <v-list align-center>
+          <v-list-tile>
+            <v-list-tile-avatar size="80" style="font-size: 2em;">
+              <task status="failed" />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title class="title font-weight-thin">
+                Stop Server
+              </v-list-tile-title>
+            </v-list-tile-content>
+          </v-list-tile>
+        </v-list>
+      </v-flex>
+    </v-layout>
   </v-container>
 </template>
 
 <script>
 import { mixin } from '@/mixins/index'
+import Task from '@/components/cylc/Task'
+import Job from '@/components/cylc/Job'
 
 export default {
   mixins: [mixin],
+  components: {
+    task: Task,
+    job: Job
+  },
   metaInfo () {
     return {
       title: this.getPageTitle('App.dashboard')
@@ -57,9 +150,3 @@ export default {
   })
 }
 </script>
-
-<style>
-.c-dashboard {
-  font-size: 120%;
-}
-</style>


### PR DESCRIPTION
Part of #94, opening the way for #139. This pull request removes all the links from the sidebar, but the Suites/Graph view links.

The idea is that this way, once GScan works begin, the other links such as Hub, User, etc have already been moved elsewhere (the login page was done in #147).

Tried to follow the example from the current design document (#87 ), but my SvgFu fails me @oliver-sanders . Do you reckon it would be easy to create the arrows and connect the nodes, as in the sketch?

I used the components `Task` and `Job` and the result is close to the sketch. There is some example code in this PR with the ID of the `Task` element, which contains the SVG node.

Then, there is a JS function pending implementation where I was going to start working on creating the lines/arrows.

The issue that I have now, is that I haven't done that without a canvas? I found a few people with ideas like creating an SVG element on the fly and just positioning it on the UI, or creating a DIV and hacking its X/Y/Z, etc.

But I thought at this stage it would be better to show you what I've done today and see if it's going in a good direction, or if you had something else in mind.

Note: not a complete solution for the #94 , as that issue has discussion about allowing users to customize their dashboards. However, this could very well be the default dashboard, when the user has not customized the UI.