### PR TITLE
Remove vue-flag-icon dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9866,11 +9866,6 @@
         "locate-path": "^2.0.0"
       }
     },
-    "flag-icon-css": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.9.0.tgz",
-      "integrity": "sha512-SeHvGEB43XFPZiJz6lFFRGHfp+Db+s1qGiClW70cZauQVbPM42wImlNUEuXSXs94kPchz7xvoxP0QK1y6FxLfg=="
-    },
     "flat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
@@ -21394,14 +21389,6 @@
             "estraverse": "^4.1.1"
           }
         }
-      }
-    },
-    "vue-flag-icon": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/vue-flag-icon/-/vue-flag-icon-1.0.6.tgz",
-      "integrity": "sha1-AwT9/uvZgqa/mFxjPDRv88bS+dc=",
-      "requires": {
-        "flag-icon-css": "^2.8.0"
       }
     },
     "vue-hot-reload-api": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "vue": "^2.6.10",
     "vue-apollo": "^3.0.0-beta.30",
     "vue-cytoscape": "^0.2.10",
-    "vue-flag-icon": "^1.0.6",
     "vue-i18n": "^8.14.0",
     "vue-meta": "^2.2.1",
     "vue-router": "^3.1.2",

--- a/src/plugins/flags.js
+++ b/src/plugins/flags.js
@@ -1,4 +1,0 @@
-import Vue from 'vue'
-import FlagIcon from 'vue-flag-icon'
-
-Vue.use(FlagIcon)

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,5 +1,4 @@
 import './axios'
-import './flags'
 import './layouts'
 import './veevalidate'
 import './apollo'


### PR DESCRIPTION
Closes #211 

One review should do it IMO. I was the one who added it, for the old drop down language switcher. We don't have that component now, so this shouldn't break anything.

Tested locally, no console errors or other errors.

Cheers
Bruno