### PR TITLE
Fix cached items retained after Tree component is destroyed

### DIFF
--- a/src/components/cylc/Tree.vue
+++ b/src/components/cylc/Tree.vue
@@ -105,6 +105,11 @@ export default {
           this.activeCache.add(treeItem)
         }
       }
+    },
+    clearCaches () {
+      this.treeItemCache.clear()
+      this.activeCache.clear()
+      this.expandedCache.clear()
     }
   }
 }

--- a/src/components/cylc/Tree.vue
+++ b/src/components/cylc/Tree.vue
@@ -35,6 +35,13 @@ export default {
       default: 0
     }
   },
+  watch: {
+    workflows: {
+      handler () {
+        this.clearCaches()
+      }
+    }
+  },
   components: {
     'tree-item': TreeItem
   },

--- a/src/components/cylc/TreeItem.vue
+++ b/src/components/cylc/TreeItem.vue
@@ -73,6 +73,7 @@
       <!-- component recursion -->
       <TreeItem
           v-for="child in node.children"
+          ref="treeitem"
           :key="child.id"
           :node="child"
           :depth="depth + 1"
@@ -169,7 +170,18 @@ export default {
   created () {
     this.$emit('tree-item-created', this)
   },
+  beforeDestroy () {
+    if (Object.prototype.hasOwnProperty.call(this.$refs, 'treeitem')) {
+      this.$refs.treeitem.map((treeitem) => {
+        treeitem.destroy()
+      })
+    }
+  },
   methods: {
+    destroy () {
+      // $destroy will trigger beforeDestroy and destroyed
+      this.$destroy(/* destroy from DOM as well */ true)
+    },
     typeClicked () {
       this.isExpanded = !this.isExpanded
       if (this.isExpanded) {

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -126,6 +126,7 @@ function _getWorkflowTree (workflows) {
       }
       workflowTree.push(workflow)
     }
+    cycles.clear()
   }
   return workflowTree
 }

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -100,7 +100,7 @@ export default {
   },
 
   beforeDestroy () {
-    this.$refs['tree0'].clearCaches()
+    this.$refs.tree0.clearCaches()
     workflowService.unregister(this)
   },
 

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -6,6 +6,8 @@
       :activable="false"
       :multiple-active="false"
       :min-depth="1"
+      ref="tree0"
+      key="tree0"
     ></tree>
   </div>
 </template>
@@ -98,6 +100,7 @@ export default {
   },
 
   beforeDestroy () {
+    this.$refs['tree0'].clearCaches()
     workflowService.unregister(this)
   },
 


### PR DESCRIPTION
Part of #222 

Not sure if will be done before 0.1, but it is part of the problem in the memory performance issue.

The three caches were holding references to objects that were never removed or collected. Found by filtering for detached in the Chrome memory tool, then expanding the nodes until I located several that were retained due to the caches.

![Screenshot_2019-09-16_00-07-46](https://user-images.githubusercontent.com/304786/64921826-f6551b00-d81b-11e9-9607-883a1d4353c4.png)

(doesn't actually show the cache, but was around there where I located the issue)

It appears - after some initial test post midnight, so to be reviewed tomorrow morning - to fix the issue. However, still need to:

- [x] probably clear the cache when the Vuex store data gets re-populated, this could be the cause for not being able to run the complex suite for very long
- [x] check if the complex suite works
