### PR TITLE
Remove duplicate Dashboard route

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -26,7 +26,7 @@
       </v-list-tile>
 
       <v-list-tile
-          to="/dashboard"
+          to="/"
           :active-class="color"
           avatar
           class="v-list-item"

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -7,13 +7,12 @@ import i18n from '@/i18n'
  */
 export default [
   {
-    path: '/dashboard',
+    path: '/',
     view: 'Dashboard',
     name: i18n.t('App.dashboard'),
     meta: {
       layout: 'default'
-    },
-    alias: ['/']
+    }
   },
   {
     path: '/graph',

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -47,13 +47,6 @@ export default [
     }
   },
   {
-    path: '/',
-    view: 'Dashboard',
-    meta: {
-      layout: 'default'
-    }
-  },
-  {
     path: '*',
     view: 'NotFound',
     meta: {


### PR DESCRIPTION
Fix browser console warning (yellow-ish console log, not really an Error and frequently ignored) for "[vue-router] Duplicate named routes definition: { name: "Dashboard", path: "" }".

I probably accidentally added a duplicate route while adding the Dashboard view I guess. Trivial change (click on the blue icon in the diff near the top of the change to see more of the file, and keep doing that until you can see another route that is also mapped to `Dashboard` view), one review should do :+1: 