### PR TITLE
Remove unused functions in Dashboard.vue

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -137,10 +137,6 @@
 import { mixin } from '@/mixins/index'
 import { mapState } from 'vuex'
 
-function connectNodes (fromNode, toNode) {
-  console.log('TODO?')
-}
-
 export default {
   mixins: [mixin],
   metaInfo () {
@@ -158,11 +154,6 @@ export default {
   }),
   computed: {
     ...mapState('app', ['color'])
-  },
-  mounted: function () {
-    const settingsNode = document.getElementById('settings-node').children[0]
-    const suiteDesignGuideNode = document.getElementById('guide-node').children[0]
-    connectNodes(settingsNode, suiteDesignGuideNode)
   }
 }
 </script>


### PR DESCRIPTION
Had noticed some days ago that the `Dashboard.vue` when displayed always resulted in some console errors.

```
Error in mounted hook: "TypeError: Cannot read property 'children' of null"
```

This was due to some function I left from the initial implementation, when I was working on that graph-like display, with connected dots.

We decided not to add that for now, but I forgot to remote the functions. Sorry.

One review should be enough, as this code is not used.