### PR TITLE
Ignore no-console eslint rule in a few places

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -266,6 +266,7 @@ export default {
       if (['waiting', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed'].includes(this.status)) {
         classes.push(this.status)
       } else {
+        // eslint-disable-next-line no-console
         console.error(`Invalid task status: ${this.status}`)
         classes.push('unknown')
       }

--- a/src/components/cylc/Toolbar.vue
+++ b/src/components/cylc/Toolbar.vue
@@ -121,7 +121,6 @@ export default {
     },
     onClickAddView () {
       // TODO: implement adding views action
-      console.log('Adding views has not been implemented yet')
     }
   }
 }

--- a/src/services/gquery.js
+++ b/src/services/gquery.js
@@ -166,6 +166,7 @@ class GQuery {
      * Perform a REST GraphQL request for all subscriptions.
      */
     if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
       console.debug('graphql request:', this.query)
     }
     return this.apolloClient.query({
@@ -233,6 +234,7 @@ class GQuery {
         })
     })
 
+    // eslint-disable-next-line no-console
     console.debug(ret)
   }
 }


### PR DESCRIPTION
This is a small change with no associated Issue.

Simply prevents build warnings for calls to methods of `console`. The exceptions added are already protected by `if (process.env.NODE_ENV !== 'production') {` - meaning print only when not production environment - or are intentional - like in `Task.vue`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? lint only).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
