### PR TITLE
Cylc doc URL fix.

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -100,7 +100,7 @@
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
-          <v-list-item href="https://cylc.github.io/documentation.html">
+          <v-list-item href="https://cylc.github.io/documentation">
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon medium>mdi-file-document-box-multiple</v-icon>
             </v-list-item-avatar>


### PR DESCRIPTION
Minor dashboard tweak - the new responsive web site doesn't like "documentation.html".

One review will do!