### PR TITLE
Use only cy instance provided by vue-cytoscape

### DIFF
--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -44,7 +44,6 @@ import VueCytoscape from '@/components/core/Cytoscape.vue'
 import { mixin } from '@/mixins/index'
 
 const DATA_URL = 'simple-cytoscape-dot.7.js'
-let cy = {}
 let ur = {}
 const elements = []
 // eslint-disable-next-line no-unused-vars
@@ -340,7 +339,7 @@ export default {
       cytoscape.use(coseBilkent)
       cytoscape.use(klay)
     },
-    async afterCreated () {
+    async afterCreated (cy) {
       console.log('after created')
       const dagreOptions = {
         name: 'dagre',
@@ -622,7 +621,6 @@ export default {
 
       // load graph data and run layout
       const { data: elements } = await updateData()
-      cy = await this.$cytoscape.instance
       ur = await getGraph(cy)
       console.log('loaded elements: ', elements, cy)
       this.loading = false // remove spinner


### PR DESCRIPTION
Closes #112

@MartinRyan I think I found what was going on. The `cy` instance was being created and re-used, but from looking at the [vue-cytoscape](https://github.com/rcarcasses/vue-cytoscape), I found that `afterCreated` actually takes a `cy` parameter.

That means we don't have to worry about the Cytoscape instance, and can abstract that away and just assume the instance provided is OK.

![GIFrecord_2019-08-13_090721](https://user-images.githubusercontent.com/304786/62898575-ed4ed500-bda9-11e9-8d53-75b224c2ce9e.gif)

I think this issue happened maybe because you didn't start with `vue-cytoscape` from the beginning, and adding it later probably you didn't need the `cy` instance as the code was working.

Hope that helps
Bruno
