### PR TITLE
Task failed

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -39,14 +39,14 @@
           stroke-dasharray="157"
           v-bind:style="progressStyle"
         ></circle>
-        <!-- circle in the middle
+        <!-- circle in the middle (hub)
                * position in the middle
                * radius can be changed independently
         -->
         <circle
           id="hub"
           cx="50" cy="50"
-          r="12">
+          r="15">
         </circle>
         <!-- outer circle
                * position in the middle
@@ -203,7 +203,6 @@
 
             &.submit-failed {
                 @include outline();
-                @include hub();
                 @include cross($foreground);
             }
         }

--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -141,9 +141,9 @@
             }
         }
 
-        @mixin cross() {
+        @mixin cross($colour) {
             #cross rect {
-                fill: $foreground;
+                fill: $colour;
             }
         }
 
@@ -196,14 +196,15 @@
             }
 
             &.failed {
+                @include disk();
                 @include outline();
-                @include cross();
+                @include cross($background);
             }
 
             &.submit-failed {
                 @include outline();
                 @include hub();
-                @include cross();
+                @include cross($foreground);
             }
         }
     }


### PR DESCRIPTION
Proposal to close #173 (because it's faster to code than draw for this one)

* Visually clarify that succeeded and failed are both "completed" states.
* Visually distinguish failed from submit-failed
* Remove hub (circle) from submit-failed icon (because it's just messy)

Idea credit @hjoliver 

![Screenshot from 2019-08-14 10-30-09](https://user-images.githubusercontent.com/16705946/63010581-8f3ff180-be7e-11e9-88b4-96d860059eb7.png)