### PR TITLE
Prevent accessing user when still undefined

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -68,9 +68,12 @@ router.beforeResolve((to, from, next) => {
 
 router.beforeEach((to, from, next) => {
   if (!store.state.user.user) {
-    UserService.getUserProfile().then(() => {})
+    UserService.getUserProfile().then(() => {
+      next()
+    })
+  } else {
+    next()
   }
-  next()
 })
 
 router.afterEach(() => {


### PR DESCRIPTION
This is a small change with no associated Issue.

It is possible that the `user` object will be accessed from the Vuex store while the `Promise` has not yet been fulfilled. This PR just changes the logic to call `next()` only if we already have a user, or after the `Promise` has completed.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? not sure how to test the `beforeEach` of routes, maybe with e2e tests?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
