### PR TITLE
Log GraphQL queries to debug level only

### DIFF
--- a/src/services/gquery.js
+++ b/src/services/gquery.js
@@ -165,7 +165,9 @@ class GQuery {
     /**
      * Perform a REST GraphQL request for all subscriptions.
      */
-    console.log('graphql request:', this.query)
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('graphql request:', this.query)
+    }
     return this.apolloClient.query({
       query: this.query,
       fetchPolicy: 'no-cache'
@@ -228,7 +230,9 @@ class GQuery {
         })
     })
 
-    console.log(ret)
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug(ret)
+    }
   }
 }
 


### PR DESCRIPTION
Closes #213 

This PR uses `process.env.NODE_ENV`, which contains the Vue.js application mode. Most of the time I am working with the `offline` mode, which is a custom mode we created.

But users will run on the `production` (except for `offline`, all other names here are standard names in Node.js/Vue/etc). Developers by default run on `development`, unless they specify `offline` or another mode.

The value of `process.env.NODE_ENV` gets replaced by the string value during compile-time by... WebPack I guess.

The solution on this PR checks that value - which is common practice - and when it is set to something different than `production`, it will log the query, but now to `debug` level (`console.error` goes to error logging level, `console.warn` to warn logging level, and so it goes).

So production will look like (see copyright footer with or without the mode... without means production).

![no-logs-production](https://user-images.githubusercontent.com/304786/64308140-67126100-cfec-11e9-87e7-29fca3ddb4e1.png)

Development and other methods will look like:

![Screenshot_2019-09-05_14-40-56](https://user-images.githubusercontent.com/304786/64308151-6f6a9c00-cfec-11e9-8335-5ef98de75b08.png)

And if the developer wants to see the debug log, all s/he needs to do is just enable it on the browser console.

![Screenshot_2019-09-05_14-41-14](https://user-images.githubusercontent.com/304786/64308169-7c878b00-cfec-11e9-99bb-5b3147b11043.png)

Cheers
Bruno

