### PR TITLE
Fix promise use in mocked data, and field being displayed in user form

### DIFF
--- a/src/services/mock/user.service.mock.js
+++ b/src/services/mock/user.service.mock.js
@@ -4,10 +4,15 @@ import store from '@/store/index'
 export const UserService = {
 
   getUserProfile () {
-    return new Promise((resolve, reject) => {
-      const user = new User(process.env.USER, ['cylc-developers', 'linux-users'], new Date(), true, `/user/${process.env.USER}/`)
-      return store.dispatch('user/setUser', user)
-    })
+    const username = 'cylc'
+    const user = new User(
+      username,
+      ['cylc-developers', 'linux-users'],
+      new Date(),
+      true,
+      `/user/${username}/`
+    )
+    return store.dispatch('user/setUser', user)
   }
 
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -14,7 +14,7 @@
               <v-layout row wrap>
                 <v-flex xs12 md12>
                   <v-text-field
-                      :value="user.name"
+                      :value="user.username"
                       :label="$t('UserProfile.username')"
                       disabled
                       aria-disabled="true"


### PR DESCRIPTION
This is a small change with no associated Issue.

Noticed after rebasing the issue that I had a bug in my `Promise`. Was returning a `Promise` that returned a `Promise` (Vuex store method), instead of chaining it. But I think we also don't need to chain anything, instead we can just simply return the Vuex method/`Promise`.

But that showed that there was a bug (probably old) where the username was not displayed in the form. Probably nobody noticed because we rarely need that screen.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? mock data).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
