### PR TITLE
Show ready/preparing task status.

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -286,7 +286,8 @@ export default {
       if (this.isHeld) {
         classes.push('held')
       }
-      if (['waiting', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed'].includes(this.status)) {
+      // TODO: remove cylc 7 'ready' state once no longer needed
+      if (['waiting', 'preparing', 'ready', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed'].includes(this.status)) {
         classes.push(this.status)
       } else {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Get rid of the remaining `?` undefined task state icon that regular appears in the tree view.  The old "ready" status, still coming from the back-end, is to be renamed "preparing" - but we can use the new "open small dot" icon for it already. :+1: 

![shot](https://user-images.githubusercontent.com/2362137/68638414-5dfebc80-0566-11ea-878d-735a955f5824.png)
