### PR TITLE
drop IE support?

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,300italic,400italic' rel="stylesheet" type="text/css">
     <link href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" rel="stylesheet">


### PR DESCRIPTION
Quick question, should we be setting the `X-UA-Compatible` flag?

Probably no harm done, Vuetify apparently [supports IE11 via pollyfill](https://vuetifyjs.com/en/getting-started/browser-support).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
