### PR TITLE
Order jobs per cycle point in mocked data

### DIFF
--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -8,31 +8,8 @@ const checkpoint = {
             "status": "running",
             "owner": "cylc",
             "host": "ranma",
-            "port": 43007,
+            "port": 43057,
             "taskProxies": [
-                {
-                    "id": "cylc|one|20000102T0000Z|failed",
-                    "state": "failed",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed/EXIT",
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "failed"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|failed|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "16314",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:53:02Z",
-                            "submittedTime": "2019-09-17T06:53:02Z",
-                            "finishedTime": "2019-09-17T06:53:03Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
                 {
                     "id": "cylc|one|20000101T0000Z|sleepy",
                     "state": "succeeded",
@@ -46,58 +23,12 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|sleepy|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "15657",
+                            "batchSysJobId": "6675",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:43Z",
-                            "submittedTime": "2019-09-17T06:52:43Z",
-                            "finishedTime": "2019-09-17T06:52:44Z",
+                            "startedTime": "2019-09-18T04:37:01Z",
+                            "submittedTime": "2019-09-18T04:37:01Z",
+                            "finishedTime": "2019-09-18T04:37:02Z",
                             "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "succeeded",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "15808",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:47Z",
-                            "submittedTime": "2019-09-17T06:52:47Z",
-                            "finishedTime": "2019-09-17T06:52:48Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|retrying",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2019-09-17T06:57:17Z)",
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "retrying"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|retrying|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "14817",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:16Z",
-                            "submittedTime": "2019-09-17T06:52:16Z",
-                            "finishedTime": "2019-09-17T06:52:17Z",
-                            "state": "failed",
                             "submitNum": 1
                         }
                     ]
@@ -108,118 +39,51 @@ const checkpoint = {
                     "cyclePoint": "20000101T0000Z",
                     "latestMessage": "succeeded",
                     "task": {
-                        "meanElapsedTime": 1.0,
+                        "meanElapsedTime": 0.0,
                         "name": "eventually_succeeded"
                     },
                     "jobs": [
                         {
                             "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
                             "batchSysName": "background",
-                            "batchSysJobId": "15219",
+                            "batchSysJobId": "6516",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:28Z",
-                            "submittedTime": "2019-09-17T06:52:28Z",
-                            "finishedTime": "2019-09-17T06:52:29Z",
+                            "startedTime": "2019-09-18T04:36:46Z",
+                            "submittedTime": "2019-09-18T04:36:45Z",
+                            "finishedTime": "2019-09-18T04:36:46Z",
                             "state": "succeeded",
                             "submitNum": 4
                         },
                         {
                             "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
                             "batchSysName": "background",
-                            "batchSysJobId": "15082",
+                            "batchSysJobId": "6469",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:24Z",
-                            "submittedTime": "2019-09-17T06:52:24Z",
-                            "finishedTime": "2019-09-17T06:52:25Z",
+                            "startedTime": "2019-09-18T04:36:42Z",
+                            "submittedTime": "2019-09-18T04:36:41Z",
+                            "finishedTime": "2019-09-18T04:36:42Z",
                             "state": "failed",
                             "submitNum": 3
                         },
                         {
                             "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
                             "batchSysName": "background",
-                            "batchSysJobId": "14949",
+                            "batchSysJobId": "6428",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:20Z",
-                            "submittedTime": "2019-09-17T06:52:20Z",
-                            "finishedTime": "2019-09-17T06:52:21Z",
+                            "startedTime": "2019-09-18T04:36:38Z",
+                            "submittedTime": "2019-09-18T04:36:37Z",
+                            "finishedTime": "2019-09-18T04:36:38Z",
                             "state": "failed",
                             "submitNum": 2
                         },
                         {
                             "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "14816",
+                            "batchSysJobId": "6309",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:16Z",
-                            "submittedTime": "2019-09-17T06:52:16Z",
-                            "finishedTime": "2019-09-17T06:52:17Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|sleepy",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": []
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "succeeded",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
-                            "batchSysName": "background",
-                            "batchSysJobId": "16201",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:59Z",
-                            "submittedTime": "2019-09-17T06:52:59Z",
-                            "finishedTime": "2019-09-17T06:53:00Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
-                            "batchSysName": "background",
-                            "batchSysJobId": "16068",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:55Z",
-                            "submittedTime": "2019-09-17T06:52:55Z",
-                            "finishedTime": "2019-09-17T06:52:56Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
-                            "batchSysName": "background",
-                            "batchSysJobId": "16006",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:51Z",
-                            "submittedTime": "2019-09-17T06:52:51Z",
-                            "finishedTime": "2019-09-17T06:52:52Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "15804",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:47Z",
-                            "submittedTime": "2019-09-17T06:52:47Z",
-                            "finishedTime": "2019-09-17T06:52:48Z",
+                            "startedTime": "2019-09-18T04:36:34Z",
+                            "submittedTime": "2019-09-18T04:36:33Z",
+                            "finishedTime": "2019-09-18T04:36:34Z",
                             "state": "failed",
                             "submitNum": 1
                         }
@@ -231,99 +95,42 @@ const checkpoint = {
                     "cyclePoint": "20000101T0000Z",
                     "latestMessage": "succeeded",
                     "task": {
-                        "meanElapsedTime": 1.0,
+                        "meanElapsedTime": 0.5,
                         "name": "succeeded"
                     },
                     "jobs": [
                         {
                             "id": "cylc|one|20000101T0000Z|succeeded|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "14822",
+                            "batchSysJobId": "6313",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:16Z",
-                            "submittedTime": "2019-09-17T06:52:16Z",
-                            "finishedTime": "2019-09-17T06:52:17Z",
+                            "startedTime": "2019-09-18T04:36:34Z",
+                            "submittedTime": "2019-09-18T04:36:33Z",
+                            "finishedTime": "2019-09-18T04:36:34Z",
                             "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
                 },
                 {
-                    "id": "cylc|one|20000101T0000Z|checkpoint",
+                    "id": "cylc|one|20000101T0000Z|retrying",
                     "state": "succeeded",
                     "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "task": {
-                        "meanElapsedTime": 6.0,
-                        "name": "checkpoint"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|checkpoint|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "15394",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:34Z",
-                            "submittedTime": "2019-09-17T06:52:34Z",
-                            "finishedTime": "2019-09-17T06:52:40Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|retrying",
-                    "state": "retrying",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2019-09-17T06:57:48Z)",
+                    "latestMessage": "failed, retrying in PT5M (after 2019-09-18T04:41:34Z)",
                     "task": {
                         "meanElapsedTime": 0.0,
                         "name": "retrying"
                     },
                     "jobs": [
                         {
-                            "id": "cylc|one|20000102T0000Z|retrying|1",
+                            "id": "cylc|one|20000101T0000Z|retrying|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "15805",
+                            "batchSysJobId": "6310",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:47Z",
-                            "submittedTime": "2019-09-17T06:52:47Z",
-                            "finishedTime": "2019-09-17T06:52:48Z",
+                            "startedTime": "2019-09-18T04:36:34Z",
+                            "submittedTime": "2019-09-18T04:36:33Z",
+                            "finishedTime": "2019-09-18T04:36:34Z",
                             "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|waiting",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "waiting"
-                    },
-                    "jobs": []
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|waiting",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "waiting"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|waiting|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "15658",
-                            "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:43Z",
-                            "submittedTime": "2019-09-17T06:52:43Z",
-                            "finishedTime": "2019-09-17T06:52:44Z",
-                            "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
@@ -341,11 +148,170 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|failed|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "15331",
+                            "batchSysJobId": "6561",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:52:31Z",
-                            "submittedTime": "2019-09-17T06:52:31Z",
-                            "finishedTime": "2019-09-17T06:52:32Z",
+                            "startedTime": "2019-09-18T04:36:49Z",
+                            "submittedTime": "2019-09-18T04:36:48Z",
+                            "finishedTime": "2019-09-18T04:36:49Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|checkpoint",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "task": {
+                        "meanElapsedTime": 7.0,
+                        "name": "checkpoint"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|checkpoint|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6602",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:36:52Z",
+                            "submittedTime": "2019-09-18T04:36:52Z",
+                            "finishedTime": "2019-09-18T04:36:59Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|waiting",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|waiting|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6676",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:01Z",
+                            "submittedTime": "2019-09-18T04:37:01Z",
+                            "finishedTime": "2019-09-18T04:37:02Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|sleepy",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "succeeded",
+                    "task": {
+                        "meanElapsedTime": 0.5,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6759",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:05Z",
+                            "submittedTime": "2019-09-18T04:37:05Z",
+                            "finishedTime": "2019-09-18T04:37:06Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "succeeded",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6954",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:17Z",
+                            "submittedTime": "2019-09-18T04:37:17Z",
+                            "finishedTime": "2019-09-18T04:37:17Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6913",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:13Z",
+                            "submittedTime": "2019-09-18T04:37:13Z",
+                            "finishedTime": "2019-09-18T04:37:14Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6872",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:09Z",
+                            "submittedTime": "2019-09-18T04:37:09Z",
+                            "finishedTime": "2019-09-18T04:37:10Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6755",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:05Z",
+                            "submittedTime": "2019-09-18T04:37:05Z",
+                            "finishedTime": "2019-09-18T04:37:06Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|retrying",
+                    "state": "retrying",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "failed, retrying in PT5M (after 2019-09-18T04:42:06Z)",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "retrying"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|retrying|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6756",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:05Z",
+                            "submittedTime": "2019-09-18T04:37:05Z",
+                            "finishedTime": "2019-09-18T04:37:06Z",
                             "state": "failed",
                             "submitNum": 1
                         }
@@ -357,19 +323,53 @@ const checkpoint = {
                     "cyclePoint": "20000102T0000Z",
                     "latestMessage": "started",
                     "task": {
-                        "meanElapsedTime": 6.0,
+                        "meanElapsedTime": 7.0,
                         "name": "checkpoint"
                     },
                     "jobs": [
                         {
                             "id": "cylc|one|20000102T0000Z|checkpoint|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "16376",
+                            "batchSysJobId": "7037",
                             "host": "localhost",
-                            "startedTime": "2019-09-17T06:53:05Z",
-                            "submittedTime": "2019-09-17T06:53:05Z",
+                            "startedTime": "2019-09-18T04:37:23Z",
+                            "submittedTime": "2019-09-18T04:37:23Z",
                             "finishedTime": "",
                             "state": "running",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|waiting",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "",
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|failed",
+                    "state": "failed",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "failed/EXIT",
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "failed"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|failed|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "6996",
+                            "host": "localhost",
+                            "startedTime": "2019-09-18T04:37:20Z",
+                            "submittedTime": "2019-09-18T04:37:20Z",
+                            "finishedTime": "2019-09-18T04:37:20Z",
+                            "state": "failed",
                             "submitNum": 1
                         }
                     ]


### PR DESCRIPTION
Quick PR that does not change any source code, only a file that is generated by the `generate` script. Reason for this, is that the part of the query to order cycle points was not working (see #238).

Re-generated the mock data with the PR prepared by @dwsutherland (thanks!). This is useful only for screenshots and for future work, to make sure we don't confuse users - or ourselves with incorrectly ordered cycle points :)

Another 1 review issue IMO

Cheers
Bruno