### PR TITLE
api on the fly - part 1 - generate forms from mutations

### DIFF
--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -2,64 +2,34 @@
   <v-form>
     <h3>{{ mutation.name }}</h3>
     <p>{{ mutation.description }}</p>
-    <component
+    <form-input
      v-for="arg in getArguments(mutation)"
      v-bind:key="arg.label"
      v-model="model[arg.label]"
-     :is="arg.component"
+     :gqlType="arg.gqlType"
      :label="arg.label"
-    >
-      <component
-       v-if="arg.ofType"
-       :is="derive(arg.ofType).component"
-      >
-        <component
-         v-if="arg.ofType.ofType"
-         :is="derive(arg.ofType.ofType).component"
-        >
-        </component>
-      </component>
-    </component>
+    />
     <v-btn
       @click="meh"
     >
       Done
     </v-btn>
-    <pre>{{ model }}</pre>
+    <pre ref="output">{{ model }}</pre>
   </v-form>
 </template>
 
 <script>
-import Vue from 'vue'
-
-import { VTextField } from 'vuetify/lib/components/VTextField'
 import { VForm } from 'vuetify/lib/components/VForm'
-import GList from '@/components/graphqlFormGenerator/components/List'
-import GNonNull from '@/components/graphqlFormGenerator/components/NonNull'
+import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
 
