### PR TITLE
Remove (unnecessary) vuex getters

### DIFF
--- a/src/components/core/Footer.vue
+++ b/src/components/core/Footer.vue
@@ -6,21 +6,25 @@
   >
     <v-spacer/>
     <span class="font-weight-light copyright">
-      <strong v-if="env !== 'PRODUCTION'">{{ env }}</strong>
-      {{ $t('App.name') }} {{ $store.getters.appVersion }} &copy; 2008-{{ (new Date()).getFullYear() }} {{ $t('App.footer') }}
+      <strong v-if="environment !== 'PRODUCTION'">{{ environment }}</strong>
+      {{ $t('App.name') }} {{ packageJson.version }} &copy; 2008-{{ (new Date()).getFullYear() }} {{ $t('App.footer') }}
     </span>
   </v-footer>
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 export default {
   data: () => ({
     links: [
       { name: 'Website', Link: 'https://cylc.github.io/', route: false },
       { name: 'About', Link: '/about', route: true }
-    ],
-    env: process.env.NODE_ENV.toUpperCase()
-  })
+    ]
+  }),
+  computed: {
+    ...mapState(['packageJson', 'environment'])
+  }
 }
 </script>
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,6 +17,7 @@ import { user } from './user.module'
 // State
 const state = {
   packageJson: JSON.parse(unescape(process.env.PACKAGE_JSON || '%7B%7D')),
+  environment: process.env.NODE_ENV.toUpperCase(),
   isLoading: false,
   refCount: 0,
   alert: null
@@ -54,13 +55,6 @@ const mutations = {
   }
 }
 
-// Getters
-const getters = {
-  appVersion: (state) => {
-    return state.packageJson.version
-  }
-}
-
 Vue.use(Vuex)
 
 // Create a new store
@@ -71,7 +65,6 @@ const store = new Vuex.Store({
     user
   },
   actions,
-  getters,
   mutations,
   state
 })

--- a/src/store/user.module.js
+++ b/src/store/user.module.js
@@ -14,16 +14,9 @@ export const actions = {
   }
 }
 
-const getters = {
-  user: (state) => {
-    return state.user
-  }
-}
-
 export const user = {
   namespaced: true,
   state,
   mutations,
-  actions,
-  getters
+  actions
 }

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -17,16 +17,9 @@ const actions = {
   }
 }
 
-const getters = {
-  workflows: (state) => {
-    return state.workflows
-  }
-}
-
 export const workflows = {
   namespaced: true,
   state,
   mutations,
-  actions,
-  getters
+  actions
 }

--- a/tests/unit/services/user.service.spec.js
+++ b/tests/unit/services/user.service.spec.js
@@ -22,7 +22,7 @@ describe('UserService', () => {
       }))
       sandbox.stub(axios, 'get').returns(userReturned)
       return UserService.getUserProfile().then(function () {
-        const user = store.getters['user/user']
+        const user = store.state.user.user
         expect(user.getUserName()).to.equal('cylc-user-01')
         expect(user.getGroups().length).to.equal(2)
         expect(user.getCreated()).to.equal('2019-01-01')

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,9 +1,19 @@
 // optional file, loaded automatically by @vue/cli-service if present next to package.json
+var webpack = require('webpack')
 
 module.exports = {
   publicPath: '',
   outputDir: 'dist',
   indexPath: 'index.html',
+  configureWebpack: {
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env': {
+          PACKAGE_JSON: '"' + escape(JSON.stringify(require('./package.json'))) + '"'
+        }
+      })
+    ]
+  },
   chainWebpack: config => {
     if (process.env.NODE_ENV !== 'production') {
       config.module.rule('js')


### PR DESCRIPTION
Remove the [getters](https://vuex.vuejs.org/guide/getters.html) from Vuex stores. The getters are similar to `computed` values in Vuejs.

So you will only need them when you have a value that depends on some `state` data from Vuex, using reactivity. This will eliminate unused code, and make it easier to write the unit tests.

This closes #122 