### PR TITLE
logo: add svg xml-namespace

### DIFF
--- a/public/img/logo.svg
+++ b/public/img/logo.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="655" height="260">
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<svg width="655" height="260" xmlns="http://www.w3.org/2000/svg">
   <g transform="translate(292.53268,-49.505044)">
     <g>
       <g>


### PR DESCRIPTION
The XML namespace was missing from the `<svg />` tag which could cause browsers to refuse rendering in certain circumstances. E.G. try viewing the SVG file directly in your browser.