### PR TITLE
Add slots to Tree component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6892,12 +6892,55 @@
       }
     },
     "cross-env": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
-      "integrity": "sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.5"
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -21312,9 +21355,9 @@
       "dev": true
     },
     "vue-cli-plugin-vuetify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-1.1.1.tgz",
-      "integrity": "sha512-Sd1bQhMPKjFUKtAqsbndxu+fOSmCrSXF7pa4bIToFszP6Otu3HcwICzdGfNOyXOCX4/qqvNfSOdYapbNEVG+Uw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.0.1.tgz",
+      "integrity": "sha512-vNCSuG1mI3Ik6gAr19Gf8Iju+P+qGYj4yGBhpBtWItH0ejMZcPSo/sMBnys7sgGyaTNY43IBi6VTye7DVzDAFQ==",
       "dev": true,
       "requires": {
         "semver": "^6.0.0",
@@ -21341,9 +21384,9 @@
       }
     },
     "vue-cli-plugin-vuetify-essentials": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify-essentials/-/vue-cli-plugin-vuetify-essentials-0.7.0.tgz",
-      "integrity": "sha512-LkaNPjyw1QutULl3h/BiPQCnfIkTPbb0pS6LEGDKpcGaK7YUS5Du8uDLp34R+OIUr+h5NFdv/rMJRVmIRnE6Jg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify-essentials/-/vue-cli-plugin-vuetify-essentials-0.8.2.tgz",
+      "integrity": "sha512-uf+MClJ2WpoWzWxyMuvDHfGRA3ZNp4iGCS/siJeFIQ1oAHyR3fupan7sLLVvYZAORDHXhPEeeQ301vRQfhA2uA==",
       "dev": true
     },
     "vue-cytoscape": {

--- a/src/components/cylc/TreeItem.vue
+++ b/src/components/cylc/TreeItem.vue
@@ -203,7 +203,7 @@ export default {
             node: child,
             depth: this.depth + 1,
             hoverable: this.hoverable,
-            'min-depth': this.minDepth,
+            minDepth: this.minDepth,
             initialExpanded: this.initialExpanded
           }
         })


### PR DESCRIPTION
These changes partially address #145 

**WIP**: hard/boring part done and working, which was converting each element to a JSX JS call. Now pending:

- [ ] merge conflicts after #291 (new block added for families needs to be converted to JSX too)
- [ ] insert slots and pass them recursively to the `TreeItem` child component
- [ ] implement the `GScan` sidebar panel using the `Tree` with `minDepth=0` & `TreeItem`s with slots for the top level workflow level, which do not render children nodes, instead displaying only workflow name, and summary of existing job states in the workflow

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
