### PR TITLE
Add tr to table row in Workflows/GScan view

### DIFF
--- a/src/views/GScan.vue
+++ b/src/views/GScan.vue
@@ -45,19 +45,21 @@
               slot="item"
               slot-scope="{ item }"
             >
-              <td>{{ item.name }}</td>
-              <td>{{ item.owner }}</td>
-              <td>{{ item.host }}</td>
-              <td>{{ item.port }}</td>
-              <td class="justify-center">
-                <v-icon
-                    small
-                    class="mr-2"
-                    @click="viewWorkflow(item)"
-                >
-                  mdi-table-edit
-                </v-icon>
-              </td>
+              <tr>
+                <td>{{ item.name }}</td>
+                <td>{{ item.owner }}</td>
+                <td>{{ item.host }}</td>
+                <td>{{ item.port }}</td>
+                <td class="justify-center">
+                  <v-icon
+                      small
+                      class="mr-2"
+                      @click="viewWorkflow(item)"
+                  >
+                    mdi-table-edit
+                  </v-icon>
+                </td>
+              </tr>
             </template>
           </v-data-table>
         </material-card>


### PR DESCRIPTION
Reported by @hjoliver on Riot, but he mentioned @oliver-sanders was the one that spotted it

> (...)  have noticed one more problem. With two suites running, in the workflow list they now appear on the same line.

The image attached

![Screenshot from 2019-09-18 17-41-40](https://user-images.githubusercontent.com/304786/65129284-13256480-da4f-11e9-86ec-a11f0380e958.png)

Successfully reproduced locally

![Screenshot_2019-09-18_19-55-13](https://user-images.githubusercontent.com/304786/65129301-19b3dc00-da4f-11e9-8dd0-45f0df158067.png)

Then confirmed that it was during the Vuetify migration. I missed adding a `<tr>`, so instead of having to rows (table row = tr), we get only a bunch of columns piled up together.

![Screenshot_2019-09-18_19-57-33](https://user-images.githubusercontent.com/304786/65129351-34865080-da4f-11e9-9cb0-543f4b12e7b2.png)

Quick fix, here's the end result

![Screenshot_2019-09-18_19-57-54](https://user-images.githubusercontent.com/304786/65129363-3b14c800-da4f-11e9-8acd-04d596ad7638.png)


