### PR TITLE
Fix Task progress

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -176,7 +176,7 @@ export default {
   computed: {
     progressStyle: function () {
       return {
-        'stroke-dashoffset': `calc(157 - (157 * ${this.progress / 100} + ))`
+        'stroke-dashoffset': `calc(157 - (157 * ${this.progress / 100} ))`
       }
     }
   }

--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -175,8 +175,9 @@ export default {
   },
   computed: {
     progressStyle: function () {
+      const progress = 157 - (157 * (this.progress / 100))
       return {
-        'stroke-dashoffset': `calc(157 - (157 * ${this.progress / 100} ))`
+        'stroke-dashoffset': progress
       }
     }
   }


### PR DESCRIPTION
@oliver-sanders I think the progress in the tasks has been broken for a while. I noticed it while reviewing your PR #168 

If you look at your example code, you have progress set to `0.3`. The code seems to be expecting `30`. But even passing `30`, I didn't get anything in Chrome or Firefox.

After removing the extra `+` sign, it worked on chrome. But on Firefox it did not work. I tested replacing the `calc(157 - (157 * ${this.progress / 100} + ))` (which was working on Chrome) by simply `109.9`, and it worked.

Undoing this change, and going back to the Firefox browser console, it is possible to see that Firefox rejected the value expression for `stroke-dashoffset` (there is a warning in the CSS category, which is not always enabled for me).

In this PR, I've moved the calculation logic to JS. This way we don't need to worry about issues with `calc()` I think? And it worked on my Chrome and Firefox. But I never used `stroke-dashoffset` before, so maybe you know about some other way to fix it. I don't have my NIWA note with me, so can't confirm if that's working on IE Edge.

Cheers
Bruno