### PR TITLE
security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7019,11 +7019,11 @@
       "resolved": "https://registry.npmjs.org/cytoscape-navigator/-/cytoscape-navigator-1.3.3.tgz",
       "integrity": "sha512-OngSzPm/3p/8toTaVS8FROp51ymVB/IAfnEMaXX0escKlRK+h7XWrHhdDVI6rvSAKdVjYIa4LZ7vNi3kDRhT4w==",
       "requires": {
-        "jquery": "^2.0.0 || ^1.4.0"
+        "jquery": ">=3.0.0"
       },
       "dependencies": {
         "jquery": {
-          "version": "2.2.4",
+          "version": ">=3.0.0",
           "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
           "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
         }
@@ -12882,7 +12882,7 @@
       "dev": true
     },
     "mem": {
-      "version": "1.1.0",
+      "version": ">=4.0.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
@@ -14014,7 +14014,7 @@
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "mem": ">=4.0.0"
           }
         },
         "p-limit": {
@@ -14401,7 +14401,7 @@
       "requires": {
         "execa": "^0.7.0",
         "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "mem": ">=4.0.0"
       },
       "dependencies": {
         "cross-spawn": {


### PR DESCRIPTION
Issues 
### Memory Leak

> WS-2018-0236 More information
> moderate severity
> Vulnerable versions: < 4.0.0
> Patched version: 4.0.0
> 
> In nodejs-mem before version 4.0.0 there is a memory leak due to old results not being removed from the cache despite reaching maxAge. Exploitation of this can lead to exhaustion of memory and subsequent denial of service.

### Cross Site Scripting
NPM audit produced the following warning:

>   High            Cross-Site Scripting (XSS)                                     
>   Package         jquery                                              
>   Patched in      >=3.0.0                                            
>   Dependency of   cytoscape-navigator                      
>   Path            cytoscape-navigator > jquery              
>   More info       https://nodesecurity.io/advisories/328                        

