### PR TITLE
Update i18n or add when missing

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -80,6 +80,7 @@ import {
   mapState
 } from 'vuex'
 import Header from '@/components/cylc/Header'
+import i18n from '@/i18n'
 
 export default {
   components: {
@@ -90,25 +91,25 @@ export default {
       {
         to: '/dashboard',
         icon: 'mdi-view-dashboard',
-        text: 'Dashboard',
+        text: i18n.t('App.dashboard'),
         view: false
       },
       {
         to: '/workflows',
         icon: 'mdi-vector-circle',
-        text: 'Workflows',
+        text: i18n.t('App.workflows'),
         view: true
       },
       {
         to: '/graph',
         icon: 'mdi-vector-polyline',
-        text: 'Graph',
+        text: i18n.t('App.graph'),
         view: true
       },
       {
         to: '/user-profile',
         icon: 'mdi-account',
-        text: 'User Profile',
+        text: i18n.t('App.userProfile'),
         view: false
       }
     ],

--- a/src/components/core/Footer.vue
+++ b/src/components/core/Footer.vue
@@ -7,7 +7,7 @@
     <v-spacer/>
     <span class="font-weight-light copyright">
       <strong v-if="env !== 'PRODUCTION'">{{ env }}</strong>
-      Cylc UI {{ $store.getters.appVersion }} &copy; 2008-{{ (new Date()).getFullYear() }} NIWA &amp; British Crown (Met Office) &amp; contributors
+      {{ $t('App.name') }} {{ $store.getters.appVersion }} &copy; 2008-{{ (new Date()).getFullYear() }} {{ $t('App.footer') }}
     </span>
   </v-footer>
 </template>

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -34,7 +34,7 @@
       </a>
 
       <a>
-        <v-chip color="#E7E7E7" @click="toggleExtended">Control</v-chip>
+        <v-chip color="#E7E7E7" @click="toggleExtended">{{ $t('Toolbar.control') }}</v-chip>
       </a>
 
       <span>Running, will stop at 30000101T0000 cycle</span>
@@ -42,7 +42,7 @@
       <v-spacer />
 
       <a class="add-view" @click="onClickAddView">
-        Add View <v-icon color="#5995EB">mdi-plus-circle</v-icon>
+        {{ $t('Toolbar.addView') }} <v-icon color="#5995EB">mdi-plus-circle</v-icon>
       </a>
     </template>
 

--- a/src/lang/en-GB/App.json
+++ b/src/lang/en-GB/App.json
@@ -1,0 +1,10 @@
+{
+  "name": "Cylc UI",
+  "dashboard": "Dashboard",
+  "graph": "Graph",
+  "workflow": "Workflow {name}",
+  "workflows": "Workflows",
+  "notFound": "Not Found",
+  "userProfile": "User Profile",
+  "footer": "NIWA & British Crown (Met Office) & contributors"
+}

--- a/src/lang/en-GB/NotFound.json
+++ b/src/lang/en-GB/NotFound.json
@@ -1,0 +1,6 @@
+{
+  "title": "Page not found",
+  "message": "Maybe the page you are looking for has been removed, or you typed in the wrong address",
+  "goBack": "Go Back",
+  "toHomepage": "Go to Homepage"
+}

--- a/src/lang/en-GB/Toolbar.json
+++ b/src/lang/en-GB/Toolbar.json
@@ -1,0 +1,4 @@
+{
+  "control": "Control",
+  "addView": "Add View"
+}

--- a/src/lang/en-GB/UserProfile.json
+++ b/src/lang/en-GB/UserProfile.json
@@ -1,0 +1,8 @@
+{
+  "tableHeader": "Your Profile",
+  "tableSubHeader": "This is a read-only view of your user",
+  "username": "Username",
+  "administrator": "Administrator",
+  "groups": "Groups",
+  "created": "Created"
+}

--- a/src/lang/en-GB/Workflows.json
+++ b/src/lang/en-GB/Workflows.json
@@ -2,10 +2,8 @@
   "tableHeader": "List of Workflows",
   "tableSubHeader": "This is the list of workflows the current user has access to",
   "tableColumnName": "Name",
-  "tableColumnGroup": "Group",
-  "tableColumnHost": "Host",
   "tableColumnOwner": "Owner",
-  "tableColumnVersion": "Version",
-  "tableColumnUpdated": "Updated",
-  "tableColumnStatus": "Status"
+  "tableColumnHost": "Host",
+  "tableColumnPort": "Port",
+  "tableColumnActions": "Actions"
 }

--- a/src/lang/pt-BR/App.json
+++ b/src/lang/pt-BR/App.json
@@ -1,0 +1,10 @@
+{
+  "name": "Cylc UI",
+  "dashboard": "Dashboard",
+  "graph": "Grafo",
+  "workflow": "Workflow {name}",
+  "workflows": "Workflows",
+  "notFound": "Página não encontrada",
+  "userProfile": "Perfil de Usuário",
+  "footer": "NIWA & British Crown (Met Office) & contribuidores"
+}

--- a/src/lang/pt-BR/NotFound.json
+++ b/src/lang/pt-BR/NotFound.json
@@ -1,0 +1,6 @@
+{
+  "title": "Página não encontrada",
+  "message": "Talvez a página que você está procurando tenha sido removida ou você tenha digitado o endereço errado",
+  "goBack": "Voltar",
+  "toHomepage": "Voltar para a página principal"
+}

--- a/src/lang/pt-BR/Toolbar.json
+++ b/src/lang/pt-BR/Toolbar.json
@@ -1,0 +1,4 @@
+{
+  "control": "Controle",
+  "addView": "Adicionar Painel"
+}

--- a/src/lang/pt-BR/UserProfile.json
+++ b/src/lang/pt-BR/UserProfile.json
@@ -1,0 +1,8 @@
+{
+  "tableHeader": "Seu perfil de Usuário",
+  "tableSubHeader": "Esta é a lista (modo leitura) do perfil do seu usuário",
+  "username": "Nome de Usuário",
+  "administrator": "Administrador",
+  "groups": "Grupos",
+  "created": "Criado"
+}

--- a/src/lang/pt-BR/Workflows.json
+++ b/src/lang/pt-BR/Workflows.json
@@ -2,10 +2,8 @@
   "tableHeader": "Lista de Workflows",
   "tableSubHeader": "Esta é a lista de workflows que este usuário possui permissoões para visualizar",
   "tableColumnName": "Nome",
-  "tableColumnGroup": "Grupo",
-  "tableColumnHost": "Host",
   "tableColumnOwner": "Usuário",
-  "tableColumnVersion": "Versão",
-  "tableColumnUpdated": "Atualizado",
-  "tableColumnStatus": "Status"
+  "tableColumnHost": "Servidor",
+  "tableColumnPort": "Porta",
+  "tableColumnActions": "Ações"
 }

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,0 +1,28 @@
+import i18n from '@/i18n'
+
+/**
+ * Here we can define the operations that are common to components/views.
+ * @type {{methods: {setPageTitle(*=, *=): string}}}
+ */
+
+const mixin = {
+  /**
+   * Automatically created methods for components.
+   */
+  methods: {
+    /**
+     * i18n-enabled operation, to get the title respecting the locale used
+     * in the application settings.
+     * @param key {string} i18n key
+     * @param params {object} optional object key=value used in the i18n message
+     * @returns {string}
+     */
+    getPageTitle: function (key, params = {}) {
+      return `${i18n.t('App.name')} | ${i18n.t(key, params)}`
+    }
+  }
+}
+
+export {
+  mixin
+}

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -1,3 +1,5 @@
+import i18n from '@/i18n'
+
 /**
  * Define all of your application routes here
  * for more information on routes, see the
@@ -7,6 +9,7 @@ export default [
   {
     path: '/dashboard',
     view: 'Dashboard',
+    name: i18n.t('App.dashboard'),
     meta: {
       layout: 'default'
     },
@@ -15,12 +18,14 @@ export default [
   {
     path: '/graph',
     view: 'Graph',
+    name: i18n.t('App.graph'),
     meta: {
       layout: 'default'
     }
   },
   {
     path: '/workflows',
+    name: i18n.t('App.workflows'),
     view: 'GScan',
     meta: {
       layout: 'default'
@@ -35,7 +40,7 @@ export default [
   },
   {
     path: '/user-profile',
-    name: 'User Profile',
+    name: i18n.t('App.userProfile'),
     view: 'UserProfile',
     meta: {
       layout: 'default'

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -8,10 +8,13 @@
 </template>
 
 <script>
+import { mixin } from '@/mixins/index'
+
 export default {
+  mixins: [mixin],
   metaInfo () {
     return {
-      title: 'Cylc UI | Dashboard'
+      title: this.getPageTitle('App.dashboard')
     }
   }
 }

--- a/src/views/GScan.vue
+++ b/src/views/GScan.vue
@@ -12,8 +12,8 @@
         md12
       >
         <material-card
-          :text="$t('Workflows.tableSubHeader')"
-          :title="$t('Workflows.tableHeader')"
+            :title="$t('Workflows.tableHeader')"
+            :text="$t('Workflows.tableSubHeader')"
           color="green"
         >
           <v-data-table
@@ -68,6 +68,8 @@
 <script>
 import { workflowService } from 'workflow-service'
 import { mapState } from 'vuex'
+import { mixin } from '@/mixins/index'
+import i18n from '@/i18n'
 
 // query to retrieve all workflows
 const QUERIES = {
@@ -85,9 +87,10 @@ const QUERIES = {
 }
 
 export default {
+  mixins: [mixin],
   metaInfo () {
     return {
-      title: 'Cylc GScan'
+      title: this.getPageTitle('App.workflows')
     }
   },
 
@@ -101,27 +104,27 @@ export default {
     headers: [
       {
         sortable: true,
-        text: 'Name',
+        text: i18n.t('Workflows.tableColumnName'),
         value: 'name'
       },
       {
         sortable: true,
-        text: 'Owner',
+        text: i18n.t('Workflows.tableColumnOwner'),
         value: 'owner'
       },
       {
         sortable: true,
-        text: 'Host',
+        text: i18n.t('Workflows.tableColumnHost'),
         value: 'host'
       },
       {
         sortable: false,
-        text: 'Port',
+        text: i18n.t('Workflows.tableColumnPort'),
         value: 'port'
       },
       {
         sortable: false,
-        text: 'Actions',
+        text: i18n.t('Workflows.tableColumnActions'),
         value: 'actions'
       }
     ]

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -45,6 +45,7 @@ import Tippy from 'tippy.js'
 
 import VueCytoscape from '@/components/core/Cytoscape.vue'
 import CyElement from '@/components/core/CyElement.vue'
+import { mixin } from '@/mixins/index'
 
 const DATA_URL = 'simple-cytoscape-dot.7.js'
 let cy = {}
@@ -299,9 +300,13 @@ const config = {
 }
 
 export default {
+  mixins: [mixin],
   metaInfo () {
+    // TODO: once the component is using live data, use the workflow name here
+    // const workflowName = this.$route.params.name || '(TODO)'
+    // and pass to the getPageTitle('App.graph', , { name: workflowName })
     return {
-      title: 'Cylc UI | Graph'
+      title: this.getPageTitle('App.graph')
     }
   },
   name: 'Graph',

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -12,15 +12,15 @@
         <v-card>
           <v-card-title primary-title>
             <div>
-              <h3 class="headline mb-0">Page not found</h3>
+              <h3 class="headline mb-0">{{ $t('NotFound.title') }}</h3>
             </div>
           </v-card-title>
           <v-card-text>
-            Maybe the page you are looking for has been removed, or you typed in the wrong address
+            {{ $t('NotFound.message') }}
           </v-card-text>
           <v-card-actions>
-            <button @click="$router.go(-1)" class="v-btn success">Go Back</button>
-            <router-link to="/dashboard" tag="button" class="white--text success v-btn">Go to Homepage</router-link>
+            <button @click="$router.go(-1)" class="v-btn success">{{ $t('NotFound.goBack') }}</button>
+            <router-link to="/dashboard" tag="button" class="white--text success v-btn">{{ $t('NotFound.toHomepage') }}</router-link>
           </v-card-actions>
         </v-card>
       </v-flex>
@@ -29,10 +29,13 @@
 </template>
 
 <script>
+import { mixin } from '@/mixins/index'
+
 export default {
+  mixins: [mixin],
   metaInfo () {
     return {
-      title: 'Cylc UI | Not Found'
+      title: this.getPageTitle('App.notFound')
     }
   }
 }

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -43,6 +43,7 @@ import { workflowService } from 'workflow-service'
 import { mapState } from 'vuex'
 import Task from '@/components/cylc/Task'
 import Job from '@/components/cylc/Job'
+import { mixin } from '@/mixins/index'
 
 // query to retrieve all workflows
 const QUERIES = {
@@ -71,14 +72,16 @@ const QUERIES = {
 }
 
 export default {
+  mixins: [mixin],
   components: {
     task: Task,
     job: Job
   },
 
   metaInfo () {
+    const workflowName = this.$route.params.name
     return {
-      title: 'Tree View'
+      title: this.getPageTitle('App.workflow', { name: workflowName })
     }
   },
 

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -4,8 +4,8 @@
       <v-flex xs12 md12>
         <material-card
             color="green"
-            title="Your Profile"
-            text="This is a read-only view of your user"
+            :title="$t('UserProfile.tableHeader')"
+            :text="$t('UserProfile.tableSubHeader')"
         >
           <v-form v-if="user !== null">
             <v-container py-0>
@@ -13,7 +13,7 @@
                 <v-flex xs12 md12>
                   <v-text-field
                       :value="user.getUserName()"
-                      label="Username"
+                      :label="$t('UserProfile.username')"
                       disabled
                       aria-disabled="true"
                   />
@@ -23,7 +23,7 @@
                 <v-flex xs12 md12>
                   <v-checkbox
                       v-model="user.admin"
-                      label="Administrator"
+                      :label="$t('UserProfile.administrator')"
                       disabled
                       aria-disabled="true"
                   />
@@ -37,7 +37,7 @@
                   <v-select
                       :items="user.getGroups()"
                       v-model="user.groups"
-                      label="Groups"
+                      :label="$t('UserProfile.groups')"
                       attach
                       chips
                       multiple
@@ -53,7 +53,7 @@
                 >
                   <v-text-field
                       :value="user.getCreated()"
-                      label="Created"
+                      :label="$t('UserProfile.created')"
                       disabled
                       aria-disabled="true"
                   />
@@ -71,7 +71,10 @@
 <script>
 import { UserService } from '@/services/user.service'
 import { mapState } from 'vuex'
+import { mixin } from '@/mixins/index'
+
 export default {
+  mixins: [mixin],
   computed: {
     ...mapState('user', ['user'])
   },
@@ -84,7 +87,7 @@ export default {
   },
   metaInfo () {
     return {
-      title: 'Cylc UI | User Profile'
+      title: this.getPageTitle('App.userProfile')
     }
   }
 }


### PR DESCRIPTION
Adds new i18n translations, and updates the ones that have been removed.

This also closes #142 , as the application name (Cylc UI) is now centralized in the i18n messages files. This allows to reuse it for Footer, and also for the page titles.