### PR TITLE
Display toolbar for workflows only

### DIFF
--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -33,14 +33,17 @@
           <v-icon color="#5E5E5E">mdi-stop</v-icon>
         </a>
 
+        <!-- TODO: add control options and call mutations -->
+        <!--
         <a>
           <v-chip color="#E7E7E7" @click="toggleExtended">{{ $t('Toolbar.control') }}</v-chip>
         </a>
+        -->
 
-        <!-- TODO: workflow latest message goes here -->
+        <!-- TODO: add workflow latest message -->
         <span></span>
 
-        <!-- TODO: enable add view when tabs are added -->
+        <!-- TODO: enable add view button to add view to a tab/panel -->
         <!--
         <v-spacer />
 
@@ -109,11 +112,9 @@ export default {
     },
     onClickPause () {
       // TODO: implement the pause action
-      console.log('Pausing workflows has not been implemented yet')
     },
     onClickStop () {
       // TODO: implement the stop action
-      console.log('Stopping workflows has not been implemented yet')
     },
     toggleExtended () {
       this.extended = !this.extended

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -37,13 +37,17 @@
           <v-chip color="#E7E7E7" @click="toggleExtended">{{ $t('Toolbar.control') }}</v-chip>
         </a>
 
-        <span>Running, will stop at 30000101T0000 cycle</span>
+        <!-- TODO: workflow latest message goes here -->
+        <span></span>
 
+        <!-- TODO: enable add view when tabs are added -->
+        <!--
         <v-spacer />
 
         <a class="add-view" @click="onClickAddView">
           {{ $t('Toolbar.addView') }} <v-icon color="#5995EB">mdi-plus-circle</v-icon>
         </a>
+        -->
       </template>
 
       <!-- displayed only when extended===true -->

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -2,10 +2,8 @@
   <div>
     <v-app-bar
       id="core-app-bar"
-      app
-      absolute
-      flat
       dense
+      flat
       class="c-toolbar"
     >
       <v-toolbar-title
@@ -26,7 +24,7 @@
       </v-toolbar-title>
 
       <!-- control bar elements displayed only when a workflow has been positioned -->
-      <template v-if="isDisplayingWorkflow()">
+      <template>
         <a @click="onClickPause">
           <v-icon color="#5E5E5E">mdi-pause</v-icon>
         </a>
@@ -119,22 +117,13 @@ export default {
     onClickAddView () {
       // TODO: implement adding views action
       console.log('Adding views has not been implemented yet')
-    },
-    isDisplayingWorkflow () {
-      // add other view names that must display the Control bar here
-      return ['Tree'].includes(this.$route.name)
     }
   }
 }
 </script>
 
 <style>
-  /* Fix coming in v2.0.8 */
-  #core-app-bar {
-    width: auto;
-  }
-
-  #core-app-bar a {
-    text-decoration: none;
-  }
+#core-app-bar a {
+  text-decoration: none;
+}
 </style>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,7 +1,5 @@
 <template>
   <div>
-    <toolbar />
-
     <drawer />
 
     <v-content>
@@ -17,7 +15,6 @@
 </template>
 
 <script>
-import Toolbar from '@/components/cylc/Toolbar'
 import Alert from '@/components/core/Alert'
 import Drawer from '@/components/cylc/Drawer'
 import Footer from '@/components/core/Footer'
@@ -25,7 +22,6 @@ import Footer from '@/components/core/Footer'
 export default {
   name: 'Default',
   components: {
-    Toolbar,
     Alert,
     Drawer,
     Footer

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -1,14 +1,17 @@
 <template>
-  <div class="c-tree">
-    <tree
-      :workflows="currentWorkflow"
-      :hoverable="false"
-      :activable="false"
-      :multiple-active="false"
-      :min-depth="1"
-      ref="tree0"
-      key="tree0"
-    ></tree>
+  <div>
+    <toolbar />
+    <div class="c-tree">
+      <tree
+        :workflows="currentWorkflow"
+        :hoverable="false"
+        :activable="false"
+        :multiple-active="false"
+        :min-depth="1"
+        ref="tree0"
+        key="tree0"
+      ></tree>
+    </div>
   </div>
 </template>
 
@@ -17,6 +20,7 @@ import { workflowService } from 'workflow-service'
 import { mixin } from '@/mixins/index'
 import { mapState } from 'vuex'
 import Tree from '@/components/cylc/Tree'
+import Toolbar from '@/components/cylc/Toolbar'
 
 // query to retrieve all workflows
 const QUERIES = {
@@ -58,6 +62,7 @@ const QUERIES = {
 export default {
   mixins: [mixin],
   components: {
+    toolbar: Toolbar,
     tree: Tree
   },
 


### PR DESCRIPTION
Closes #253 

At the moment the toolbar is displayed all over the pages/views in Cylc UI. But the design ketches actually hid it, and displayed it only on the pages with workflows running.

This PR

- Moves the toolbar to within the Tree view (this would have to be replicated in the Graph view for now, but in the future we will have a single view with tabs)
- Removes the elements that were used to display where/how things would be, adding `TODO`'s

If the second part of the PR is fine, I will add issues set to the 1.0 milestone. I left the pause and stop buttons, as I think we are ready to add these. I believe @dwsutherland has created the mutations already. All that is missing is investigate what is missing in the UI to call that. So this should be fixed soon for 0.2.

But if others prefer, happy to drop commits and leave just the move of the toolbar to within the workflows view here :+1: 

Cheers
Bruno