### PR TITLE
Replaces usages of `var` with `const`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ below.
  - David Sutherland
  - Martin Ryan
  - Tim Pillinger
+ - Alex Szabó
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/src/services/gquery.js
+++ b/src/services/gquery.js
@@ -25,7 +25,7 @@ function getSelections (a) {
   if (!a.selectionSet || !a.selectionSet.selections) {
     return {}
   }
-  var selections = {}
+  const selections = {}
   for (const selection of a.selectionSet.selections) {
     if (selection.kind === 'Field') {
       selections[selection.name.value] = selection
@@ -95,7 +95,7 @@ class GQuery {
       return
     }
     // merge together active subscriptions
-    var root = gClone(this.subscriptions[0].query)
+    const root = gClone(this.subscriptions[0].query)
     for (const subscription of this.subscriptions.slice(1)) {
       merge(root, subscription.query)
     }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,6 @@
 // optional file, loaded automatically by @vue/cli-service if present next to package.json
-var webpack = require('webpack')
-var path = require('path')
+const webpack = require('webpack')
+const path = require('path')
 
 module.exports = {
   publicPath: '',


### PR DESCRIPTION
Fixes #271

Ran unit tests, and both `build` and `build:report` - everything seemed fine (except for some `console` usages reported by eslint).