-const FORM_COMPONENTS = {
-  Form: {
-    component: VForm,
-  }
-}
-
-const TYPE_COMPONENTS = {
-  String: {
-    component: VTextField,
-  }
-}
-
-const KIND_COMPONENTS = {
-    LIST: {
-      component: GList
-    },
-    NON_NULL: {
-      component: GNonNull
-    }
-}
+// import Vue from 'vue'
+// Vue.component('form-input', FormInput)
 
 export default {
+  name: 'form-generator',
+
   components: {
+    'form-input': FormInput
   },
 
   props: {
@@ -73,68 +43,15 @@ export default {
     model: {}
   }),
 
-  created () {
-    // TEST DATA
-    this.mutation = {
-      name: 'My Mutation',
-      description: 'Test example.',
-      args: [
-        {
-          name: 'MyString',
-          type: {
-            name: 'String',
-            kind: 'SCALAR'
-          }
-        },
-        {
-          name: 'MyInteger',
-          type: {
-            name: 'Int',
-            kind:' SCALAR'
-          }
-        },
-        {
-          name: 'MyNonNull',
-          defaultValue: 'cant null this',
-          type: {
-            name: null,
-            kind: 'NON_NULL',
-            ofType: {
-              name: 'String',
-              kind: 'SCALAR'
-            }
-          }
-        }
-      ]
-    }
-  },
-
   methods: {
-    derive (type) {
-      const name = type.name
-      const kind = type.kind
-      if (TYPE_COMPONENTS[name]) {
-        return TYPE_COMPONENTS[name]
-      }
-      if (KIND_COMPONENTS[kind]) {
-        return KIND_COMPONENTS[kind]
-      }
-      return TYPE_COMPONENTS['String']
-    },
-
-    processType (type) {
-      return {
-        component: this.derive(type).component,
-        ofType: type.ofType
-      }
-    },
-
     getArguments (mutations) {
+      // TODO convert to computed?
       const ret = []
       for (let argument of mutations.args) {
-        const arg = this.processType(argument.type)
-        arg.label = argument.name
-        ret.push(arg)
+        ret.push({
+          gqlType: argument.type,
+          label: argument.name
+        })
         // spin up the model
         this.model[argument.name] = (
           argument.defaultValue
@@ -145,7 +62,9 @@ export default {
       return ret
     },
 
-    meh () {console.log(this.model)}
+    meh () {
+      this.$refs.output.innerText = JSON.stringify(this.model, null, '  ')
+    }
   }
 }
 </script>

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -19,8 +19,7 @@
 </template>
 
 <script>
-import { VForm } from 'vuetify/lib/components/VForm'
-import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
+import FormInput from '@/components/graphqlFormGenerator/FormInput'
 
 export default {
   name: 'form-generator',
@@ -108,7 +107,7 @@ export default {
           ret = []
           break
         }
-        if (pointer.kind == 'OBJECT') {
+        if (pointer.kind === 'OBJECT') {
           ret = {}
           break
         }

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -20,6 +20,7 @@
 
 <script>
 import FormInput from '@/components/graphqlFormGenerator/FormInput'
+import cloneDeep from 'lodash/cloneDeep'
 
 export default {
   name: 'form-generator',
@@ -50,7 +51,7 @@ export default {
     /* Provide a list of all form inputs for this mutation. */
     inputs () {
       const ret = []
-      for (let arg of this.mutation.args) {
+      for (const arg of this.mutation.args) {
         ret.push({
           gqlType: arg.type,
           label: arg.name
@@ -64,11 +65,11 @@ export default {
     /* Set this form to its initial conditions. */
     reset () {
       // begin with the initial data
-      const model = this.deepcopy(this.initialData || {})
+      const model = cloneDeep(this.initialData || {})
 
       // then apply default values from the schema
-      var defaultValue
-      for (let arg of this.mutation.args) {
+      let defaultValue
+      for (const arg of this.mutation.args) {
         if (arg.name in model) {
           // if the argument is defined in the initial data leave it unchanged
           continue
@@ -90,18 +91,10 @@ export default {
       this.model = model
     },
 
-    deepcopy (obj) {
-      return JSON.parse(
-        JSON.stringify(
-          obj
-        )
-      )
-    },
-
     /* Return a null value of a JS type corresponding to the GraphQL type. */
     getNullValue (type) {
-      var ret = null
-      var pointer = type
+      let ret = null
+      let pointer = type
       while (pointer) {
         if (pointer.kind === 'LIST') {
           ret = []

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -3,17 +3,12 @@
     <h3>{{ mutation.name }}</h3>
     <p>{{ mutation.description }}</p>
     <form-input
-     v-for="arg in getArguments(mutation)"
-     v-bind:key="arg.label"
-     v-model="model[arg.label]"
-     :gqlType="arg.gqlType"
-     :label="arg.label"
+     v-for="input in inputs"
+     v-bind:key="input.label"
+     v-model="model[input.label]"
+     :gqlType="input.gqlType"
+     :label="input.label"
     />
-    <v-btn
-      @click="meh"
-    >
-      Done
-    </v-btn>
     <v-btn
       @click="reset"
     >
@@ -26,9 +21,6 @@
 <script>
 import { VForm } from 'vuetify/lib/components/VForm'
 import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
-
-// import Vue from 'vue'
-// Vue.component('form-input', FormInput)
 
 export default {
   name: 'form-generator',
@@ -55,7 +47,22 @@ export default {
     this.reset()
   },
 
+  computed: {
+    /* Provide a list of all form inputs for this mutation. */
+    inputs () {
+      const ret = []
+      for (let arg of this.mutation.args) {
+        ret.push({
+          gqlType: arg.type,
+          label: arg.name
+        })
+      }
+      return ret
+    }
+  },
+
   methods: {
+    /* Set this form to its initial conditions. */
     reset () {
       // begin with the initial data
       const model = this.deepcopy(this.initialData || {})
@@ -72,8 +79,9 @@ export default {
           defaultValue = arg.defaultValue
         } else {
           // if no default value is provided choose a sensible null value
-          // NOTE: that if we set null as the default type for a list then
-          //       tried to change it to [] later this would break the Vue model
+          // NOTE: IF we set null as the default type for a list
+          //       THEN tried to change it to [] later this would break
+          //       THIS would break Vue model
           defaultValue = this.getNullValue(arg.type)
         }
         model[arg.name] = defaultValue
@@ -89,18 +97,6 @@ export default {
           obj
         )
       )
-    },
-
-    getArguments (mutations) {
-      // TODO convert to computed?
-      const ret = []
-      for (let arg of mutations.args) {
-        ret.push({
-          gqlType: arg.type,
-          label: arg.name
-        })
-      }
-      return ret
     },
 
     /* Return a null value of a JS type corresponding to the GraphQL type. */
@@ -119,10 +115,6 @@ export default {
         pointer = pointer.ofType
       }
       return ret
-    },
-
-    meh () {
-      this.$refs.output.innerText = JSON.stringify(this.model, null, '  ')
     }
   }
 }

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class='graphql-form-generator' ref='container'>
+    <h3>{{ mutation.name }}</h3>
+    <p>{{ mutation.description }}</p>
+  </div>
+</template>
+
+<script>
+import { VTextField } from 'vuetify/lib/components/VTextField'
+import { VForm } from 'vuetify/lib/components/VForm'
+
+const FORM_COMPONENTS = {
+  Form: {
+    component: VForm,
+    model: 'v-model'
+  }
+}
+
+const TYPE_COMPONENTS = {
+  String: {
+    component: VTextField,
+    model: 'v-model',
+    label: 'label'
+  }
+}
+
+const KIND_COMPONENTS = {
+}
+
+export default {
+  components: {
+  },
+
+  props: {
+    mutation: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data: () => ({
+    model: {}
+  }),
+
+  mounted () {
+    // create form
+    const Form = FORM_COMPONENTS.Form
+    const propsData = {}
+    propsData[Form] = {}
+    propsData['ref'] = 'form'
+    const form = new Form.component({
+      propsData
+    })
+    form.$mount()
+    this.$refs.container.appendChild(form.$el)
+
+    // create arguments
+    for (let argument of this.mutation.args) {
+      form.$el.append(
+        this.createArgumentComponent(argument).$el
+      )
+    }
+  },
+
+  methods: {
+    derive (argument) {
+      // const type = argument.type.name
+      // const kind = argument.type.kind
+
+      // TODO: hardcoded for now
+      const type = 'String'
+      const kind = null
+
+      if (TYPE_COMPONENTS[type]) {
+        return [type, TYPE_COMPONENTS[type]]
+      }
+      if (KIND_COMPONENTS[kind]) {
+        return [kind, KIND_COMPONENTS[kind]]
+      }
+      return null
+    },
+
+    createArgumentComponent (argument) {
+      const [name, options] = this.derive(argument)
+      const propsData = {}
+      propsData[options.label] = argument.name
+      propsData[options.model] = {}
+      const instance = new options.component({
+        propsData
+      })
+      // instance.$slots.default = []
+      instance.$mount()
+      //this.$refs.container.appendChild(instance.$el)
+      return instance
+    }
+  }
+}
+</script>

--- a/src/components/graphqlFormGenerator/FormInput.vue
+++ b/src/components/graphqlFormGenerator/FormInput.vue
@@ -13,8 +13,10 @@
 import Vue from 'vue'
 
 import { VTextField } from 'vuetify/lib/components/VTextField'
-import GList from '@/components/graphqlFormGenerator/components/List'
+
+import { formElement } from '@/components/graphqlFormGenerator/mixins'
 import GNonNull from '@/components/graphqlFormGenerator/components/NonNull'
+import GList from '@/components/graphqlFormGenerator/components/List'
 
 /* Vuetify number input component.
  *
@@ -67,32 +69,20 @@ const NAMED_TYPES = {
 // registry of GraphQL "kinds" (e.g. LIST)
 // {namedType: {is: ComponentClass, prop1: value, ...}}
 const KINDS = {
-  LIST: {
-    is: GList
-  },
   NON_NULL: {
     is: GNonNull
+  },
+  LIST: {
+    is: GList
   }
 }
 
 export default {
-  name: 'form-input',
+  name: 'g-form-input',
+
+  mixins: [formElement],
 
   props: {
-    // the GraphQL type this input represents
-    gqlType: {
-      type: Object,
-      required: true
-    },
-    // the form label for this input
-    label: {
-      type: String,
-      required: true
-    },
-    // the value (v-model is actually syntactic sugar for this)
-    value: {
-      required: true
-    },
     // dictionary of props for overriding default values
     propOverrides: {
       type: Object,
@@ -105,22 +95,6 @@ export default {
   }),
 
   computed: {
-    /* The model we pass to the form input.
-     *
-     * Note the v-model approach does not work with nesting out of the box,
-     * you need to capture and propagate "input" events up the component tree
-     * to enable this nested structure of components to share the same model
-     * and be managed by Vue correctly.
-     */
-    model: {
-      get () {
-        return this.value
-      },
-      set (val) {
-        this.$emit('input', val)
-      }
-    },
-
     /* The props to pass to the form input.
      *
      * Note, this includes the "is" prop which tells Vue which component class

--- a/src/components/graphqlFormGenerator/FormInput.vue
+++ b/src/components/graphqlFormGenerator/FormInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <!-- NOTE: the is field domes from `props` -->
+  <!-- NOTE: the is field comes from `props` -->
   <!-- eslint-disable-next-line vue/require-component-is -->
   <component
    v-model="model"
@@ -141,8 +141,9 @@ export default {
       } else if (KINDS[kind]) {
         componentProps = KINDS[kind]
       } else {
-        componentProps = NAMED_TYPES['String']
-        console.log(
+        componentProps = NAMED_TYPES.String
+        // eslint-disable-next-line no-console
+        console.error(
           'Warning: falling back to string for ' +
           `type: ${this.gqlType.name}, kind: ${this.gqlType.kind}`
         )
@@ -154,7 +155,7 @@ export default {
 
       // rules is a list so needs special treatment
       ret.rules = []
-      for (let prop in props) {
+      for (const prop in props) {
         if (prop.rules) {
           ret.rules.push(...prop.rules)
         }

--- a/src/components/graphqlFormGenerator/components/FormInput.vue
+++ b/src/components/graphqlFormGenerator/components/FormInput.vue
@@ -1,0 +1,73 @@
+<template>
+  <component
+   v-model="componentValue"
+   :is="componentClass"
+   :label="label"
+   :gqlType="gqlType"
+  />
+</template>
+
+<script>
+import { VTextField } from 'vuetify/lib/components/VTextField'
+import GList from '@/components/graphqlFormGenerator/components/List'
+import GNonNull from '@/components/graphqlFormGenerator/components/NonNull'
+
+const TYPE_COMPONENTS = {
+  String: VTextField,
+}
+
+const KIND_COMPONENTS = {
+    LIST: GList,
+    NON_NULL: GNonNull
+}
+
+export default {
+  name: 'form-input',
+
+  props: {
+    gqlType: {
+      type: Object,
+      required: true
+    },
+    label: {
+      type: String,
+      required: true
+    },
+    value: {
+      required: true
+    }
+  },
+
+  computed: {
+    componentValue: {
+      get () {
+        return this.value
+      },
+      set (val) {
+        this.$emit('input', val)
+      }
+    },
+
+    componentClass () {
+      const name = this.gqlType.name
+      const kind = this.gqlType.kind
+      // const ofType = this.gqlType.ofType
+
+      // TODO: move to rule based system to allow changing
+      //       of parent compoents based on child types
+
+      if (TYPE_COMPONENTS[name]) {
+        return TYPE_COMPONENTS[name]
+      }
+      if (KIND_COMPONENTS[kind]) {
+        return KIND_COMPONENTS[kind]
+      }
+
+      console.log(
+        `Warning: falling back to string for ${this.gqlType.name}, ${this.gqlType.kind}`
+      )
+      return TYPE_COMPONENTS['String']
+    }
+  }
+}
+</script>

--- a/src/components/graphqlFormGenerator/components/FormInput.vue
+++ b/src/components/graphqlFormGenerator/components/FormInput.vue
@@ -1,7 +1,6 @@
 <template>
-  <!-- TODO: merge props in a method so rules are preserved -->
   <component
-   v-model="componentValue"
+   v-model="model"
    v-bind="Object.assign({}, defaultProps, props, propOverrides)"
    :label="label"
    :gqlType="gqlType"
@@ -13,12 +12,15 @@ import { VTextField } from 'vuetify/lib/components/VTextField'
 import GList from '@/components/graphqlFormGenerator/components/List'
 import GNonNull from '@/components/graphqlFormGenerator/components/NonNull'
 
+// default props for all form inputs
 const DEFAULT_PROPS = {
   filled: true,
   rounded: true,
 }
 
-const TYPE_COMPONENTS = {
+// registry of GraphQL "named types" (e.g. String)
+// {namedType: {is: ComponentClass, prop1: value, ...}}
+const NAMED_TYPES = {
   String: {
     is: VTextField,
   },
@@ -31,7 +33,9 @@ const TYPE_COMPONENTS = {
   }
 }
 
-const KIND_COMPONENTS = {
+// registry of GraphQL "kinds" (e.g. LIST)
+// {namedType: {is: ComponentClass, prop1: value, ...}}
+const KINDS = {
     LIST: {
       is: GList
     },
@@ -44,17 +48,21 @@ export default {
   name: 'form-input',
 
   props: {
+    // the GraphQL type this input represents
     gqlType: {
       type: Object,
       required: true
     },
+    // the form label for this input
     label: {
       type: String,
       required: true
     },
+    // the value (v-model is actually syntactic sugar for this)
     value: {
       required: true
     },
+    // dictionary of props for overriding default values
     propOverrides: {
       type: Object,
       default: () => {{}}
@@ -66,7 +74,14 @@ export default {
   }),
 
   computed: {
-    componentValue: {
+    /* The model we pass to the form input.
+     *
+     * Note the v-model approach does not work with nesting out of the box,
+     * you need to capture and propagate "input" events up the component tree
+     * to enable this nested structure of components to share the same model
+     * and be managed by Vue correctly.
+     */
+    model: {
       get () {
         return this.value
       },
@@ -75,8 +90,14 @@ export default {
       }
     },
 
-    // TODO: move to rule based system to allow changing
-    //       of parent components based on child types
+    /* The props to pass to the form input.
+     *
+     * Note, this includes the "is" prop which tells Vue which component class
+     * to use.
+     *
+     * TODO: move to rule based system to allow changing
+     *       of parent components based on child types
+     */
     props () {
       // get the default props for this graphQL type
       const name = this.gqlType.name
@@ -84,13 +105,13 @@ export default {
       // const ofType = this.gqlType.ofType
 
       var componentProps
-      if (TYPE_COMPONENTS[name]) {
-        componentProps = TYPE_COMPONENTS[name]
+      if (NAMED_TYPES[name]) {
+        componentProps = NAMED_TYPES[name]
       }
-      else if (KIND_COMPONENTS[kind]) {
-        componentProps = KIND_COMPONENTS[kind]
+      else if (KINDS[kind]) {
+        componentProps = KINDS[kind]
       } else {
-        componentProps = TYPE_COMPONENTS['String']
+        componentProps = NAMED_TYPES['String']
         console.log(
           'Warning: falling back to string for ' +
           `type: ${this.gqlType.name}, kind: ${this.gqlType.kind}`

--- a/src/components/graphqlFormGenerator/components/FormInput.vue
+++ b/src/components/graphqlFormGenerator/components/FormInput.vue
@@ -1,7 +1,8 @@
 <template>
+  <!-- TODO: merge props in a method so rules are preserved -->
   <component
    v-model="componentValue"
-   :is="componentClass"
+   v-bind="Object.assign({}, defaultProps, props, propOverrides)"
    :label="label"
    :gqlType="gqlType"
   />
@@ -12,13 +13,31 @@ import { VTextField } from 'vuetify/lib/components/VTextField'
 import GList from '@/components/graphqlFormGenerator/components/List'
 import GNonNull from '@/components/graphqlFormGenerator/components/NonNull'
 
+const DEFAULT_PROPS = {
+  filled: true,
+  rounded: true,
+}
+
 const TYPE_COMPONENTS = {
-  String: VTextField,
+  String: {
+    is: VTextField,
+  },
+  Int: {
+    is: VTextField,
+    type: 'number',
+    rules: [
+      x => Number.isInteger(x) || 'Integer'
+    ]
+  }
 }
 
 const KIND_COMPONENTS = {
-    LIST: GList,
-    NON_NULL: GNonNull
+    LIST: {
+      is: GList
+    },
+    NON_NULL: {
+      is: GNonNull
+    }
 }
 
 export default {
@@ -35,8 +54,16 @@ export default {
     },
     value: {
       required: true
+    },
+    propOverrides: {
+      type: Object,
+      default: () => {{}}
     }
   },
+
+  data: () => ({
+    defaultProps: DEFAULT_PROPS
+  }),
 
   computed: {
     componentValue: {
@@ -48,25 +75,41 @@ export default {
       }
     },
 
-    componentClass () {
+    // TODO: move to rule based system to allow changing
+    //       of parent components based on child types
+    props () {
+      // get the default props for this graphQL type
       const name = this.gqlType.name
       const kind = this.gqlType.kind
       // const ofType = this.gqlType.ofType
 
-      // TODO: move to rule based system to allow changing
-      //       of parent compoents based on child types
-
+      var componentProps
       if (TYPE_COMPONENTS[name]) {
-        return TYPE_COMPONENTS[name]
+        componentProps = TYPE_COMPONENTS[name]
       }
-      if (KIND_COMPONENTS[kind]) {
-        return KIND_COMPONENTS[kind]
+      else if (KIND_COMPONENTS[kind]) {
+        componentProps = KIND_COMPONENTS[kind]
+      } else {
+        componentProps = TYPE_COMPONENTS['String']
+        console.log(
+          'Warning: falling back to string for ' +
+          `type: ${this.gqlType.name}, kind: ${this.gqlType.kind}`
+        )
       }
 
-      console.log(
-        `Warning: falling back to string for ${this.gqlType.name}, ${this.gqlType.kind}`
-      )
-      return TYPE_COMPONENTS['String']
+      // merge this in with default and override props
+      const props = [DEFAULT_PROPS, componentProps, this.propOverrides]
+      const ret = Object.assign({}, ...props)
+
+      // rules is a list so needs special treatment
+      ret.rules = []
+      for (let prop in props) {
+        if (prop.rules) {
+          ret.rules.push(...prop.rules)
+        }
+      }
+
+      return ret
     }
   }
 }

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -5,11 +5,11 @@
     </v-row>
     <v-row
      v-for="(item, index) in value"
-     v-bind="index"
     >
       <v-col cols="10">
         <component
          v-model="value[index]"
+         :propOverrides="{'dense': true}"
          :gqlType="gqlType.ofType"
          :is="FormInput"
          label=""

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -56,54 +56,12 @@
 </template>
 
 <script>
-import FormInput from '@/components/graphqlFormGenerator/FormInput'
+import { formElement } from '@/components/graphqlFormGenerator/mixins'
 
 export default {
-  name: 'non-null',
+  name: 'g-list',
 
-  components: {
-    'form-input': FormInput
-  },
-
-  props: {
-    // the GraphQL type this input represents
-    gqlType: {
-      type: Object,
-      required: true
-    },
-    // the form label for this input
-    label: {
-      type: String,
-      required: true
-    },
-    // the value (v-model is actually syntactic sugar for this)
-    value: {
-      required: true
-    }
-  },
-
-  data: () => ({
-    FormInput: FormInput
-  }),
-
-  computed: {
-    /* The model we pass to the form input.
-     *
-     * Note the v-model approach does not work with nesting out of the box,
-     * you need to capture and propagate "input" events up the component tree
-     * to enable this nested structure of components to share the same model
-     * and be managed by Vue correctly.
-     */
-    model: {
-      get () {
-        return this.value
-      },
-
-      set (val) {
-        this.$emit('input', val)
-      }
-    }
-  },
+  mixins: [formElement],
 
   methods: {
     /* Add an item to the list. */

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <ul>
+      <li>
+        <slot></slot>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -7,6 +7,7 @@
     <!-- The List -->
     <v-row
      v-for="(item, index) in value"
+     :key="index"
     >
       <v-col cols="10">
         <!-- The input -->
@@ -55,8 +56,7 @@
 </template>
 
 <script>
-import PassProps from 'vue-pass-props'
-import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
+import FormInput from '@/components/graphqlFormGenerator/FormInput'
 
 export default {
   name: 'non-null',
@@ -107,7 +107,7 @@ export default {
 
   methods: {
     /* Add an item to the list. */
-    add() {
+    add () {
       this.value.push(null)
     },
 

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -1,13 +1,105 @@
 <template>
-  <div>
-    <ul>
-      <li>
-        <slot></slot>
-      </li>
-    </ul>
-  </div>
+  <v-container>
+    <v-row>
+      {{label}}
+    </v-row>
+    <v-row
+     v-for="(item, index) in value"
+     v-bind="index"
+    >
+      <v-col cols="10">
+        <component
+         v-model="value[index]"
+         :gqlType="gqlType.ofType"
+         :is="FormInput"
+         label=""
+        />
+        <!--
+          NOTE: we use :is here due to a nested component
+          registration issue.
+        -->
+      </v-col>
+      <v-col cols="2">
+        <v-btn
+         class="mx-2"
+         fab
+         dark
+         x-small
+         color="primary"
+         @click="remove(index)"
+        >
+          <v-icon dark>mdi-minus</v-icon>
+        </v-btn>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="2">
+        <v-btn
+         class="mx-2"
+         fab
+         dark
+         x-small
+         color="primary"
+         @click="add"
+        >
+          <v-icon dark>mdi-plus</v-icon>
+        </v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
-export default {}
+import PassProps from 'vue-pass-props'
+import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
+
+export default {
+  name: 'non-null',
+
+  components: {
+    'form-input': FormInput
+  },
+
+  props: {
+    'value': {
+      required: true
+    },
+    'gqlType': {
+      type: Object,
+      required: true
+    },
+    'label': {
+      type: String,
+      required: true
+    }
+  },
+
+  data: () => ({
+    'FormInput': FormInput
+  }),
+
+  computed: {
+    componentValue: {
+      // v-model for the child components
+      get () {
+        return this.value
+      },
+
+      set (val) {
+        this.$emit('input', val)
+      }
+    }
+  },
+
+  methods: {
+    // add and remove elements from the list
+    add() {
+      this.value.push(null)
+    },
+
+    remove (index) {
+      this.value.splice(index, 1)
+    }
+  }
+}
 </script>

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -1,12 +1,15 @@
 <template>
   <v-container>
+    <!-- The title -->
     <v-row>
       {{label}}
     </v-row>
+    <!-- The List -->
     <v-row
      v-for="(item, index) in value"
     >
       <v-col cols="10">
+        <!-- The input -->
         <component
          v-model="value[index]"
          :propOverrides="{'dense': true}"
@@ -20,6 +23,7 @@
         -->
       </v-col>
       <v-col cols="2">
+        <!-- The remove row button -->
         <v-btn
          class="mx-2"
          fab
@@ -34,6 +38,7 @@
     </v-row>
     <v-row>
       <v-col cols="2">
+        <!-- The add row button -->
         <v-btn
          class="mx-2"
          fab
@@ -61,15 +66,18 @@ export default {
   },
 
   props: {
-    'value': {
-      required: true
-    },
-    'gqlType': {
+    // the GraphQL type this input represents
+    gqlType: {
       type: Object,
       required: true
     },
-    'label': {
+    // the form label for this input
+    label: {
       type: String,
+      required: true
+    },
+    // the value (v-model is actually syntactic sugar for this)
+    value: {
       required: true
     }
   },
@@ -79,8 +87,14 @@ export default {
   }),
 
   computed: {
-    componentValue: {
-      // v-model for the child components
+    /* The model we pass to the form input.
+     *
+     * Note the v-model approach does not work with nesting out of the box,
+     * you need to capture and propagate "input" events up the component tree
+     * to enable this nested structure of components to share the same model
+     * and be managed by Vue correctly.
+     */
+    model: {
       get () {
         return this.value
       },
@@ -92,11 +106,12 @@ export default {
   },
 
   methods: {
-    // add and remove elements from the list
+    /* Add an item to the list. */
     add() {
       this.value.push(null)
     },
 
+    /* Remove the item at `index` from the list. */
     remove (index) {
       this.value.splice(index, 1)
     }

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -83,7 +83,7 @@ export default {
   },
 
   data: () => ({
-    'FormInput': FormInput
+    FormInput: FormInput
   }),
 
   computed: {

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -1,23 +1,29 @@
 <template>
-  <div>
-    NON_NULL:
-    label({{label}}), value({{value}})
-    <!--PassProps
-      :label="label"
-      :value="value"
-    -->
-      <slot
-      />
-    <!--/PassProps-->
-  </div>
+  <component
+   v-model="componentValue"
+   :gqlType="gqlType.ofType"
+   :label="label"
+   :is="FormInput"
+  />
 </template>
 
 <script>
 import PassProps from 'vue-pass-props'
+import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
 
 export default {
+  name: 'non-null',
+
+  components: {
+    'form-input': FormInput
+  },
+
   props: {
     'value': {
+      required: true
+    },
+    'gqlType': {
+      type: Object,
       required: true
     },
     'label': {
@@ -25,8 +31,20 @@ export default {
       required: true
     }
   },
-  components: {
-    PassProps
+
+  data: () => ({
+    'FormInput': FormInput
+  }),
+
+  computed: {
+    componentValue: {
+      get () {
+        return this.value
+      },
+      set (val) {
+        this.$emit('input', val)
+      }
+    }
   }
 }
 </script>

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -36,7 +36,7 @@ export default {
   },
 
   data: () => ({
-    'FormInput': FormInput
+    FormInput: FormInput
   }),
 
   computed: {

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -9,8 +9,7 @@
 </template>
 
 <script>
-import PassProps from 'vue-pass-props'
-import FormInput from '@/components/graphqlFormGenerator/components/FormInput'
+import FormInput from '@/components/graphqlFormGenerator/FormInput'
 
 export default {
   name: 'non-null',

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    NON_NULL:
+    label({{label}}), value({{value}})
+    <!--PassProps
+      :label="label"
+      :value="value"
+    -->
+      <slot
+      />
+    <!--/PassProps-->
+  </div>
+</template>
+
+<script>
+import PassProps from 'vue-pass-props'
+
+export default {
+  props: {
+    'value': {
+      required: true
+    },
+    'label': {
+      type: String,
+      required: true
+    }
+  },
+  components: {
+    PassProps
+  }
+}
+</script>

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -1,8 +1,9 @@
 <template>
   <component
    v-model="componentValue"
+   :propOverrides="{rules: [(x) => !!x || 'Required!']}"
    :gqlType="gqlType.ofType"
-   :label="label"
+   :label="label + ' (required)'"
    :is="FormInput"
   />
 </template>

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -9,52 +9,10 @@
 </template>
 
 <script>
-import FormInput from '@/components/graphqlFormGenerator/FormInput'
+import { formElement } from '@/components/graphqlFormGenerator/mixins'
 
 export default {
-  name: 'non-null',
-
-  components: {
-    'form-input': FormInput
-  },
-
-  props: {
-    // the GraphQL type this input represents
-    gqlType: {
-      type: Object,
-      required: true
-    },
-    // the form label for this input
-    label: {
-      type: String,
-      required: true
-    },
-    // the value (v-model is actually syntactic sugar for this)
-    value: {
-      required: true
-    }
-  },
-
-  data: () => ({
-    FormInput: FormInput
-  }),
-
-  computed: {
-    /* The model we pass to the form input.
-     *
-     * Note the v-model approach does not work with nesting out of the box,
-     * you need to capture and propagate "input" events up the component tree
-     * to enable this nested structure of components to share the same model
-     * and be managed by Vue correctly.
-     */
-    model: {
-      get () {
-        return this.value
-      },
-      set (val) {
-        this.$emit('input', val)
-      }
-    }
-  }
+  name: 'g-non-null',
+  mixins: [formElement]
 }
 </script>

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-   v-model="componentValue"
+   v-model="model"
    :propOverrides="{rules: [(x) => !!x || 'Required!']}"
    :gqlType="gqlType.ofType"
    :label="label + ' (required)'"
@@ -20,15 +20,18 @@ export default {
   },
 
   props: {
-    'value': {
-      required: true
-    },
-    'gqlType': {
+    // the GraphQL type this input represents
+    gqlType: {
       type: Object,
       required: true
     },
-    'label': {
+    // the form label for this input
+    label: {
       type: String,
+      required: true
+    },
+    // the value (v-model is actually syntactic sugar for this)
+    value: {
       required: true
     }
   },
@@ -38,7 +41,14 @@ export default {
   }),
 
   computed: {
-    componentValue: {
+    /* The model we pass to the form input.
+     *
+     * Note the v-model approach does not work with nesting out of the box,
+     * you need to capture and propagate "input" events up the component tree
+     * to enable this nested structure of components to share the same model
+     * and be managed by Vue correctly.
+     */
+    model: {
       get () {
         return this.value
       },

--- a/src/components/graphqlFormGenerator/mixins.js
+++ b/src/components/graphqlFormGenerator/mixins.js
@@ -1,0 +1,47 @@
+import FormInput from '@/components/graphqlFormGenerator/FormInput'
+
+export const formElement = {
+  components: {
+    'form-input': FormInput
+  },
+
+  props: {
+    // the GraphQL type this input represents
+    gqlType: {
+      type: Object,
+      required: true
+    },
+    // the form label for this input
+    label: {
+      type: String,
+      required: true
+    },
+    // the value (v-model is actually syntactic sugar for this)
+    value: {
+      required: true
+    }
+  },
+
+  data: () => ({
+    FormInput: FormInput
+  }),
+
+  computed: {
+    /* The model we pass to the form input.
+     *
+     * Note the v-model approach does not work with nesting out of the box,
+     * you need to capture and propagate "input" events up the component tree
+     * to enable this nested structure of components to share the same model
+     * and be managed by Vue correctly.
+     */
+    model: {
+      get () {
+        return this.value
+      },
+
+      set (val) {
+        this.$emit('input', val)
+      }
+    }
+  }
+}

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -32,6 +32,15 @@ export default [
     props: true
   },
   {
+    path: '/workflows/mutations',
+    view: 'Mutations',
+    name: 'mutations',
+    meta: {
+      layout: 'default'
+    },
+    props: true
+  },
+  {
     path: '/user-profile',
     name: i18n.t('App.userProfile'),
     view: 'UserProfile',

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -32,7 +32,7 @@ export default [
     props: true
   },
   {
-    path: '/workflows/mutations',
+    path: '/mutations',
     view: 'Mutations',
     name: 'mutations',
     meta: {

--- a/src/views/Mutations.vue
+++ b/src/views/Mutations.vue
@@ -1,18 +1,23 @@
 <template>
   <div class="c-mutations">
-    <h1>Mutations</h1>
-    <ul>
-      <li v-for="mutation in mutations">{{ mutation['name'] }}</li>
-    </ul>
-    <h1>Form</h1>
-    <div v-if="mutations[4]">
+    <div v-if="!loaded">
+      Loading...
+    </div>
+    <div v-if="loaded">
+      <v-select
+        v-if="mutations"
+        v-model="selectedMutation"
+        :items="mutationNames"
+        label="Mutation"
+      />
       <v-card
-        class="mx-auto"
+        v-if="selectedMutation"
+        class="mx-auto d-inline-block"
         max-width="500"
         outlined
       >
-        <!--FormGenerator :mutation='mutations[4]' /-->
-        <FormGenerator :mutation='sampleMutation' />
+        <!--FormGenerator :mutation='sampleMutation' /-->
+        <FormGenerator :mutation='getMutation(selectedMutation)' />
       </v-card>
     </div>
   </div>
@@ -30,6 +35,8 @@ export default {
   },
 
   data: () => ({
+    loaded: false,
+    selectedMutation: null,
     mutations: {},
     sampleMutation: {
       name: 'My Mutation',
@@ -77,6 +84,19 @@ export default {
     }
   }),
 
+  computed: {
+    mutationNames () {
+      const names = []
+      if (!this.mutations) {
+        return names
+      }
+      for (let mutation of this.mutations) {
+        names.push(mutation.name)
+      }
+      return names
+    },
+  },
+
   created () {
     this.getSchema()
   },
@@ -115,8 +135,17 @@ export default {
         fetchPolicy: 'no-cache'
       }).then((response) => {
         this.mutations = response.data.__schema.mutationType.fields
+        this.loaded = true
       })
     },
+
+    getMutation (name) {
+      for (let mutation of this.mutations) {
+        if (mutation.name === name) {
+          return mutation
+        }
+      }
+    }
   }
 
 }

--- a/src/views/Mutations.vue
+++ b/src/views/Mutations.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="c-mutations">
+    <h1>{{ mutationName }}</h1>
+    <h2>JSON Schema</h2>
+    <pre>{{ mutations[mutationName] }}</pre>
+    <h2>Form</h2>
+    <FormSchema
+      class="form"
+      :schema="mutations[mutationName]"
+      v-model="model"
+      v-if="mutations[mutationName]"
+    >
+      <div class="buttons">
+        <button type="submit">Submit</button>
+      </div>
+    </FormSchema>
+  </div>
+</template>
+
+<style>
+  .c-mutations > h1, .c-mutations > h2 {
+    color: blue
+  }
+</style>
+
+<script>
+import gql from 'graphql-tag'
+import { buildClientSchema } from 'graphql/utilities/buildClientSchema'
+import { graphqlSync, introspectionQuery } from 'graphql'
+import { fromIntrospectionQuery } from 'graphql-2-json-schema'
+import FormSchema from '@formschema/native'
+
+export default {
+  components: {
+    FormSchema
+  },
+
+  data: () => ({
+    mutationName: 'nudgeWorkflow',
+    mutations: [],
+    model: {}
+  }),
+
+  created () {
+    this.getMutations()
+  },
+
+  methods: {
+    getGraphqlSchema (introspection) {
+      // graphql introspectionQuery
+      return graphqlSync(
+        buildClientSchema(introspection['data']),
+        introspectionQuery
+      ).data
+    },
+
+    getJsonSchema (graphqlSchema) {
+      return fromIntrospectionQuery(graphqlSchema)
+    },
+
+    extractMutations (jsonSchema) {
+      const mutations = jsonSchema.properties.Mutation.properties
+      const ret = {}
+      var mutation = {}
+      for (let mutationName in mutations) {
+        // turn these into valid json schema forms
+        // (the translation doesn't work well with mutation types)
+        mutation = {
+          type: 'object',
+          title: mutationName,
+          properties: mutations[mutationName].properties.arguments.properties
+        }
+        // add default metadata (not generated in translation)
+        for (let argumentName in mutation.properties) {
+          mutation.properties[argumentName].attrs = {
+            placeholder: argumentName,
+            title: argumentName
+          }
+        }
+        ret[mutationName] = mutation
+      }
+      return ret
+    },
+
+    getMutations () {
+      this.$workflowService.apolloClient.query({
+        query: gql(introspectionQuery),
+        fetchPolicy: 'no-cache'
+      }).then((response) => {
+        // extract graphql schema via introspection
+        const graphqlSchema = this.getGraphqlSchema(response)
+
+        // translate graphql schema to json schema
+        const jsonSchema = this.getJsonSchema(graphqlSchema)
+
+        // extract mutations from json schema
+        const mutations = this.extractMutations(jsonSchema)
+
+        this.mutations = mutations
+      })
+    }
+  }
+
+}
+</script>

--- a/src/views/Mutations.vue
+++ b/src/views/Mutations.vue
@@ -116,27 +116,7 @@ export default {
       }).then((response) => {
         this.mutations = response.data.__schema.mutationType.fields
       })
-    }
-
-    /*
-    getGraphqlSchema (introspection) {
-      return graphqlSync(
-        buildClientSchema(introspection['data']),
-        introspectionQuery
-      ).data
     },
-
-    getSchema () {
-      // extract graphql schema via introspection
-      this.$workflowService.apolloClient.query({
-        query: gql(introspectionQuery),
-        fetchPolicy: 'no-cache'
-      }).then((response) => {
-        const graphqlSchema = this.getGraphqlSchema(response)
-        this.schema = graphqlSchema
-      })
-    }
-    */
   }
 
 }

--- a/src/views/Mutations.vue
+++ b/src/views/Mutations.vue
@@ -90,7 +90,7 @@ export default {
       if (!this.mutations) {
         return names
       }
-      for (let mutation of this.mutations) {
+      for (const mutation of this.mutations) {
         names.push(mutation.name)
       }
       return names
@@ -106,8 +106,8 @@ export default {
       // we are only interested in mutations so can make our life
       // a little easier by restricting the scope of the default
       // introspection query
-      var fullIntrospection = gql(introspectionQuery)
-      var mutationQuery = gql(`
+      const fullIntrospection = gql(introspectionQuery)
+      const mutationQuery = gql(`
         query {
           __schema {
             mutationType {
@@ -140,7 +140,7 @@ export default {
     },
 
     getMutation (name) {
-      for (let mutation of this.mutations) {
+      for (const mutation of this.mutations) {
         if (mutation.name === name) {
           return mutation
         }

--- a/src/views/Mutations.vue
+++ b/src/views/Mutations.vue
@@ -11,7 +11,8 @@
         max-width="500"
         outlined
       >
-        <FormGenerator :mutation='mutations[4]' />
+        <!--FormGenerator :mutation='mutations[4]' /-->
+        <FormGenerator :mutation='sampleMutation' />
       </v-card>
     </div>
   </div>
@@ -29,7 +30,51 @@ export default {
   },
 
   data: () => ({
-    mutations: {}
+    mutations: {},
+    sampleMutation: {
+      name: 'My Mutation',
+      description: 'Test example.',
+      args: [
+        {
+          name: 'MyString',
+          type: {
+            name: 'String',
+            kind: 'SCALAR'
+          }
+        },
+        {
+          name: 'MyInteger',
+          type: {
+            name: 'Int',
+            kind:' SCALAR'
+          }
+        },
+        {
+          name: 'MyNonNull',
+          defaultValue: 'cant null this',
+          type: {
+            name: null,
+            kind: 'NON_NULL',
+            ofType: {
+              name: 'String',
+              kind: 'SCALAR'
+            }
+          }
+        },
+        {
+          name: 'MyStringList',
+          defaultValue: ['a', 'b', 'c'],
+          type: {
+            name: null,
+            kind: 'LIST',
+            ofType: {
+              name: 'String',
+              kind: 'SCALAR'
+            }
+          }
+        }
+      ]
+    }
   }),
 
   created () {

--- a/src/views/Mutations.vue
+++ b/src/views/Mutations.vue
@@ -53,7 +53,7 @@ export default {
           name: 'MyInteger',
           type: {
             name: 'Int',
-            kind:' SCALAR'
+            kind: 'SCALAR'
           }
         },
         {
@@ -94,7 +94,7 @@ export default {
         names.push(mutation.name)
       }
       return names
-    },
+    }
   },
 
   created () {

--- a/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
+++ b/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
@@ -1,0 +1,145 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+import FormGenerator from '@/components/graphqlFormGenerator/FormGenerator'
+import { expect } from 'chai'
+
+// suppress "ReferenceError: requestAnimationFrame is not defined" errors
+global.requestAnimationFrame = cb => cb()
+
+const BASIC_MUTATION = {
+  name: 'My Mutation',
+  description: 'Test example.',
+  args: [
+    {
+      name: 'MyString',
+      defaultValue: 'MyDefault',
+      type: {
+        name: 'String',
+        kind: 'SCALAR'
+      }
+    },
+    {
+      name: 'MyInteger',
+      type: {
+        name: 'Int',
+        kind: 'SCALAR'
+      }
+    }
+  ]
+}
+
+describe('FormGenerator Component', () => {
+  it('should display mutation name and description', () => {
+    const localVue = createLocalVue()
+    const wrapper = mount(FormGenerator, {
+      localVue,
+      propsData: {
+        mutation: BASIC_MUTATION
+      }
+    })
+    const html = wrapper.html()
+    expect(html).to.contain('My Mutation')
+    expect(html).to.contain('Test example.')
+  })
+
+  it('should handle default values from the GraphQL schema', () => {
+    const localVue = createLocalVue()
+    const wrapper = mount(FormGenerator, {
+      localVue,
+      propsData: {
+        mutation: BASIC_MUTATION
+      }
+    })
+    expect(wrapper.vm.$data.model).to.deep.equal({
+      MyString: 'MyDefault',
+      MyInteger: null
+    })
+  })
+
+  it('should handle initial data', () => {
+    const localVue = createLocalVue()
+    const wrapper = mount(FormGenerator, {
+      localVue,
+      propsData: {
+        mutation: BASIC_MUTATION,
+        initialData: {
+          MyString: 'Foo'
+        }
+      }
+    })
+    expect(wrapper.vm.$data.model).to.deep.equal({
+      MyString: 'Foo',
+      MyInteger: null
+    })
+  })
+
+  it('should reset to initial conditions', () => {
+    const localVue = createLocalVue()
+    const wrapper = mount(FormGenerator, {
+      localVue,
+      propsData: {
+        mutation: BASIC_MUTATION,
+        initialData: {
+          MyString: 'Foo'
+        }
+      }
+    })
+    const before = wrapper.vm.$data.model
+    wrapper.vm.reset()
+    expect(wrapper.vm.$data.model).to.deep.equal(before)
+  })
+
+  it('should pick appropriate default types', () => {
+    [
+      [ // String => null
+        {
+          type: 'String',
+          kind: 'SCALAR'
+        },
+        null
+      ],
+      [ // NON_NULL<String> => null
+        {
+          type: null,
+          kind: 'NON_NULL',
+          ofType: {
+            type: 'String',
+            kind: 'SCALAR'
+          }
+        },
+        null
+      ],
+      [ // LIST<String> => []
+        {
+          type: null,
+          kind: 'LIST',
+          ofType: {
+            type: 'String',
+            kind: 'SCALAR'
+          }
+        },
+        []
+      ],
+      [ // NON_NULL<LIST<String>> => []
+        {
+          type: null,
+          kind: 'NON_NULL',
+          ofType: {
+            type: null,
+            kind: 'LIST',
+            ofType: {
+              type: 'String',
+              kind: 'SCALAR'
+            }
+          }
+        },
+        []
+      ]
+    ].forEach((item) => {
+      expect(
+        FormGenerator.methods.getNullValue(item[0])
+      ).to.deep.equal(
+        item[1]
+      )
+    })
+  })
+})


### PR DESCRIPTION
Addresses the first three points of #339 

This PR adds a temporary "mutations" view which lists available mutations and auto-generates forms for them on request.

This is orthogonal to https://github.com/cylc/cylc-flow/pull/3469 which makes the mutations more declarative and brings them more inline with the Cylc CLI.

Getting the nested components and data model working correctly took nearly all the time. Thanks for the `<component :is="class" />` suggestion @kinow, I would have wasted days otherwise :+1:.

**Overview:**

* Introspect the GraphQL schema for information about mutations.
* Auto-generate forms to act as interfaces to these mutations.
* When complete output JSON from these forms to be used as arguments in the GraphQL request.

**Caveats:**

* ~Some of the default values in the GraphQL schema are presently set as string representations for list types~. Either Graphene or GraphQL seems to convert all default types to JSON which is added as a string in the JSON response? This results in traceback and errors. :eyes: 
* Styling not yet complete.
* The abstraction form generator is roughly independent of the component library being used but there is't a proper interface for implementing different libraries as yet. Not a big job but probably a bridge to cross if and when we get to it.

**Justification:**

There are some tools out there which could have been used, instead I wrote this from scratch. Just to dump my reasoning down here for the record:

There is a potential pathway where we convert GraphQL -> JSONSchema -> Web Form -> JSON -> GraphQL Arguments.

* There are a lot of interfaces here and it gets a bit messy/
* Most of the tools are immature
* None of them seem to work with mutations properly (they are seem focused on the data model)
* Most don't support Vue or are written for other frameworks.
* None work with Vuetify.
* Supporting GraphQL mutation schema natively seems more natural.

**TODO:**

* [x] Vuetify doesn't have an integer field, it has a "number" mode to the text field. This outputs strings rather than number which won't do.
* [x] Testing (basic).
* [x] Consider using an inheritance or composition model to keep things DRY.
* [ ] Fix persistence of the `FormGenerator` model.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
