### PR TITLE
Use only Workflows table title

### DIFF
--- a/src/components/material/Card.vue
+++ b/src/components/material/Card.vue
@@ -16,7 +16,7 @@
         :elevation="elevation"
         class="v-card--material__header d-flex align-center"
         dark
-        min-height="80"
+        min-height="60"
       >
         <slot
           v-if="!title && !text"
@@ -27,11 +27,11 @@
           class="px-3"
         >
           <h4
-            class="title font-weight-light mb-2"
+            class="title font-weight-light mb-0"
             v-text="title"
           />
           <p
-            class="category font-weight-thin mb-0"
+            class="category font-weight-thin mb-1"
             v-text="text"
           />
         </div>

--- a/src/lang/en-GB/Workflows.json
+++ b/src/lang/en-GB/Workflows.json
@@ -1,6 +1,5 @@
 {
-  "tableHeader": "List of Workflows",
-  "tableSubHeader": "This is the list of workflows the current user has access to",
+  "tableHeader": "Your Workflows",
   "tableColumnName": "Name",
   "tableColumnOwner": "Owner",
   "tableColumnHost": "Host",

--- a/src/lang/pt-BR/Workflows.json
+++ b/src/lang/pt-BR/Workflows.json
@@ -1,6 +1,5 @@
 {
-  "tableHeader": "Lista de Workflows",
-  "tableSubHeader": "Esta é a lista de workflows que este usuário possui permissoões para visualizar",
+  "tableHeader": "Seus Workflows",
   "tableColumnName": "Nome",
   "tableColumnOwner": "Usuário",
   "tableColumnHost": "Servidor",

--- a/src/views/GScan.vue
+++ b/src/views/GScan.vue
@@ -13,7 +13,6 @@
       >
         <material-card
           :title="$t('Workflows.tableHeader')"
-          :text="$t('Workflows.tableSubHeader')"
           :elevation="0"
           :flat="true"
           color="grey"


### PR DESCRIPTION
From Riot today, @hjoliver 

> (...) the text in the grey box is a bit verbose and repetitive.  And the information is also redundant given the blue heading up top.
> (...)
> For the moment let's just make the existing text more concise.  i.e. "Your Workflows"

This PR changes the title text to "Your Workflows", removes the subtitle (text below it), and adjust margins after the change.

Here's before: 

![image](https://user-images.githubusercontent.com/304786/65127492-a361aa80-da4b-11e9-8efa-d3ee35fa9a72.png)

Here's the end result:

![image](https://user-images.githubusercontent.com/304786/65127519-b5434d80-da4b-11e9-8a41-86a9cdbc8f1d.png)

Assigning @hjoliver to review as he requested the change. I think 1 review is enough, but otherwise anyone can feel free to jump in and have a second look at the change :+1: 