### PR TITLE
Execute GitHub action on pull requests too and fix coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,12 @@ jobs:
     - name: Test
       run: |
         npm run coverage:unit
-        bash <(curl -s https://codecov.io/bash)
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage/lcov.info
+        fail_ci_if_error: false
     - name: Build
       run: npm run build
 


### PR DESCRIPTION
This is a small change with no associated Issue.

Noticed that after marking a PR as ready for review it was not showing that the GItHub action had run successfully. Then found [a similar issue](https://github.com/sdras/awesome-actions/issues/98) (that repository has a lot of useful things for actions), and turns out I also did not include the `on: [pull_request]`, only `on: [push]`.

EDIT: added an extra commit to fix the coverage reports. Will have to add a secret token to the repo settings too, as documented in the Codecov github action docs: https://github.com/codecov/codecov-action

One review should to :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? build only).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
