### PR TITLE
Add a span parent to the job component to specify the theme (normal by default)

### DIFF
--- a/src/components/cylc/Job.vue
+++ b/src/components/cylc/Job.vue
@@ -4,10 +4,11 @@
 -->
 
 <template>
-  <span
-    class="c-job"
-    style="display:inline-block; vertical-align:middle"
-  >
+  <span class="job_theme--normal">
+    <span
+      class="c-job"
+      style="display:inline-block; vertical-align:middle"
+    >
     <!-- the task icon SVG
            * comments prefixed `let` are instructions for changing style
            * contain in a 100x100 viewBox so pixels and percent are equal
@@ -29,6 +30,7 @@
         stroke-width="10"
       />
     </svg>
+  </span>
   </span>
 </template>
 


### PR DESCRIPTION
These changes close #310 

This change appears to solve the transparent/missing job icons for now.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? theme/layout change).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
