### PR TITLE
Keep cache in sync, and use a global event bus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@ workflows only.
 [#275](https://github.com/cylc/cylc-ui/pull/275) - Fix size of dashboard
 links on hover.
 
+[#254](https://github.com/cylc/cylc-ui/pull/254) -  Keep cache in sync,
+and use a global event bus.
+
 ### Documentation
 
 [#215](https://github.com/cylc/cylc-ui/pull/215) - guide: add beginnings

--- a/src/components/cylc/Tree.vue
+++ b/src/components/cylc/Tree.vue
@@ -9,6 +9,7 @@
         :min-depth="minDepth"
         :initialExpanded="expanded"
         v-on:tree-item-created="onTreeItemCreated"
+        v-on:tree-item-destroyed="onTreeItemDestroyed"
         v-on:tree-item-expanded="onTreeItemExpanded"
         v-on:tree-item-collapsed="onTreeItemCollapsed"
         v-on:tree-item-clicked="onTreeItemClicked"
@@ -33,13 +34,6 @@ export default {
     minDepth: {
       type: Number,
       default: 0
-    }
-  },
-  watch: {
-    workflows: {
-      handler () {
-        this.clearCaches()
-      }
     }
   },
   components: {
@@ -84,6 +78,8 @@ export default {
     },
     onTreeItemExpanded (treeItem) {
       this.expandedCache.add(treeItem)
+      this.expanded = true
+      this.$emit('tree-item-expanded', treeItem)
     },
     onTreeItemCollapsed (treeItem) {
       this.expandedCache.delete(treeItem)
@@ -92,7 +88,14 @@ export default {
       this.treeItemCache.add(treeItem)
       if (treeItem.isExpanded) {
         this.expandedCache.add(treeItem)
+        this.$emit('tree-item-expanded', treeItem)
       }
+    },
+    onTreeItemDestroyed (treeItem) {
+      // make sure the item is removed from all caches, otherwise we will have a memory leak
+      this.treeItemCache.delete(treeItem)
+      this.expandedCache.delete(treeItem)
+      this.activeCache.delete(treeItem)
     },
     onTreeItemClicked (treeItem) {
       if (this.activable) {
@@ -112,11 +115,6 @@ export default {
           this.activeCache.add(treeItem)
         }
       }
-    },
-    clearCaches () {
-      this.treeItemCache.clear()
-      this.activeCache.clear()
-      this.expandedCache.clear()
     }
   }
 }

--- a/src/components/cylc/Tree.vue
+++ b/src/components/cylc/Tree.vue
@@ -8,11 +8,6 @@
         :hoverable="hoverable"
         :min-depth="minDepth"
         :initialExpanded="expanded"
-        v-on:tree-item-created="onTreeItemCreated"
-        v-on:tree-item-destroyed="onTreeItemDestroyed"
-        v-on:tree-item-expanded="onTreeItemExpanded"
-        v-on:tree-item-collapsed="onTreeItemCollapsed"
-        v-on:tree-item-clicked="onTreeItemClicked"
     >
     </tree-item>
   </div>
@@ -20,6 +15,7 @@
 
 <script>
 import TreeItem from '@/components/cylc/TreeItem'
+import { TreeEventBus } from '@/components/cylc/tree/event-bus'
 
 export default {
   name: 'Tree',
@@ -48,6 +44,21 @@ export default {
       expandedFilter: null,
       collapseFilter: null
     }
+  },
+  created () {
+    TreeEventBus.$on('tree-item-created', this.onTreeItemCreated)
+    TreeEventBus.$on('tree-item-destroyed', this.onTreeItemDestroyed)
+    TreeEventBus.$on('tree-item-expanded', this.onTreeItemExpanded)
+    TreeEventBus.$on('tree-item-collapsed', this.onTreeItemCollapsed)
+    TreeEventBus.$on('tree-item-clicked', this.onTreeItemClicked)
+  },
+  destroyed () {
+    // we cannot simply call TreeEventBus.$off() as we may have more trees listening...
+    TreeEventBus.$off('tree-item-created', this.onTreeItemCreated)
+    TreeEventBus.$off('tree-item-destroyed', this.onTreeItemDestroyed)
+    TreeEventBus.$off('tree-item-expanded', this.onTreeItemExpanded)
+    TreeEventBus.$off('tree-item-collapsed', this.onTreeItemCollapsed)
+    TreeEventBus.$off('tree-item-clicked', this.onTreeItemClicked)
   },
   methods: {
     expandAll (filter = null) {
@@ -79,7 +90,6 @@ export default {
     onTreeItemExpanded (treeItem) {
       this.expandedCache.add(treeItem)
       this.expanded = true
-      this.$emit('tree-item-expanded', treeItem)
     },
     onTreeItemCollapsed (treeItem) {
       this.expandedCache.delete(treeItem)
@@ -88,7 +98,6 @@ export default {
       this.treeItemCache.add(treeItem)
       if (treeItem.isExpanded) {
         this.expandedCache.add(treeItem)
-        this.$emit('tree-item-expanded', treeItem)
       }
     },
     onTreeItemDestroyed (treeItem) {

--- a/src/components/cylc/TreeItem.vue
+++ b/src/components/cylc/TreeItem.vue
@@ -80,11 +80,6 @@
           :hoverable="hoverable"
           :min-depth="minDepth"
           :initialExpanded="initialExpanded"
-          v-on:tree-item-created="$emit('tree-item-created', $event)"
-          v-on:tree-item-destroyed="$emit('tree-item-destroyed', $event)"
-          v-on:tree-item-expanded="$emit('tree-item-expanded', $event)"
-          v-on:tree-item-collapsed="$emit('tree-item-collapsed', $event)"
-          v-on:tree-item-clicked="$emit('tree-item-clicked', $event)"
       ></TreeItem>
     </span>
   </div>
@@ -93,6 +88,7 @@
 <script>
 import Task from '@/components/cylc/Task'
 import Job from '@/components/cylc/Job'
+import { TreeEventBus } from '@/components/cylc/tree/event-bus'
 
 /**
  * Offset used to move nodes to the right or left, to represent the nodes hierarchy.
@@ -169,10 +165,10 @@ export default {
     }
   },
   created () {
-    this.$emit('tree-item-created', this)
+    TreeEventBus.$emit('tree-item-created', this)
   },
   beforeDestroy () {
-    this.$emit('tree-item-destroyed', this)
+    TreeEventBus.$emit('tree-item-destroyed', this)
   },
   beforeMount () {
     if (Object.prototype.hasOwnProperty.call(this.node, 'expanded')) {
@@ -192,9 +188,9 @@ export default {
      */
     emitExpandCollapseEvent (expanded) {
       if (expanded) {
-        this.$emit('tree-item-expanded', this)
+        TreeEventBus.$emit('tree-item-expanded', this)
       } else {
-        this.$emit('tree-item-collapsed', this)
+        TreeEventBus.$emit('tree-item-collapsed', this)
       }
     },
     getTypeStyle () {
@@ -209,7 +205,7 @@ export default {
      * @param {event} e event
      */
     nodeClicked (e) {
-      this.$emit('tree-item-clicked', this)
+      TreeEventBus.$emit('tree-item-clicked', this)
     },
     /**
      * Handler for when a job node was clicked.

--- a/src/components/cylc/TreeItem.vue
+++ b/src/components/cylc/TreeItem.vue
@@ -81,6 +81,7 @@
           :min-depth="minDepth"
           :initialExpanded="initialExpanded"
           v-on:tree-item-created="$emit('tree-item-created', $event)"
+          v-on:tree-item-destroyed="$emit('tree-item-destroyed', $event)"
           v-on:tree-item-expanded="$emit('tree-item-expanded', $event)"
           v-on:tree-item-collapsed="$emit('tree-item-collapsed', $event)"
           v-on:tree-item-clicked="$emit('tree-item-clicked', $event)"
@@ -171,11 +172,7 @@ export default {
     this.$emit('tree-item-created', this)
   },
   beforeDestroy () {
-    if (Object.prototype.hasOwnProperty.call(this.$refs, 'treeitem')) {
-      this.$refs.treeitem.map((treeitem) => {
-        treeitem.destroy()
-      })
-    }
+    this.$emit('tree-item-destroyed', this)
   },
   beforeMount () {
     if (Object.prototype.hasOwnProperty.call(this.node, 'expanded')) {
@@ -184,10 +181,6 @@ export default {
     }
   },
   methods: {
-    destroy () {
-      // $destroy will trigger beforeDestroy and destroyed
-      this.$destroy(/* destroy from DOM as well */ true)
-    },
     typeClicked () {
       this.isExpanded = !this.isExpanded
       this.emitExpandCollapseEvent(this.isExpanded)

--- a/src/components/cylc/tree/event-bus.js
+++ b/src/components/cylc/tree/event-bus.js
@@ -1,0 +1,3 @@
+import Vue from 'vue'
+
+export const TreeEventBus = new Vue()

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -105,7 +105,6 @@ export default {
   },
 
   beforeDestroy () {
-    this.$refs.tree0.clearCaches()
     workflowService.unregister(this)
   },
 


### PR DESCRIPTION
Part of #222 and #227 

The first commit was cherry-picked from the #251 PR. This commit removes code that was `watch`'ing a data structure and clearing all caches. Now it listens to only one event for when the node is deleted, and then removes that treeitem from the cache.

Confirmed in the Vue Dev Tools browser extension that the cache was being updated correctly.

The second commit is the reason for this PR being WIP. I noticed we had a lot of `closure` object in the heap. And even some events in the detached state.

My guess was that a) using closures like `@on:click='$emit(...)'` was triggering the events too soon, or maybe invoking the events for parents too, and b) having to propagate the event back to parents wasn't efficient.

Now we have a global event bus for the tree component, which is [common in Vue](https://alligator.io/vuejs/global-event-bus/). Normally the global event is a solution when projects don't want to adopt Vuex. In our case we have Vuex, but I don't think we need to put a component's cache there (nobody else is going to use it).

I am running tests in the complex workflow now, but with the browser on my Windows host machine, and the workflow and hub running on my Linux VM.

Started at 3:36 PM, with 67.1 MB. It went up to 180, 240, 320, **and then went down to 214MB**. It later went down again to **127MB**, and back to ~400, then down again to 127MB.

Right now I looked at it, and it was near 800MB, then went down to 200, back to 342 MB now. I will leave it running until tomorrow, which should be enough time for the `complex` workflow to complete.

And also enough time to check the situation of my VM and host machine, and see if the browser didn't hang, if the garbage collector collected everything, and that once the workflow is done, the browser doesn't display anything and there are no extraneous elements detached in the heap.

Bruno