### PR TITLE
Load user information on application startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ None or N/A.
 [#257](https://github.com/cylc/cylc-ui/pull/257) - Display toolbar for
 workflows only.
 
+[#283](https://github.com/cylc/cylc-ui/pull/283) -  Load user information
+on application startup.
+
 ### Fixes
 
 [#275](https://github.com/cylc/cylc-ui/pull/275) - Fix size of dashboard

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,6 +12,7 @@ import Router from 'vue-router'
 import Meta from 'vue-meta'
 import NProgress from 'nprogress'
 import store from '@/store'
+import { UserService } from 'user-service'
 
 import '../../node_modules/nprogress/nprogress.css'
 
@@ -51,6 +52,7 @@ const router = new Router({
 Vue.use(Meta)
 
 router.beforeResolve((to, from, next) => {
+  NProgress.start()
   if (to.name) {
     if (['Tree'].includes(to.name)) {
       // When a workflow is being displayed, we set the title to a
@@ -59,8 +61,14 @@ router.beforeResolve((to, from, next) => {
     } else {
       store.commit('app/setTitle', to.name)
     }
-    NProgress.start()
-    store.dispatch('setAlert', null)
+    store.dispatch('setAlert', null).then(() => {})
+  }
+  next()
+})
+
+router.beforeEach((to, from, next) => {
+  if (!store.state.user.user) {
+    UserService.getUserProfile().then(() => {})
   }
   next()
 })

--- a/src/services/mock/user.service.mock.js
+++ b/src/services/mock/user.service.mock.js
@@ -1,0 +1,13 @@
+import User from '@/model/User.model'
+import store from '@/store/index'
+
+export const UserService = {
+
+  getUserProfile () {
+    return new Promise((resolve, reject) => {
+      const user = new User('cylc-dev', ['cylc-developers', 'linux-users'], new Date(), true)
+      return store.dispatch('user/setUser', user)
+    })
+  }
+
+}

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -6,7 +6,7 @@ import Alert from '@/model/Alert.model'
 export const UserService = {
 
   getUserProfile () {
-    return axios.get(window.location.pathname + '/userprofile').then((response) => {
+    return axios.get(`${window.location.pathname}/userprofile`).then((response) => {
       const user = new User(response.data.name, response.data.groups, response.data.created, response.data.admin)
       return store.dispatch('user/setUser', user)
     }).catch((error) => {

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -71,7 +71,6 @@
 </template>
 
 <script>
-import { UserService } from '@/services/user.service'
 import { mapState } from 'vuex'
 import { mixin } from '@/mixins/index'
 
@@ -80,13 +79,7 @@ export default {
   computed: {
     ...mapState('user', ['user'])
   },
-  beforeCreate () {
-    this.$store
-      .dispatch('user/setUser', null)
-      .then(() => {
-        UserService.getUserProfile()
-      })
-  },
+
   metaInfo () {
     return {
       title: this.getPageTitle('App.userProfile')

--- a/vue.config.js
+++ b/vue.config.js
@@ -57,9 +57,15 @@ module.exports = {
     }
 
     // set up aliases for mock services, used when the offline mode is used
-    const workflowService = process.env.NODE_ENV === 'offline'
+    const isOffline = process.env.NODE_ENV === 'offline'
+    const workflowService = isOffline
       ? '@/services/mock/workflow.service.mock'
       : '@/services/workflow.service'
     config.resolve.alias.set('workflow-service', workflowService)
+
+    const userService = isOffline
+      ? '@/services/mock/user.service.mock'
+      : '@/services/user.service'
+    config.resolve.alias.set('user-service', userService)
   }
 }


### PR DESCRIPTION
Closes #260 

This PR first adds a mock service for the `UserService`. The returned information should be the same for everybody, with the exception of created date, which is a `new Date()` object, meaning it will display different whenever called.

![Screenshot_2019-10-09_12-14-28](https://user-images.githubusercontent.com/304786/66440201-b7b72700-ea8e-11e9-9f19-de738b576fa1.png)

So now this view should work on the offline mode.

Then we move the call to the `/userprofile` service from the `UserProfile.vue` view to a global route guard.

This guard will check if the Vuex store contains a user already in place. If not, it will fetch the user information from JupyterHub, and store in the Vuex store.

After this, the application should have the `store.state.user.user` information available to any screen/module/code/etc that may need it, e.g. #258 

Cheers
Bruno