### PR TITLE
Fix coverage

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -18,5 +18,7 @@
   "reporter" : ["html", "lcov", "text-summary"],
   "cache" : false,
   "all" : true,
-  "check-coverage" : true
+  "check-coverage" : true,
+  "instrument" : false,
+  "sourceMap" : false
 }

--- a/.nycrc
+++ b/.nycrc
@@ -16,6 +16,6 @@
   "cache": false,
   "all": true,
   "check-coverage": false,
-  "instrument": false,
-  "sourceMap": false
+  "instrument": true,
+  "sourceMap": true
 }

--- a/.nycrc
+++ b/.nycrc
@@ -1,9 +1,6 @@
 {
-  "lines" : 0,
-  "statements" : 0,
-  "branches" : 0,
-  "include" : ["src/**/*.js"],
-  "exclude" : [
+  "include": ["src/**/*.js"],
+  "exclude": [
     "node_modules",
     "docs",
     "tests",
@@ -14,11 +11,11 @@
     "src/styles",
     "src/components/index.js"
    ],
-  "extension" : [".js", ".vue"],
-  "reporter" : ["html", "lcov", "text-summary"],
-  "cache" : false,
-  "all" : true,
-  "check-coverage" : true,
-  "instrument" : false,
-  "sourceMap" : false
+  "extension": [".js", ".vue"],
+  "reporter": ["html", "lcov", "text-summary"],
+  "cache": false,
+  "all": true,
+  "check-coverage": false,
+  "instrument": false,
+  "sourceMap": false
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 // optional file, loaded automatically by @vue/cli-service if present next to package.json
 var webpack = require('webpack')
+var path = require('path')
 
 module.exports = {
   publicPath: '',
@@ -15,9 +16,11 @@ module.exports = {
     ]
   },
   chainWebpack: config => {
-    if (process.env.NODE_ENV !== 'production') {
-      config.module.rule('js')
-        .use('istanbul')
+    if (process.env.NODE_ENV === 'test') {
+      config.module.rule('istanbul')
+        .test(/\.js$/)
+        .include.add(path.resolve('src')).end()
+        .use('istanbul-instrumenter-loader')
         .loader('istanbul-instrumenter-loader')
         .options({ esModules: true })
         .before('babel-loader')
@@ -25,7 +28,9 @@ module.exports = {
       config.output
         .devtoolModuleFilenameTemplate('[absolute-resource-path]')
         .devtoolFallbackModuleFilenameTemplate('[absolute-resource-path]?[hash]')
+    }
 
+    if (process.env.NODE_ENV !== 'production') {
       config.devtool('inline-cheap-module-source-map')
     }
 


### PR DESCRIPTION
Closes #255 

Had to play with the settings a bit. First commit is re-enabling the coverage. Next commit is to match that istanbul plugin documentation, making it easier to check for differences. Then we reformat the JSON in the next commit, and finally had to enable `instrument` and `sourceMap`, as otherwise it would report only on covered file (i.e. exclude not covered files, giving a coverage report number of ~94%).