### PR TITLE
Include .vue components in coverage report

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.js"],
+  "include": ["src/**/*.js", "src/**/*.vue"],
   "exclude": [
     "node_modules",
     "docs",

--- a/vue.config.js
+++ b/vue.config.js
@@ -30,8 +30,13 @@ module.exports = {
         .devtoolFallbackModuleFilenameTemplate('[absolute-resource-path]?[hash]')
     }
 
+    // https://webpack.js.org/configuration/devtool/
     if (process.env.NODE_ENV !== 'production') {
-      config.devtool('inline-cheap-module-source-map')
+      if (process.env.NODE_ENV === 'test') {
+        config.devtool('eval')
+      } else {
+        config.devtool('inline-cheap-module-source-map')
+      }
     }
 
     // mocha-webpack appears to be having issues with sass-loader, interpreting .sass files as .scss after


### PR DESCRIPTION
This is a small change with no associated Issue.

After this PR, our code coverage on Codecov will include both `.js` and `.vue` files. The coverage will decrease, but that's better than not seeing how much of `.vue` single file components are being tested :+1: 

Before: https://codecov.io/gh/kinow/cylc-ui/tree/master/src

After: https://codecov.io/gh/kinow/cylc-ui/tree/include-vue-coverage/src

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? change affects build only).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
