### PR TITLE
api-on-the-fly - part 2 - mutation association

### DIFF
--- a/src/components/graphqlFormGenerator/FormInput.vue
+++ b/src/components/graphqlFormGenerator/FormInput.vue
@@ -109,7 +109,7 @@ export default {
       const kind = this.gqlType.kind
       // const ofType = this.gqlType.ofType
 
-      var componentProps
+      let componentProps
       if (NAMED_TYPES[name]) {
         componentProps = NAMED_TYPES[name]
       } else if (KINDS[kind]) {

--- a/tests/unit/components/graphqlFormGenerator/mutations.vue.spec.js
+++ b/tests/unit/components/graphqlFormGenerator/mutations.vue.spec.js
@@ -1,0 +1,117 @@
+import { associate } from '@/views/Mutations'
+import { expect } from 'chai'
+
+const fooMutation = {
+  name: 'foo',
+  args: [
+    {
+      name: 'a',
+      type: {
+        name: 'FOO',
+        kind: 'INPUT_OBJECT'
+      }
+    },
+    {
+      name: 'b',
+      type: {
+        name: 'String',
+        kind: 'SCALAR'
+      }
+    }
+  ]
+}
+
+const fooListMutation = {
+  name: 'foo',
+  args: [
+    {
+      // List<Foo>
+      name: 'a',
+      type: {
+        name: null,
+        kind: 'LIST',
+        ofType: {
+          name: 'FOO',
+          kind: 'INPUT_OBJECT'
+        }
+      }
+    }
+  ]
+}
+
+const fooNestedMutation = {
+  name: 'foo',
+  args: [
+    {
+      // NonNull<List<NonNull<Foo>>>
+      name: 'a',
+      type: {
+        name: null,
+        kind: 'NON_NULL',
+        ofType: {
+          name: null,
+          kind: 'LIST',
+          ofType: {
+            name: null,
+            kind: 'NON_NULL',
+            ofType: {
+              name: 'FOO',
+              kinda: 'INPUT_OBJECT'
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+
+const objects = {
+  foo: [['FOO', false]],
+  bar: [['BAR', false], ['BARS', true]]
+}
+
+// okay so it's a view not a compoent of formgenerator, this functionality
+// will get collected and tidied in a future PR
+describe('Mutations Component', () => {
+  it('should associate mutations with objects', () => {
+    expect(
+      associate([fooMutation], objects)
+    ).to.deep.equal({
+      foo: [
+        {
+          argument: 'a',
+          cylcObject: 'foo',
+          multiple: false
+        }
+      ]
+    })
+  })
+
+  it('should detect when a field is used in a collection', () => {
+    expect(
+      associate([fooListMutation], objects)
+    ).to.deep.equal({
+      foo: [
+        {
+          argument: 'a',
+          cylcObject: 'foo',
+          multiple: true
+        }
+      ]
+    })
+  })
+
+  it('should detect fields in nested structures', () => {
+    expect(
+      associate([fooNestedMutation], objects)
+    ).to.deep.equal({
+      foo: [
+        {
+          argument: 'a',
+          cylcObject: 'foo',
+          multiple: true
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
Addresses the fourth point of #339 

~**Note - Built on top of #357**~ now merged
**Note - Works with the data types defined in https://github.com/cylc/cylc-flow/pull/3469**

Use the argument types defined in the GraphQL schema to associate mutations with "Cylc Objects" by which I mean workflows, cycle point, tasks, etc.

This mapping will be used when you right-click on something (say a task in the tree view) to work out which mutations are relevant to the thing you clicked on.

At the moment this is built into the temporary Mutations view.

**Example**

![Screenshot from 2020-01-10 14-41-32](https://user-images.githubusercontent.com/16705946/72118856-6719d780-33b7-11ea-8330-0d5a2a21e559.png)

**TODO**

* [ ] Test

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change long necessary, functionality not exposed to users (yet)
- [x] No documentation update required.
