### PR TITLE
Add function to compute percent progress for the Tree component

### DIFF
--- a/src/components/cylc/TreeItem.vue
+++ b/src/components/cylc/TreeItem.vue
@@ -26,7 +26,7 @@
       </v-layout>
       <v-layout @click="nodeClicked" row wrap v-else-if="node.__type === 'task'">
         <v-flex shrink>
-          <task :status="node.state" :progress=0 />
+          <task :status="node.state" :progress="node.progress" />
         </v-flex>
         <v-flex shrink>
           <span class="mx-1">{{ node.name }}</span>

--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -1,183 +1,294 @@
 const checkpoint = {
-  workflows: [
-    {
-      id: 'cylc/one',
-      name: 'one',
-      status: 'running',
-      owner: 'cylc',
-      host: 'cylc-VirtualBox',
-      port: 43060,
-      taskProxies: [
+    "workflows": [
         {
-          id: 'cylc/one/20000101T0000Z/sleepy',
-          state: 'succeeded',
-          cyclePoint: '20000101T0000Z',
-          task: {
-            meanElapsedTime: 1.0,
-            name: 'sleepy'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000101T0000Z/sleepy/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:30Z',
-              state: 'succeeded',
-              submitNum: 1
-            }
-          ]
-        },
-        {
-          id: 'cylc/one/20000101T0000Z/waiting',
-          state: 'succeeded',
-          cyclePoint: '20000101T0000Z',
-          task: {
-            meanElapsedTime: 1.0,
-            name: 'waiting'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000101T0000Z/waiting/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:30Z',
-              state: 'succeeded',
-              submitNum: 1
-            }
-          ]
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/checkpoint',
-          state: 'running',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 8.0,
-            name: 'checkpoint'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000102T0000Z/checkpoint/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:56Z',
-              state: 'running',
-              submitNum: 1
-            }
-          ]
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/sleepy',
-          state: 'waiting',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 1.0,
-            name: 'sleepy'
-          },
-          jobs: []
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/waiting',
-          state: 'waiting',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 1.0,
-            name: 'waiting'
-          },
-          jobs: []
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/eventually_succeeded',
-          state: 'succeeded',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 1.0,
-            name: 'eventually_succeeded'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000102T0000Z/eventually_succeeded/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:34Z',
-              state: 'running',
-              submitNum: 1
-            },
-            {
-              id: 'cylc/one/20000102T0000Z/eventually_succeeded/02',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:40Z',
-              state: 'running',
-              submitNum: 2
-            },
-            {
-              id: 'cylc/one/20000102T0000Z/eventually_succeeded/03',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:44Z',
-              state: 'running',
-              submitNum: 3
-            },
-            {
-              id: 'cylc/one/20000102T0000Z/eventually_succeeded/04',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:49Z',
-              state: 'succeeded',
-              submitNum: 4
-            }
-          ]
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/failed',
-          state: 'failed',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 0.0,
-            name: 'failed'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000102T0000Z/failed/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:52Z',
-              state: 'failed',
-              submitNum: 1
-            }
-          ]
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/retrying',
-          state: 'retrying',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 0.0,
-            name: 'retrying'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000102T0000Z/retrying/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:34Z',
-              state: 'running',
-              submitNum: 1
-            }
-          ]
-        },
-        {
-          id: 'cylc/one/20000102T0000Z/succeeded',
-          state: 'succeeded',
-          cyclePoint: '20000102T0000Z',
-          task: {
-            meanElapsedTime: 0.5,
-            name: 'succeeded'
-          },
-          jobs: [
-            {
-              id: 'cylc/one/20000102T0000Z/succeeded/01',
-              host: 'localhost',
-              startedTime: '2019-08-21T01:31:35Z',
-              state: 'succeeded',
-              submitNum: 1
-            }
-          ]
+            "id": "cylc|one",
+            "name": "one",
+            "status": "running",
+            "owner": "cylc",
+            "host": "ranma",
+            "port": 43082,
+            "taskProxies": [
+                {
+                    "id": "cylc|one|20000101T0000Z|succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:38Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|sleepy",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:09Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|retrying",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "retrying"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|retrying|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:38Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|waiting",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|failed",
+                    "state": "failed",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "failed"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|failed|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:24Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|failed",
+                    "state": "failed",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "failed"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|failed|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:53Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:50Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:46Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:42Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:38Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|sleepy",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|sleepy|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:05Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|checkpoint",
+                    "state": "running",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 6.0,
+                        "name": "checkpoint"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|checkpoint|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:27Z",
+                            "state": "running",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:21Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:17Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:13Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:09Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|waiting",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|waiting|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:05Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|checkpoint",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 6.0,
+                        "name": "checkpoint"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|checkpoint|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:21:56Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|retrying",
+                    "state": "retrying",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "retrying"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|retrying|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:22:09Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }
 
 export { checkpoint }

--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const checkpoint = {
     "workflows": [
         {
@@ -6,8 +8,18 @@ const checkpoint = {
             "status": "running",
             "owner": "cylc",
             "host": "ranma",
-            "port": 43082,
+            "port": 43043,
             "taskProxies": [
+                {
+                    "id": "cylc|one|20000102T0000Z|waiting",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": []
+                },
                 {
                     "id": "cylc|one|20000101T0000Z|succeeded",
                     "state": "succeeded",
@@ -20,35 +32,7 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|succeeded|1",
                             "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:38Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|sleepy",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": []
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|succeeded|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:09Z",
+                            "startedTime": "2019-09-16T04:46:00Z",
                             "state": "succeeded",
                             "submitNum": 1
                         }
@@ -66,167 +50,7 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|retrying|1",
                             "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:38Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|waiting",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "waiting"
-                    },
-                    "jobs": []
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|failed",
-                    "state": "failed",
-                    "cyclePoint": "20000102T0000Z",
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "failed"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|failed|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:24Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|failed",
-                    "state": "failed",
-                    "cyclePoint": "20000101T0000Z",
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "failed"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|failed|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:53Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:50Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:46Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:42Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:38Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|sleepy",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|sleepy|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:05Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|checkpoint",
-                    "state": "running",
-                    "cyclePoint": "20000102T0000Z",
-                    "task": {
-                        "meanElapsedTime": 6.0,
-                        "name": "checkpoint"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|checkpoint|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:27Z",
-                            "state": "running",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:21Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:17Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:13Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
-                            "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:09Z",
+                            "startedTime": "2019-09-16T04:46:00Z",
                             "state": "failed",
                             "submitNum": 1
                         }
@@ -244,8 +68,129 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|waiting|1",
                             "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:05Z",
+                            "startedTime": "2019-09-16T04:46:27Z",
                             "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|checkpoint",
+                    "state": "running",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 6.0,
+                        "name": "checkpoint"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|checkpoint|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:49Z",
+                            "state": "running",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:31Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|sleepy",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|sleepy",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|sleepy|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:27Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.5,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:12Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:08Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:04Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:00Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|failed",
+                    "state": "failed",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "failed"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|failed|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:46Z",
+                            "state": "failed",
                             "submitNum": 1
                         }
                     ]
@@ -262,8 +207,65 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|checkpoint|1",
                             "host": "localhost",
-                            "startedTime": "2019-09-16T04:21:56Z",
+                            "startedTime": "2019-09-16T04:46:18Z",
                             "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|failed",
+                    "state": "failed",
+                    "cyclePoint": "20000101T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "failed"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|failed|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:15Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "task": {
+                        "meanElapsedTime": 0.5,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:43Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:39Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:35Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
+                            "host": "localhost",
+                            "startedTime": "2019-09-16T04:46:31Z",
+                            "state": "failed",
                             "submitNum": 1
                         }
                     ]
@@ -280,7 +282,7 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000102T0000Z|retrying|1",
                             "host": "localhost",
-                            "startedTime": "2019-09-16T04:22:09Z",
+                            "startedTime": "2019-09-16T04:46:31Z",
                             "state": "failed",
                             "submitNum": 1
                         }

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -15,7 +15,7 @@ query = '''
                 meanElapsedTime
                 name
             }
-            jobs {
+            jobs(sort: { keys: ["submit_num"], reverse:true }) {
                 id
                 host
                 startedTime

--- a/src/services/mock/generate
+++ b/src/services/mock/generate
@@ -16,5 +16,11 @@ else
     exit 1
 fi
 
-sed -i "1 s/^/const checkpoint = /; s/${USER}/cylc/g" "${CHECK_FILE}"
+# This line goes to the top of the file, disabling eslint for the checkpoint.js file
+sed -i "1 i\/* eslint-disable */\n" "${CHECK_FILE}"
+# This one goes to the second line, prepending the JS variable declaration before the JSON string
+sed -i "3 s/^/const checkpoint = /" "${CHECK_FILE}"
+# Replace globally the user running the workflow
+sed -i "s/${USER}/cylc/g" "${CHECK_FILE}"
+# Finally we export it so we can use it from JS modules
 echo -e '\nexport { checkpoint }' >> "${CHECK_FILE}"

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -41,6 +41,28 @@ function _getCycles (workflows) {
 }
 
 /**
+ * Compute percent progress.
+ *
+ * @see https://github.com/cylc/cylc-flow/blob/de7d938496e82dbdfb165938145670dd8e801efd/lib/cylc/gui/updater_tree.py#L248-L263
+ * @param {number} startedTime in milliseconds since 1970-01-01 00:00:00 UTC, e.g. 1568353099874
+ * @param {number} meanElapsedTime mean elapsed time (e.g. 13.5)
+ * @returns {number} the percent progress, e.g. 25 (meaning 25% progress)
+ * @private
+ */
+function _computePercentProgress (startedTime, meanElapsedTime) {
+  const now = Date.now()
+  // startedTime > now reportably possible via interaction with `cylc reset`
+  if (startedTime > now || meanElapsedTime === 0) {
+    return 0
+  }
+  const elapsedTime = startedTime + meanElapsedTime
+  if (now > elapsedTime) {
+    return 100
+  }
+  return 100 * (now - startedTime) / meanElapsedTime
+}
+
+/**
  * Compute a workflow tree where the root is the workflow node, followed by
  * the cycle points, and finally by task proxies.
  *
@@ -74,12 +96,19 @@ function _getWorkflowTree (workflows) {
             taskProxy.name = taskProxy.task.name
             taskProxy.children = []
             taskProxy.__type = 'task'
+            let startedTime = 0
             for (const job of taskProxy.jobs.reverse()) {
               job.name = `#${job.submitNum}`
               job.__type = 'job'
               taskProxy.children.push(job)
+              // we use only the highest submitNum startedTime
+              if (startedTime === 0 && job.startedTime) {
+                startedTime = Date.parse(job.startedTime)
+              }
             }
             simplifiedCyclepoint.children.push(taskProxy)
+
+            taskProxy.progress = _computePercentProgress(startedTime, taskProxy.task.meanElapsedTime)
 
             childStates.push(taskProxy.state)
           }

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -99,7 +99,8 @@ function _getWorkflowTree (workflows) {
             taskProxy.children = []
             taskProxy.__type = 'task'
             let startedTime = 0
-            for (const job of taskProxy.jobs.reverse()) {
+            // the GraphQL query is expected to have `jobs(sort: { keys: ["submit_num"], reverse:true }) {`
+            for (const job of taskProxy.jobs) {
               job.name = `#${job.submitNum}`
               job.__type = 'job'
               taskProxy.children.push(job)

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -1,6 +1,8 @@
 // raw GraphQL response data structure
 import { extractGroupState } from '@/utils/tasks'
 
+const STATES_WITH_PROGRESS = ['running']
+
 const state = {
   workflows: [],
   workflowTree: []
@@ -108,7 +110,9 @@ function _getWorkflowTree (workflows) {
             }
             simplifiedCyclepoint.children.push(taskProxy)
 
-            taskProxy.progress = _computePercentProgress(startedTime, taskProxy.task.meanElapsedTime)
+            if (STATES_WITH_PROGRESS.includes(taskProxy.state)) {
+              taskProxy.progress = _computePercentProgress(startedTime, taskProxy.task.meanElapsedTime)
+            }
 
             childStates.push(taskProxy.state)
           }

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -45,21 +45,21 @@ function _getCycles (workflows) {
  *
  * @see https://github.com/cylc/cylc-flow/blob/de7d938496e82dbdfb165938145670dd8e801efd/lib/cylc/gui/updater_tree.py#L248-L263
  * @param {number} startedTime in milliseconds since 1970-01-01 00:00:00 UTC, e.g. 1568353099874
- * @param {number} meanElapsedTime mean elapsed time (e.g. 13.5)
+ * @param {number} meanElapsedTime mean elapsed time in seconds
  * @returns {number} the percent progress, e.g. 25 (meaning 25% progress)
  * @private
  */
 function _computePercentProgress (startedTime, meanElapsedTime) {
-  const now = Date.now()
-  // startedTime > now reportably possible via interaction with `cylc reset`
+  const now = Date.now() // milliseconds since 1970-01-01
+  // startedTime > now reportedly possible via interaction with `cylc reset`
   if (startedTime > now || meanElapsedTime === 0) {
     return 0
   }
-  const elapsedTime = startedTime + meanElapsedTime
-  if (now > elapsedTime) {
+
+  if (now > startedTime + meanElapsedTime * 1000) {
     return 100
   }
-  return 100 * (now - startedTime) / meanElapsedTime
+  return 100 * (now - startedTime) / (meanElapsedTime * 1000)
 }
 
 /**

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -35,7 +35,7 @@ const QUERIES = {
               meanElapsedTime
               name
             }
-            jobs {
+            jobs(sort: { keys: ["submit_num"], reverse:true }) {
               id
               host
               startedTime

--- a/tests/unit/store/workflow.store.spec.js
+++ b/tests/unit/store/workflow.store.spec.js
@@ -1,0 +1,107 @@
+import { expect } from 'chai'
+import store from '@/store'
+import sinon from 'sinon'
+
+describe('store', () => {
+  let workflows = []
+  beforeEach(() => {
+    workflows = [
+      {
+        id: 'cylc/one',
+        name: 'one',
+        status: 'running',
+        taskProxies: [
+          {
+            id: 'cylc/one/20000101T0000Z/sleepy',
+            state: 'running',
+            task: {
+              meanElapsedTime: 100.0
+            },
+            jobs: [
+              {
+                id: 'cylc/one/20000101T0000Z/sleepy/01',
+                startedTime: '2017-08-21T01:31:30Z',
+                state: 'running',
+                submitNum: 1
+              },
+              {
+                id: 'cylc/one/20000102T0000Z/sleepy/01',
+                startedTime: '2018-08-21T01:31:30Z',
+                state: 'running',
+                submitNum: 2
+              },
+              {
+                id: 'cylc/one/20000103T0000Z/sleepy/01',
+                startedTime: '2019-08-21T01:31:30Z',
+                state: 'running',
+                submitNum: 3
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  })
+  describe('workflows', () => {
+    it('should set the workflowTree for a valid workflows', () => {
+      store.dispatch('workflows/set', workflows)
+      expect(store.state.workflows.workflowTree).to.not.equal([])
+      // 1 workflow
+      expect(store.state.workflows.workflowTree.length).to.equal(1)
+      // 1 cycle point
+      expect(store.state.workflows.workflowTree[0].children.length).to.equal(1)
+      /// 1 task
+      expect(store.state.workflows.workflowTree[0].children[0].children.length).to.equal(1)
+      // 3 jobs
+      expect(store.state.workflows.workflowTree[0].children[0].children[0].children.length).to.equal(3)
+    })
+    it('should set the progress to 0 when meanElapsedTime is 0', () => {
+      workflows[0].taskProxies[0].task.meanElapsedTime = 0
+      store.dispatch('workflows/set', workflows)
+      const workflowTree = store.state.workflows.workflowTree
+      const task = workflowTree[0].children[0].children[0]
+      expect(task.progress).to.equal(0)
+    })
+    it('should set the progress to 0 when startedTime is greater than now', () => {
+      // dispatching here will call new Date() to calculate now, so let's mock it...
+      const stub = sinon.stub(Date, 'now').returns(0)
+      // now the clock is set back to moment 0 (19700101...) by sinon, so Date.now() or new Date().getTime()
+      // will return the clock object and the moment 0...
+      store.dispatch('workflows/set', workflows)
+      const workflowTree = store.state.workflows.workflowTree
+      const task = workflowTree[0].children[0].children[0]
+      expect(task.progress).to.equal(0)
+      // remove the mock
+      stub.restore()
+    })
+    it('should set the progress to 100 when now() is greater than elapsedTime', () => {
+      // dispatching here will call new Date() to calculate now, so let's mock it...
+      const startedTime = Date.parse(workflows[0].taskProxies[0].jobs[2].startedTime)
+      const meanElapsedTime = workflows[0].taskProxies[0].task.meanElapsedTime
+      const elapsedTime = startedTime + meanElapsedTime
+      const stub = sinon.stub(Date, 'now').returns(elapsedTime + 0.1)
+      // now the clock is set back to moment 0 (19700101...) by sinon, so Date.now() or new Date().getTime()
+      // will return the clock object and the moment 0...
+      store.dispatch('workflows/set', workflows)
+      const workflowTree = store.state.workflows.workflowTree
+      const task = workflowTree[0].children[0].children[0]
+      expect(task.progress).to.equal(100)
+      // remove the mock
+      stub.restore()
+    })
+    it('should compute the progress percent', () => {
+      // dispatching here will call new Date() to calculate now, so let's mock it...
+      const startedTime = Date.parse(workflows[0].taskProxies[0].jobs[2].startedTime)
+      workflows[0].taskProxies[0].task.meanElapsedTime = 1000 // mean will be 1000, later added to the started time
+      const stub = sinon.stub(Date, 'now').returns(startedTime + 500) // so let's make the now() function return started time plus 500 ms
+      // now the clock is set back to moment 0 (19700101...) by sinon, so Date.now() or new Date().getTime()
+      // will return the clock object and the moment 0...
+      store.dispatch('workflows/set', workflows)
+      const workflowTree = store.state.workflows.workflowTree
+      const task = workflowTree[0].children[0].children[0]
+      expect(task.progress).to.equal(50)
+      // remove the mock
+      stub.restore()
+    })
+  })
+})

--- a/tests/unit/store/workflow.store.spec.js
+++ b/tests/unit/store/workflow.store.spec.js
@@ -15,14 +15,14 @@ describe('store', () => {
             id: 'cylc/one/20000101T0000Z/sleepy',
             state: 'running',
             task: {
-              meanElapsedTime: 100.0
+              meanElapsedTime: 1.0
             },
             jobs: [
               {
-                id: 'cylc/one/20000101T0000Z/sleepy/01',
-                startedTime: '2017-08-21T01:31:30Z',
+                id: 'cylc/one/20000103T0000Z/sleepy/01',
+                startedTime: '2019-08-21T01:31:30Z',
                 state: 'running',
-                submitNum: 1
+                submitNum: 3
               },
               {
                 id: 'cylc/one/20000102T0000Z/sleepy/01',
@@ -31,10 +31,10 @@ describe('store', () => {
                 submitNum: 2
               },
               {
-                id: 'cylc/one/20000103T0000Z/sleepy/01',
-                startedTime: '2019-08-21T01:31:30Z',
+                id: 'cylc/one/20000101T0000Z/sleepy/01',
+                startedTime: '2017-08-21T01:31:30Z',
                 state: 'running',
-                submitNum: 3
+                submitNum: 1
               }
             ]
           }
@@ -76,10 +76,11 @@ describe('store', () => {
     })
     it('should set the progress to 100 when now() is greater than elapsedTime', () => {
       // dispatching here will call new Date() to calculate now, so let's mock it...
-      const startedTime = Date.parse(workflows[0].taskProxies[0].jobs[2].startedTime)
+      const startedTime = Date.parse(workflows[0].taskProxies[0].jobs[0].startedTime)
       const meanElapsedTime = workflows[0].taskProxies[0].task.meanElapsedTime
-      const elapsedTime = startedTime + meanElapsedTime
-      const stub = sinon.stub(Date, 'now').returns(elapsedTime + 0.1)
+      const timeExpectedToComplete = startedTime + meanElapsedTime * 1000
+      // even if 0.1 greater than the timeExpectedToComplete, it will be 100
+      const stub = sinon.stub(Date, 'now').returns(timeExpectedToComplete + 0.1)
       // now the clock is set back to moment 0 (19700101...) by sinon, so Date.now() or new Date().getTime()
       // will return the clock object and the moment 0...
       store.dispatch('workflows/set', workflows)
@@ -91,9 +92,8 @@ describe('store', () => {
     })
     it('should compute the progress percent', () => {
       // dispatching here will call new Date() to calculate now, so let's mock it...
-      const startedTime = Date.parse(workflows[0].taskProxies[0].jobs[2].startedTime)
-      workflows[0].taskProxies[0].task.meanElapsedTime = 1000 // mean will be 1000, later added to the started time
-      const stub = sinon.stub(Date, 'now').returns(startedTime + 500) // so let's make the now() function return started time plus 500 ms
+      const startedTime = Date.parse(workflows[0].taskProxies[0].jobs[0].startedTime)
+      const stub = sinon.stub(Date, 'now').returns(startedTime + 500) // so let's make the now() function return started time plus 500 ms (half of meanElapsedTime * 1000)
       // now the clock is set back to moment 0 (19700101...) by sinon, so Date.now() or new Date().getTime()
       // will return the clock object and the moment 0...
       store.dispatch('workflows/set', workflows)


### PR DESCRIPTION
Closes #220 

Implemented and with tests, but I am not sure if it is working or not :confused: 

For my workflow `five`, modified to run `script = sleep 2` for every task, and with a more distant stop point, it only displays progress as 0% or 100%.

I had a look at the code, and also at the response of the GraphQL queries... if I configured the script command to sleep for 2 seconds, the `meanElapsedTime` returned always 2 seconds.

Using that number with the old code ported to JS (using the job `startedTime` and the `Date.now()` time in JS), it looked to me like it had to always return 0 or 100 indeed.

Later, I changed the script to be: `script = "sleep $[ ( $RANDOM % 30 )  + 1 ]s`, in the hope the `meanElapsedTime` would be different. It was, at one point I was getting `12.4...`. But even then, it still returned 0% or 100%.

Any help to reproduce a scenario where the returned progress would be different than 0 or 100?

Here's the old code: https://github.com/cylc/cylc-flow/blob/de7d938496e82dbdfb165938145670dd8e801efd/lib/cylc/gui/updater_tree.py#L248-L263

Here's the code I ported to JS (which may have bugs, it's Friday 7PM, not the best time to write any code like this, but had some spare time...): https://github.com/cylc/cylc-ui/pull/223/files#diff-cef93d4e230a1d011a9de08fdf0a7b3cR52-R63