### PR TITLE
Avoid any calculation in print function when in production

### DIFF
--- a/src/services/gquery.js
+++ b/src/services/gquery.js
@@ -213,7 +213,10 @@ class GQuery {
     /**
      * Dump a human-readable representation of all subscriptions.
      */
-    var ret = 'Combined Query:'
+    if (process.env.NODE_ENV === 'production') {
+      return
+    }
+    let ret = 'Combined Query:'
     if (this.query) {
       ret += '\n' + prefixLines(print(this.query), '    ')
     } else {
@@ -230,9 +233,7 @@ class GQuery {
         })
     })
 
-    if (process.env.NODE_ENV !== 'production') {
-      console.debug(ret)
-    }
+    console.debug(ret)
   }
 }
 


### PR DESCRIPTION
Small improvement for the `gquery` `print` function.

Noticed it the other day while working on some issues, and added a post-it so I wouldn't forget it.

When the mode is production, the function is currently doing some string manipulation, just to reach the end of the code and decide it won't print as it is production.

A better approach, IMO, is to just return immediately if production :+1: 