### PR TITLE
Skip the job status "ready" until the backend is updated

### DIFF
--- a/src/components/cylc/gscan/index.js
+++ b/src/components/cylc/gscan/index.js
@@ -10,6 +10,10 @@ function getWorkflowSummary (workflow) {
   const states = new Map()
   for (const taskProxy of workflow.taskProxies) {
     for (const job of taskProxy.jobs) {
+      // TODO: temporary fix, as the backend is sending ready jobs, but they will change in cylc flow&uiserver in the future
+      if (job.state === 'ready') {
+        continue
+      }
       if (!states.has(job.state)) {
         states.set(job.state, new Set())
       }


### PR DESCRIPTION
This is a small change with no associated Issue.

@hjoliver related to the discussion on Riot about the job status "ready". Due to #310 you may have to move your mouse over the area of the icons to confirm there is no tooltip for "ready" 😄 the first icon that should display the tooltip is "running" (in alphabetical order, unless you have some failed or some other < "ready").

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? temporary fix).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
