### PR TITLE
Add unit tests for GQuery

### DIFF
--- a/tests/unit/services/gquery.spec.js
+++ b/tests/unit/services/gquery.spec.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai'
+import { GQuery } from '@/services/gquery'
+import { parse } from 'graphql/language/parser'
+
+describe('GQuery', () => {
+  describe('constructor', () => {
+    it('should create an object correctly', () => {
+      const gquery = new GQuery()
+      expect(gquery.apolloClient).to.not.equal(null)
+      expect(gquery.query).to.equal(null)
+    })
+  })
+  describe('merge', () => {
+    it('should merge two queries correctly', () => {
+      const gquery = new GQuery()
+      const query1 = `
+        query {
+          workflows {
+            id
+          }
+        }
+      `
+      const view1 = {
+      }
+      gquery.subscribe(view1, query1)
+      // at this point we have only 1 query, so the computed query must have the exact value we provided
+      const expectedQuery1 = JSON.stringify(parse(query1))
+      expect(expectedQuery1).to.equal(JSON.stringify(gquery.query))
+
+      const query2 = `
+        query {
+          workflows {
+            name
+          }
+        }
+      `
+      const view2 = {
+      }
+      gquery.subscribe(view2, query2)
+      // now the queries must have been merged
+      expect(JSON.stringify(gquery.query)).to.contain('name')
+    })
+  })
+  describe('recompute', () => {
+    it('should not change query if no views were added', () => {
+      const gquery = new GQuery()
+      gquery.recompute()
+      expect(gquery.query).to.equal(null)
+    })
+  })
+})


### PR DESCRIPTION
Started working on #234 today, which I thought would be a 30 minutes job. But then got stuck trying to add the variables to the query, and noticed I was changing a lot of code in `gquery.js`.

I realized it didn't have unit tests yet, so started adding a few ones here. Will add a few more tomorrow, but I digressed a little today (2 hours) trying to get the coverage to work (#255) with no luck.