### PR TITLE
Graph View style tweaks.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20631,9 +20631,9 @@
       "dev": true
     },
     "vue-cli-plugin-vuetify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.0.1.tgz",
-      "integrity": "sha512-vNCSuG1mI3Ik6gAr19Gf8Iju+P+qGYj4yGBhpBtWItH0ejMZcPSo/sMBnys7sgGyaTNY43IBi6VTye7DVzDAFQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.0.2.tgz",
+      "integrity": "sha512-OJ1YUSfDlQibj111QMGv4a44atmtWdrkynk4voiEuivUqLcZGCJyF/A8ae0VojpMU2jlvZydz0nXjmZmcg+Nqw==",
       "dev": true,
       "requires": {
         "semver": "^6.0.0",

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -9,7 +9,7 @@
     <div class='switchlayout'>
       <v-btn
         id='freeze-button'
-        x-small
+        small
         name='freeze'
         align-bottom
         justify-center
@@ -152,18 +152,18 @@ const edgeOptions = {
 const config = {}
 
 const states = Object.freeze({
-  EXPIRED: { state: 'expired', icon: 'baseline-donut_large-24px.svg', colour: '#fefaff' },
-  FAILED: { state: 'failed', icon: 'outline-cancel-24px.svg', colour: '#ff3a2b' },
-  QUEUED: { state: 'queued', icon: 'baseline-donut_large-24px.svg', colour: '#fff138' },
-  READY: { state: 'ready', icon: 'outline-radio_button_unchecked-24px.svg', colour: '#7093FF' },
-  RETRYING: { state: 'retrying', icon: 'outline-refresh-24px.svg', colour: '#ff3a2b' },
-  RUNNING: { state: 'running', icon: 'outline-adjust-24px.svg', colour: '#4ab7ff' },
-  SUBFAILED: { state: 'subfailed', icon: 'outline-filter_tilt_shift-24px.svg', colour: '#d453ff' },
-  SUBMITTED: { state: 'submitted', icon: 'outline-adjust-24px.svg', colour: '#9ef9ff' },
-  SUCCEEDED: { state: 'succeeded', icon: 'outline-radio_button_unchecked-24px.svg', colour: '#31ff53' },
-  WAITING: { state: 'waiting', icon: 'outline-radio_button_unchecked-24px.svg', colour: '#666' },
-  DEFAULT: { state: 'default', icon: 'baseline-donut_large-24px.svg', colour: '#555' },
-  UNDEFINED: { state: 'UNDEFINED', icon: '', colour: '#444' }
+  EXPIRED: { state: 'expired', icon: '', colour: '#fefaff' },
+  FAILED: { state: 'failed', icon: '', colour: '#cf4848' },
+  QUEUED: { state: 'queued', icon: '', colour: '#efefd9' },
+  READY: { state: 'ready', icon: '', colour: '#bfe5e7' },
+  RETRYING: { state: 'retrying', icon: '', colour: '#efefd9' },
+  RUNNING: { state: 'running', icon: '', colour: '#6aa4f1' },
+  SUBFAILED: { state: 'subfailed', icon: '', colour: '#be6ac0' },
+  SUBMITTED: { state: 'submitted', icon: '', colour: '#7dcfd4' },
+  SUCCEEDED: { state: 'succeeded', icon: '', colour: '#51af51' },
+  WAITING: { state: 'waiting', icon: '', colour: '#efefd9' },
+  DEFAULT: { state: 'default', icon: '', colour: '#efefd9' },
+  UNDEFINED: { state: 'UNDEFINED', icon: '', colour: '#efefd9' }
 })
 
 const dagreOptions = {
@@ -228,7 +228,7 @@ const ciseOptions = {
     return node.cyclepoint
   },
   // -------- Optional parameters --------
-  animate: 'end',
+  animate: false,
   // number of ticks per frame; higher is faster but more jerky
   refresh: 20,
   // Animation duration used for animate:'end'
@@ -285,7 +285,7 @@ const coseBilkentOptions = {
   gravity: 0.5, // Gravity force (constant)
   numIter: 2500, // Maximum number of iterations to perform
   tile: true, // Whether to tile disconnected nodes
-  animate: 'end', // Type of layout animation. The option set is {'during', 'end', false}
+  animate: false, // Type of layout animation. The option set is {'during', 'end', false}
   tilingPaddingVertical: 10, // Amount of vertical space to put between degree zero nodes during tiling (can also be a function)
   tilingPaddingHorizontal: 10, // Amount of horizontal space to put between degree zero nodes during tiling (can also be a function)
   gravityRangeCompound: 1.5, // Gravity range (constant) for compounds
@@ -325,7 +325,7 @@ const hierarchicalOptions = {
 
 const colaLayoutOptions = {
   name: 'cola',
-  animate: true, // whether to show the layout as it's running
+  animate: false, // whether to show the layout as it's running
   refresh: 1, // number of ticks per frame; higher is faster but more jerky
   maxSimulationTime: 2000, // max length in ms to run the layout
   ungrabifyWhileSimulating: true, // so you can't drag nodes during layout
@@ -822,19 +822,6 @@ export default {
             {
               selector: 'node',
               css: {
-                'background-image': function memoize (node) {
-                  const nodeState = String(node.data('state'))
-                  const STATE = nodeState.toUpperCase()
-                  let icon = states.DEFAULT.icon
-                  if (Object.hasOwnProperty.call(states, STATE)) {
-                    icon = states[STATE].icon
-                  }
-                  return require('@/../public/img/' + String(icon))
-                },
-                'background-fit': 'contain contain',
-                'background-image-opacity': function memoize (node) {
-                  return has(data, 'runpercent') && !isEmpty(data('runpercent')) && data('runpercent') > 0 ? 1.0 : 0.6
-                },
                 'background-color': function memoize (node) {
                   const nodeState = String(node.data('state'))
                   const STATE = nodeState.toUpperCase()
@@ -855,8 +842,6 @@ export default {
                 'text-margin-x': 5,
                 'font-size': '.8em',
                 'min-zoomed-font-size': '.8em',
-                'border-color': '#333',
-                'border-width': '.1em',
                 shape: 'data(shape)',
                 width: '6em',
                 height: '6em',
@@ -1169,8 +1154,7 @@ export default {
               '<rect x="' + xoffset + '" y="' + yoffset + '" width="20" height="20" rx="4" ry="4"  stroke="" fill="' + states[JOBSTATE].colour + '" fill-opacity="1" stroke-opacity="0.8"/>'
               jobsGrid = jobsGrid.concat('', jobSquare)
             })
-            return '<div style="display:relative margin-top: 3em; class="cy-title"><span class="cy-title__label">' + data.task.name +
-            '</span><br>' +
+            return '<div style="display:relative margin-top: 3em; class="cy-title"><span class="cy-title__label">' + data.task.name + '</span><br/>' +
             '<span  class="cy-title__cyclepoint">' +
             data.cyclePoint +
             '</span><br>' +

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -13,21 +13,21 @@
 
     .cytoscape-navigator-overlay {
       position: absolute;
-      border: 1px solid #222;
-      background: #fff;
+      border: 1px solid #bacbcc;
+      background: #eafbfc;
       z-index: 5;
       width: 200px;
       height: 150px;
-      bottom: 83px;
-      right: -1px;
+      bottom: 81px;
+      right: 0px;
       overflow: hidden;
     }
 
     .cytoscape-navigatorView {
-      border: 2px solid rgb(18, 6, 87);
-      border-radius: 1px;
-      background-color: #0c78ff;
-      opacity: 0.4;
+      border: 1px solid #0a4;
+      border-radius: 4px;
+      background-color: #8af;
+      opacity: 0.2;
       /* cursor: move; */
     }
 
@@ -51,14 +51,14 @@
 
     .dagre-button {
       text-align: centre;
-      color: #f2f2f2;
+      color: slategray;
       z-index: 4;
       height: 40px;
     }
 
     .cise-button {
       text-align: centre;
-      color: #f2f2f2;
+      color: slategray;
       z-index: 4;
       height: 40px;
       width: 40px;
@@ -67,7 +67,7 @@
 
     .cosebilkent-button {
       text-align: centre;
-      color: #f2f2f2;
+      color: slategray;
       z-index: 4;
       height: 40px;
       margin-left: 4px;
@@ -75,7 +75,7 @@
 
     .hierarchical-button {
       text-align: centre;
-      color: #f2f2f2;
+      color: slategray;
       z-index: 4;
       height: 40px;
       margin-left: 4px;
@@ -83,7 +83,7 @@
 
     .cola-button {
       text-align: centre;
-      color: #f2f2f2;
+      color: slategray;
       z-index: 4;
       height: 40px;
       width: 40px;
@@ -92,7 +92,7 @@
 
     .collapse-all-button {
       text-align: centre;
-      color: #f2f2f2;
+      color: slategray;
       font-size: .4em;
       size: 'x-small';
       z-index: 4;
@@ -105,15 +105,12 @@
 
     .freeze-button {
       text-align: centre;
-      color: #f2f2f2;
-      font-size: .4em;
-      size: 'x-small';
+      color: slategray;
+      size: 'small';
       z-index: 4;
       height: 10px;
-      margin-left: 0.1em;
       margin-top: 1em;
       margin-bottom: 1em;
-      margin-right: .4em;
     }
 
     .layout-title {
@@ -148,5 +145,9 @@
       font-family: arial, helvetica, sans-serif;
       width: 100%;
     }
+}
 
+.tippy-tooltip {
+    background-color: black;
+    font-family:courier;
 }

--- a/src/styles/cytoscape/html-label.scss
+++ b/src/styles/cytoscape/html-label.scss
@@ -2,58 +2,49 @@
     text-align: left;
     font-size: 1em;
     width: 130px;
-    color: #2b2b2b;
+    color: black;
     text-transform: capitalize;
-    background: rgba(255, 255, 255, 1)
   }
 
   .cy-title__cyclepoint {
     text-align: left;
     font-size: 1em;
     width: 130px;
-    color: #2b2b2b;
+    color: slategray;
     text-transform: capitalize;
-    background: rgba(255, 255, 255, 1)
   }
   
   .cy-title__label {
     font-size: 1em;
     overflow-wrap: break-word;
     color: '#333';
-    background: rgba(255, 255, 255, 1)
   }
   
   .cy-title__state {
     font-size: 0.9em;
-    background: rgba(255, 255, 255, 1)
   }
 
   .cy-title__submittedtime {
     font-size: 1em;
     color: '#333';
-    background: rgba(255, 255, 255, 1)
   }
 
   .cy-title__status {
     font-size: .8em;
     color: '#333';
-    background: rgba(255, 255, 255, 1)
   }
 
   .cy-title__jobs {
     font-size: .8em;
     color: '#333';
-    background: rgba(255, 255, 255, 1)
   }
 
   .cy-title__name {
     font-size: 1.5em;
-    background: rgba(255, 255, 255, 1)
   }
   
   .cy-title__info {
     font-size: 0.9em;
-    background: rgba(255, 255, 255, 1)
   }
 
   .box-task-graph {


### PR DESCRIPTION
Tidy up graph view styling, to at least make it more clean looking (if not actually conforming to our design at this stage, due to unresolved issues).
- use our job icon colours (mostly/sort-of) for graph nodes, and repeat some colours to approximate our new set of statuses better
- remove the gray "donut" shapes etc. inside each node (not sure what those were for, but they didn't look good ... maybe some experiment to approximate job progress or something in lieu of our svg task icons?)
- slightly less horrible font in the pop-ups
- also stops the animation from scratch on every update, for the other layouts, which is no good for a live monitor view (however, it still does a single double-jump for reasons that I couldn't figure out in the time available).

![shot](https://user-images.githubusercontent.com/2362137/68628960-fd13bc00-0546-11ea-9e99-e22630c504aa.png)

