### PR TITLE
Fix logo chrome

### DIFF
--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -2,7 +2,8 @@
   <v-list-tile-action-text class="pt-3 pb-3 c-header">
     <v-layout align-center justify-center row wrap fill-height>
       <div class="mb-2">
-        <svg version="1.1" viewBox="0 0 655 260" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb">
+        <svg version="1.1" preserveAspectRatio="xMinYMin meet" width="100%" height="100%" viewBox="0 0 655 260" xmlns="http://www.w3.org/2000/svg"
+             xmlns:osb="http://www.openswatchbook.org/uri/2009/osb">
           <g transform="translate(292.53 -49.505)">
             <g>
               <circle transform="scale(-1,1)" cx="-135.7" cy="248.39" r="27.743" fill="#818181"/>


### PR DESCRIPTION
Close #148 

@oliver-sanders apparently just needed to specify the width and height. Also copied extra attribute from the [StackOverflow answer](https://stackoverflow.com/a/37074597) where I found the fix.

Firefox 68.0.1:

![image](https://user-images.githubusercontent.com/304786/62090036-77ce0980-b2bf-11e9-8b1a-ae39872d0c0f.png)

Chrome 75.0.3770.142 (with adblock on, and cropped a piece of the logo to the left because of my bad skills with screenshots, but it's displaying just like in Ffox):

![image](https://user-images.githubusercontent.com/304786/62090047-83213500-b2bf-11e9-905b-5473f3b41f4e.png)

One review should do?