### PR TITLE
Add host and progress information (mean elapsed time, execution time) to GraphQL query (mock and real)

### DIFF
--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -3,21 +3,24 @@ const checkpoint = {
     {
       id: 'cylc/one',
       name: 'one',
-      status: 'running to stop at 20000102T0000Z',
+      status: 'running',
       owner: 'cylc',
-      host: 'eld668.cmpd1.metoffice.gov.uk',
-      port: 43092,
+      host: 'cylc-VirtualBox',
+      port: 43060,
       taskProxies: [
         {
           id: 'cylc/one/20000101T0000Z/sleepy',
           state: 'succeeded',
           cyclePoint: '20000101T0000Z',
           task: {
+            meanElapsedTime: 1.0,
             name: 'sleepy'
           },
           jobs: [
             {
               id: 'cylc/one/20000101T0000Z/sleepy/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:30Z',
               state: 'succeeded',
               submitNum: 1
             }
@@ -28,11 +31,14 @@ const checkpoint = {
           state: 'succeeded',
           cyclePoint: '20000101T0000Z',
           task: {
+            meanElapsedTime: 1.0,
             name: 'waiting'
           },
           jobs: [
             {
               id: 'cylc/one/20000101T0000Z/waiting/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:30Z',
               state: 'succeeded',
               submitNum: 1
             }
@@ -43,11 +49,14 @@ const checkpoint = {
           state: 'running',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 8.0,
             name: 'checkpoint'
           },
           jobs: [
             {
               id: 'cylc/one/20000102T0000Z/checkpoint/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:56Z',
               state: 'running',
               submitNum: 1
             }
@@ -55,9 +64,10 @@ const checkpoint = {
         },
         {
           id: 'cylc/one/20000102T0000Z/sleepy',
-          state: 'held',
+          state: 'waiting',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 1.0,
             name: 'sleepy'
           },
           jobs: []
@@ -67,6 +77,7 @@ const checkpoint = {
           state: 'waiting',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 1.0,
             name: 'waiting'
           },
           jobs: []
@@ -76,26 +87,35 @@ const checkpoint = {
           state: 'succeeded',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 1.0,
             name: 'eventually_succeeded'
           },
           jobs: [
             {
               id: 'cylc/one/20000102T0000Z/eventually_succeeded/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:34Z',
               state: 'running',
               submitNum: 1
             },
             {
               id: 'cylc/one/20000102T0000Z/eventually_succeeded/02',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:40Z',
               state: 'running',
               submitNum: 2
             },
             {
               id: 'cylc/one/20000102T0000Z/eventually_succeeded/03',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:44Z',
               state: 'running',
               submitNum: 3
             },
             {
               id: 'cylc/one/20000102T0000Z/eventually_succeeded/04',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:49Z',
               state: 'succeeded',
               submitNum: 4
             }
@@ -106,11 +126,14 @@ const checkpoint = {
           state: 'failed',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 0.0,
             name: 'failed'
           },
           jobs: [
             {
               id: 'cylc/one/20000102T0000Z/failed/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:52Z',
               state: 'failed',
               submitNum: 1
             }
@@ -121,11 +144,14 @@ const checkpoint = {
           state: 'retrying',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 0.0,
             name: 'retrying'
           },
           jobs: [
             {
               id: 'cylc/one/20000102T0000Z/retrying/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:34Z',
               state: 'running',
               submitNum: 1
             }
@@ -136,11 +162,14 @@ const checkpoint = {
           state: 'succeeded',
           cyclePoint: '20000102T0000Z',
           task: {
+            meanElapsedTime: 0.5,
             name: 'succeeded'
           },
           jobs: [
             {
               id: 'cylc/one/20000102T0000Z/succeeded/01',
+              host: 'localhost',
+              startedTime: '2019-08-21T01:31:35Z',
               state: 'succeeded',
               submitNum: 1
             }

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -12,10 +12,13 @@ query = '''
             state
             cyclePoint
             task {
+                meanElapsedTime
                 name
             }
             jobs {
                 id
+                host
+                startedTime
                 state
                 submitNum
             }
@@ -29,4 +32,4 @@ wrapper = {
 }
 
 import json
-print(json.dumps(wrapper))
+print(json.dumps(wrapper, indent=2))

--- a/src/services/mock/generate
+++ b/src/services/mock/generate
@@ -16,5 +16,5 @@ else
     exit 1
 fi
 
-sed -i "1 s/^/const checkpoint=/; s/${USER}/cylc/g" "${CHECK_FILE}"
+sed -i "1 s/^/const checkpoint = /; s/${USER}/cylc/g" "${CHECK_FILE}"
 echo -e '\nexport { checkpoint }' >> "${CHECK_FILE}"

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -53,15 +53,21 @@ const QUERIES = {
           id
           name
           status
+          owner
+          host
+          port
           taskProxies {
             id
             state
             cyclePoint
             task {
+              meanElapsedTime
               name
             }
             jobs {
               id
+              host
+              startedTime
               state
               submitNum
             }


### PR DESCRIPTION
The issue with `generate` and mock data was in my environment (see #192 and thanks @matthewrmshin !). Once fixed, managed to re-run the script using `master` from both Cylc UI Server and Cylc Flow, and update the mock data.

Also updated `Tree.vue`'s GraphQL query, and tested with offline mode, and with real data.

Part of #145 , just submitting before as it will take a bit more to finish that component's PR, and it will make it easier reviewing the PR.

Also closes #191 

Cheers
Bruno