### PR TITLE
Fix size of dashboard links on hover

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ below.
  - Martin Ryan
  - Tim Pillinger
  - Alex Szabó
+ - Ash Newport
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -41,7 +41,7 @@
       </v-flex>
     </v-layout>
     <v-divider />
-    <v-layout row wrap>
+    <v-layout wrap>
       <v-flex xs12 md6 lg6>
         <v-list three-line>
           <v-list-item to="/user-profile">


### PR DESCRIPTION
Remove `row` prop from `<v-layout>` to align hover with sibling elements and maximise use of space.

Closes #270 