### PR TITLE
Support any attributes defined in paths.js when creating routes

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,16 +19,15 @@ import '../../node_modules/nprogress/nprogress.css'
 // Routes
 import paths from './paths'
 
-function route (path, view, name, meta, alias) {
-  return {
-    name: name || view,
-    meta,
-    path,
-    alias,
+function route (path) {
+  const copy = Object.assign({}, path)
+  const view = copy.view
+  return Object.assign(copy, {
+    name: path.name || view,
     component: (resolve) => import(
       `@/views/${view}.vue`
     ).then(resolve)
-  }
+  })
 }
 
 Vue.use(Router)
@@ -36,7 +35,7 @@ Vue.use(Router)
 // Create a new router
 const router = new Router({
   mode: 'hash',
-  routes: paths.map(path => route(path.path, path.view, path.name, path.meta, path.alias)),
+  routes: paths.map(path => route(path)),
   //  .concat([{ path: '*', redirect: '/dashboard' }]),
   scrollBehavior (to, from, savedPosition) {
     if (savedPosition) {

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -23,11 +23,12 @@ export default [
     }
   },
   {
-    path: '/workflows/:name',
+    path: '/workflows/:workflowName',
     view: 'Tree',
     meta: {
       layout: 'default'
-    }
+    },
+    props: true
   },
   {
     path: '/user-profile',

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -61,15 +61,22 @@ const QUERIES = {
 
 export default {
   mixins: [mixin],
+
+  props: {
+    workflowName: {
+      type: String,
+      required: true
+    }
+  },
+
   components: {
     toolbar: Toolbar,
     tree: Tree
   },
 
   metaInfo () {
-    const workflowName = this.$route.params.name
     return {
-      title: this.getPageTitle('App.workflow', { name: workflowName })
+      title: this.getPageTitle('App.workflow', { name: this.workflowName })
     }
   },
 
@@ -84,7 +91,7 @@ export default {
     ...mapState('workflows', ['workflowTree']),
     currentWorkflow: function () {
       for (const workflow of this.workflowTree) {
-        if (workflow.name === this.$route.params.name) {
+        if (workflow.name === this.workflowName) {
           return [workflow]
         }
       }
@@ -93,7 +100,7 @@ export default {
   },
 
   created () {
-    this.workflowId = this.$route.params.name
+    this.workflowId = this.workflowName
     this.viewID = `Tree(${this.workflowId}): ${Math.random()}`
     workflowService.register(
       this,


### PR DESCRIPTION
These changes close #293

Simply accept the complete `path` object, modifying it to use the `view` value when `name` is missing (i.e. keeping previous behaviour).

This allows the approach used by @MartinRyan in the Graph component PR to work, of [passing props to route components](https://router.vuejs.org/guide/essentials/passing-props.html). Easier than relying on the route parameters directly. Vue Router instead will inject the param to the view.

What happened in the Graph PR was that even though Martin added `props: true`, it was ignored as it was not expected by the function. The code now will use whatever we define in `paths.js`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? not sure how to test this part).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
