### PR TITLE
task: support expired state

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -17,7 +17,7 @@
       class="task"
       :class="[
         props.isHeld ? 'held' : '',
-        ['waiting', 'preparing', 'ready', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed'].includes(props.status) ? props.status : 'unknown'
+        ['waiting', 'preparing', 'ready', 'expired', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed'].includes(props.status) ? props.status : 'unknown'
       ]"
       viewBox="0 0 100 100"
     >
@@ -113,6 +113,56 @@
           x=52.5 y=25
           width="10" height="50"
           rx="5" ry="5"
+        ></rect>
+      </g>
+
+      <!--
+        Warning icon.
+      -->
+      <g
+        id="warning"
+        transform="
+          scale(0.45)
+          translate(125, 0)
+        "
+      >
+        <circle
+          cx="50" cy="50"
+          r="46"
+          stroke-width="10"
+        ></circle>
+        <rect
+          x=45 y=25
+          width="10" height="35"
+          rx="5" ry="5"
+        ></rect>
+        <rect
+          x=45 y=65
+          width="10" height="10"
+          rx="5" ry="5"
+        ></rect>
+      </g>
+
+      <!--
+        Clockface.
+      -->
+      <g
+        id="clockface"
+      >
+        <circle
+          cx="50" cy="50"
+          r="7.5"
+        ></circle>
+        <rect
+          x="47.5" y="12.5"
+          width="5" height="37.5"
+        ></rect>
+        <rect
+          x="47.5" y="25"
+          width="5" height="25"
+          transform="
+            rotate(135, 50, 50)
+          "
         ></rect>
       </g>
 

--- a/src/styles/cylc/_task.scss
+++ b/src/styles/cylc/_task.scss
@@ -56,6 +56,26 @@
     }
   }
 
+  @mixin warning() {
+    #warning {
+      circle {
+        stroke: $background;
+        fill: $foreground;
+      }
+      rect {
+        fill: $background;
+      }
+    }
+  }
+
+  @mixin clockface() {
+    #clockface {
+      circle, rect {
+        fill: $foreground
+      }
+    }
+  }
+
   @mixin unknown() {
     #question-mark {
       fill: $foreground;
@@ -82,6 +102,12 @@
     &.waiting, &.queued {
       /* NOTE: queued tasks may acquire an xtrigger or similar */
       @include outline();
+    }
+
+    &.expired {
+      @include outline();
+      @include warning();
+      @include clockface();
     }
 
     &.ready, &.preparing {

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -151,7 +151,8 @@ export default {
       'running',
       'succeeded',
       'failed',
-      'submit-failed'
+      'submit-failed',
+      'expired'
     ]
   })
 }


### PR DESCRIPTION
Closes the "eccentric task states" component of #109

Proposal to handle the expired state:
  * ~Mark "expired" tasks as "succeeded", this is how they are handled in the graph.~
  * ~Most the time they should be easily distinguished from naturally succeeded tasks by the absence of a job.~
  * Treat "expired" as a top-level status with its own icon.

Questions:
  * [x] Should we do anything more to visually distinguish "expired" from "succeeded"? - *yes*

Screenshot:

![Screenshot from 2019-12-23 09-43-59](https://user-images.githubusercontent.com/16705946/71327106-34738080-2569-11ea-82bc-674efddc5f90.png)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests - durp.
- [x] No change log entry required - document later
- [x] No documentation update required - documented within project
