### PR TITLE
Graph view cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7445,15 +7445,6 @@
         "lodash.debounce": "^4.0.8"
       }
     },
-    "cytoscape-cise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cise/-/cytoscape-cise-1.0.0.tgz",
-      "integrity": "sha512-Y1NPaUo4fN992XJTEIDd4oPVkv8BsDSrFBHSB38caDu8PcmHUyl8/Q8K5wvqdTeti1mLR9IX4/o2RyuObh+P7Q==",
-      "requires": {
-        "avsdf-base": "^1.0.0",
-        "cose-base": "^1.0.0"
-      }
-    },
     "cytoscape-cose-bilkent": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7470,11 +7470,6 @@
         "dagre": "^0.8.2"
       }
     },
-    "cytoscape-expand-collapse": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-expand-collapse/-/cytoscape-expand-collapse-3.2.0.tgz",
-      "integrity": "sha512-do33Kn4S7yP4QzdV0yK+aQOsXxTBfhA+BORWynKspkn5hw7kuktc5wKJEpr8jq7Vb9tT1bFSOMFr/IGbYJNG/w=="
-    },
     "cytoscape-navigator": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/cytoscape-navigator/-/cytoscape-navigator-1.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6879,14 +6879,6 @@
         "vary": "^1"
       }
     },
-    "cose-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.1.tgz",
-      "integrity": "sha512-LErvsHUOzYseXGFKWGCAQBTePO1iYZ9JL+YZlmoyqZ7EDcBzrEMRSouOGszQl72J6VK0AVrJbnNCf3eciqy7SA==",
-      "requires": {
-        "layout-base": "^1.0.0"
-      }
-    },
     "cosmiconfig": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -7445,15 +7437,7 @@
         "lodash.debounce": "^4.0.8"
       }
     },
-    "cytoscape-cose-bilkent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-      "requires": {
-        "cose-base": "^1.0.0"
-      }
-    },
-    "cytoscape-dagre": {
+     "cytoscape-dagre": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.2.2.tgz",
       "integrity": "sha512-zsg36qNwua/L2stJSWkcbSDcvW3E6VZf6KRe6aLnQJxuXuz89tMqI5EVYVKEcNBgzTEzFMFv0PE3T0nD4m6VDw==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7454,14 +7454,6 @@
         "cose-base": "^1.0.0"
       }
     },
-    "cytoscape-cola": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.3.0.tgz",
-      "integrity": "sha512-xblxlCH8JXGLdH6XMUBJY3xBUJuL1rLy8bLMGvqkvoPHSbBfV+/klMWoqwervVKWOmFHPwUdihtxy8stG4RM5g==",
-      "requires": {
-        "webcola": "^3.3.6"
-      }
-    },
     "cytoscape-cose-bilkent": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
@@ -21046,17 +21038,6 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
-      }
-    },
-    "webcola": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
-      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
-      "requires": {
-        "d3-dispatch": "^1.0.3",
-        "d3-drag": "^1.0.4",
-        "d3-shape": "^1.3.5",
-        "d3-timer": "^1.0.5"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "apollo-boost": "^0.4.4",
     "axios-fetch": "^1.1.0",
     "cytoscape": "^3.9.0",
-    "cytoscape-cose-bilkent": "^4.0.0",
     "cytoscape-dagre": "^2.2.2",
     "cytoscape-expand-collapse": "^3.1.2",
     "cytoscape-navigator": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "axios-fetch": "^1.1.0",
     "cytoscape": "^3.9.0",
     "cytoscape-cise": "^1.0.0",
-    "cytoscape-cola": "^2.3.0",
     "cytoscape-cose-bilkent": "^4.0.0",
     "cytoscape-dagre": "^2.2.2",
     "cytoscape-expand-collapse": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "apollo-boost": "^0.4.4",
     "axios-fetch": "^1.1.0",
     "cytoscape": "^3.9.0",
-    "cytoscape-cise": "^1.0.0",
     "cytoscape-cose-bilkent": "^4.0.0",
     "cytoscape-dagre": "^2.2.2",
     "cytoscape-expand-collapse": "^3.1.2",

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -34,7 +34,7 @@
           :name='engine'
            v-bind:class="{
              'layout-button': true,
-             'button-highlight':(engine == layoutName)
+             'button-highlight':(engine === layoutName)
              }"
           @click='switchLayout(`${engine}`, $event)'
         >

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -61,7 +61,6 @@
 
 <script>
 import cytoscape from 'cytoscape'
-import cola from 'cytoscape-cola'
 import dagre from 'cytoscape-dagre'
 import cise from 'cytoscape-cise'
 import coseBilkent from 'cytoscape-cose-bilkent'
@@ -278,54 +277,6 @@ const hierarchicalOptions = {
   transform: function (node, position) { return position } // transform a given node position. Useful for changing flow direction in discrete layouts
 }
 
-const colaLayoutOptions = {
-  name: 'cola',
-  animate: false, // whether to show the layout as it's running
-  refresh: 1, // number of ticks per frame; higher is faster but more jerky
-  maxSimulationTime: 2000, // max length in ms to run the layout
-  ungrabifyWhileSimulating: true, // so you can't drag nodes during layout
-  fit: false, // on every layout reposition of nodes, fit the viewport
-  padding: 30, // padding around the simulation
-  boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
-  nodeDimensionsIncludeLabels: true, // whether labels should be included in determining the space used by a node
-  // layout event callbacks
-  ready: function () {
-    this.layoutReady = true
-    this.layoutStopped = false
-  },
-  stop: function () {
-    this.layoutReady = false
-    this.layoutStopped = true
-    this.loading = false
-  },
-  // positioning options
-  randomize: false, // use random node positions at beginning of layout
-  avoidOverlap: true, // if true, prevents overlap of node bounding boxes
-  handleDisconnected: true, // if true, avoids disconnected components from overlapping
-  convergenceThreshold: 0.01, // when the alpha value (system energy) falls below this value, the layout stops
-  // eslint-disable-next-line no-unused-vars
-  nodeSpacing: function (node) {
-    return 100
-  }, // extra spacing around nodes
-  flow: undefined, // use DAG/tree flow layout if specified, e.g. { axis: 'y', minSeparation: 30 }
-  alignment: undefined, // relative alignment constraints on nodes, e.g. function( node ){ return { x: 0, y: 1 } }
-  gapInequalities: undefined, // list of inequality constraints for the gap between the nodes, e.g. [{'axis':'y', 'left':node1, 'right':node2, 'gap':25}]
-
-  // different methods of specifying edge length
-  // each can be a constant numerical value or a function like `function( edge ){ return 2; }`
-  edgeLength: undefined, // sets edge length directly in simulation
-  edgeSymDiffLength: undefined, // symmetric diff edge length in simulation
-  edgeJaccardLength: undefined, // jaccard edge length in simulation
-
-  // iterations of cola algorithm; uses default values on undefined
-  unconstrIter: undefined, // unconstrained initial layout iterations
-  userConstIter: undefined, // initial layout iterations with user-specified constraints
-  allConstIter: undefined, // initial layout iterations with all constraints including non-overlap
-
-  // infinite layout options
-  infinite: false // overrides all other options for a forces-all-the-time mode
-}
-
 // eslint-disable-next-line no-unused-vars
 const popperOptions = {
   content: 'test data',
@@ -465,40 +416,6 @@ const expandCollapseOptionsCoseBilkent = {
   expandCollapseCueSensitivity: 1 // sensitivity of expand-collapse cues
 }
 
-const expandCollapseOptionsCola = {
-  layoutBy: {
-    name: 'cose-bilkent',
-    animate: 'end',
-    randomize: false,
-    fit: false
-  },
-  // recommended usage: use cose-bilkent layout with randomize: false to preserve mental map upon expand/collapse
-  fisheye: false, // whether to perform fisheye view after expand/collapse you can specify a function too
-  animate: false, // whether to animate on drawing changes you can specify a function too
-  ready: function () {}, // callback when expand/collapse initialized
-  stop: function () {
-    this.layoutStopped = true
-    this.layoutReady = false
-    this.loading = false
-    this.loading = false
-    this.setHtmlLabel(this.cy)
-    if (tippy) {
-      tippy.hide()
-    }
-  },
-  undoable: true, // and if undoRedoExtension exists,
-  cueEnabled: true, // Whether cues are enabled
-  // expandCollapseCuePosition: 'top-left', // default cue position is top left you can specify a function per node too
-  expandCollapseCuePosition: function (ele) {
-    return ele.position()
-  },
-  expandCollapseCueSize: 20, // size of expand-collapse cue
-  expandCollapseCueLineSize: 16, // size of lines used for drawing plus-minus icons
-  expandCueImage: undefined, // image of expand icon if undefined draw regular expand cue
-  collapseCueImage: undefined, // image of collapse icon if undefined draw regular collapse cue
-  expandCollapseCueSensitivity: 1 // sensitivity of expand-collapse cues
-}
-
 export default {
   name: 'Graph',
   props: {
@@ -534,7 +451,6 @@ export default {
         'dagre',
         'cose-bilkent',
         'hierarchical',
-        'cola',
         'cise'
       ]
     }
@@ -659,7 +575,6 @@ export default {
       // cytoscape: this is the cytoscape constructor
       try {
         console.debug('PRE-CONFIG')
-        cytoscape.use(cola)
         cytoscape.use(dagre)
         cytoscape.use(cise)
         cytoscape.use(coseBilkent)
@@ -1355,11 +1270,6 @@ export default {
             expandCollapseOptions = expandCollapseOptionsCoseBilkent
             layoutOptions = coseBilkentOptions
             this.doLayout(coseBilkentOptions, expandCollapseOptionsCoseBilkent, false)
-            break
-          case 'cola':
-            expandCollapseOptions = expandCollapseOptionsCola
-            layoutOptions = colaLayoutOptions
-            this.doLayout(colaLayoutOptions, expandCollapseOptionsCola)
             break
           case 'hierarchical':
             cy.elements().hca({

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -66,7 +66,6 @@ import cise from 'cytoscape-cise'
 import coseBilkent from 'cytoscape-cose-bilkent'
 import navigator from 'cytoscape-navigator'
 import panzoom from 'cytoscape-panzoom'
-import expandCollapse from 'cytoscape-expand-collapse'
 import undoRedo from 'cytoscape-undo-redo'
 import popper from 'cytoscape-popper'
 import SyncLoader from 'vue-spinner/src/SyncLoader.vue'
@@ -286,136 +285,6 @@ const popperOptions = {
   closeOnClickOutside: true
 }
 
-let expandCollapseOptions = {
-  layoutBy: undefined, // to rearrange after expand/collapse. It's just layout options or whole layout function. Choose your side!
-  // recommended usage: use cose-bilkent layout with randomize: false to preserve mental map upon expand/collapse
-  fisheye: true, // whether to perform fisheye view after expand/collapse you can specify a function too
-  animate: true, // whether to animate on drawing changes you can specify a function too
-  ready: function () {}, // callback when expand/collapse initialized
-  stop: function () {
-    this.layoutStopped = true
-    this.layoutReady = false
-    this.loading = false
-    this.setHtmlLabel(this.cy)
-    if (tippy) {
-      tippy.hide()
-    }
-  },
-  undoable: true, // and if undoRedoExtension exists,
-  cueEnabled: true, // Whether cues are enabled
-  // expandCollapseCuePosition: 'top-left', // default cue position is top left you can specify a function per node too
-  expandCollapseCuePosition: function (ele) {
-    return ele.position()
-  },
-  expandCollapseCueSize: 20, // size of expand-collapse cue
-  expandCollapseCueLineSize: 16, // size of lines used for drawing plus-minus icons
-  expandCueImage: undefined, // image of expand icon if undefined draw regular expand cue
-  collapseCueImage: undefined, // image of collapse icon if undefined draw regular collapse cue
-  expandCollapseCueSensitivity: 1 // sensitivity of expand-collapse cues,
-}
-
-const expandCollapseOptionsUndefined = {
-  layoutBy: undefined, // to rearrange after expand/collapse. It's just layout options or whole layout function. Choose your side!
-  // recommended usage: use cose-bilkent layout with randomize: false to preserve mental map upon expand/collapse
-  fisheye: true, // whether to perform fisheye view after expand/collapse you can specify a function too
-  animate: false, // whether to animate on drawing changes you can specify a function too
-  ready: function () {}, // callback when expand/collapse initialized
-  stop: function () {
-    this.layoutStopped = true
-    this.layoutReady = false
-    this.loading = false
-    this.setHtmlLabel(this.cy)
-    if (tippy) {
-      tippy.hide()
-    }
-  },
-  undoable: true, // and if undoRedoExtension exists,
-  cueEnabled: true, // Whether cues are enabled
-  // expandCollapseCuePosition: 'top-left', // default cue position is top left you can specify a function per node too
-  expandCollapseCuePosition: function (ele) {
-    return ele.position()
-  },
-  expandCollapseCueSize: 20, // size of expand-collapse cue
-  expandCollapseCueLineSize: 16, // size of lines used for drawing plus-minus icons
-  expandCueImage: undefined, // image of expand icon if undefined draw regular expand cue
-  collapseCueImage: undefined, // image of collapse icon if undefined draw regular collapse cue
-  expandCollapseCueSensitivity: 1 // sensitivity of expand-collapse cues
-}
-
-const expandCollapseOptionsCise = {
-  layoutBy: {
-    name: 'cise',
-    animate: 'end',
-    randomize: false,
-    fit: false
-  },
-  // recommended usage: use cose-bilkent layout with randomize: false to preserve mental map upon expand/collapse
-  fisheye: true, // whether to perform fisheye view after expand/collapse you can specify a function too
-  animate: true, // whether to animate on drawing changes you can specify a function too
-  ready: function () {
-    this.layoutReady = true
-    this.layoutStopped = false
-  }, // callback when expand/collapse initialized
-  stop: function () {
-    this.layoutStopped = true
-    this.layoutReady = false
-    this.loading = false
-    this.loading = false
-    this.setHtmlLabel(this.cy)
-    if (tippy) {
-      tippy.hide()
-    }
-  },
-  undoable: true, // and if undoRedoExtension exists,
-  cueEnabled: true, // Whether cues are enabled
-  // expandCollapseCuePosition: 'top-left', // default cue position is top left you can specify a function per node too
-  expandCollapseCuePosition: function (ele) {
-    return ele.position()
-  },
-  expandCollapseCueSize: 20, // size of expand-collapse cue
-  expandCollapseCueLineSize: 16, // size of lines used for drawing plus-minus icons
-  expandCueImage: undefined, // image of expand icon if undefined draw regular expand cue
-  collapseCueImage: undefined, // image of collapse icon if undefined draw regular collapse cue
-  expandCollapseCueSensitivity: 1 // sensitivity of expand-collapse cues
-}
-
-const expandCollapseOptionsCoseBilkent = {
-  layoutBy: {
-    name: 'cose-bilkent',
-    animate: 'end',
-    randomize: false,
-    fit: false
-  },
-  // recommended usage: use cose-bilkent layout with randomize: false to preserve mental map upon expand/collapse
-  fisheye: true, // whether to perform fisheye view after expand/collapse you can specify a function too
-  animate: true, // whether to animate on drawing changes you can specify a function too
-  ready: function () {
-    this.layoutReady = true
-    this.layoutStopped = false
-  }, // callback when expand/collapse initialized
-  stop: function () {
-    this.layoutStopped = true
-    this.layoutReady = false
-    this.loading = false
-    this.loading = false
-    this.setHtmlLabel(this.cy)
-    if (tippy) {
-      tippy.hide()
-    }
-  },
-  undoable: true, // and if undoRedoExtension exists,
-  cueEnabled: true, // Whether cues are enabled
-  // expandCollapseCuePosition: 'top-left', // default cue position is top left you can specify a function per node too
-  expandCollapseCuePosition: function (ele) {
-    return ele.position()
-  },
-  expandCollapseCueSize: 20, // size of expand-collapse cue
-  expandCollapseCueLineSize: 16, // size of lines used for drawing plus-minus icons
-  expandCueImage: undefined, // image of expand icon if undefined draw regular expand cue
-  collapseCueImage: undefined, // image of collapse icon if undefined draw regular collapse cue
-  expandCollapseCueSensitivity: 1 // sensitivity of expand-collapse cues
-}
-
 export default {
   name: 'Graph',
   props: {
@@ -591,7 +460,6 @@ export default {
       try {
       // load graph data and run layout
         layoutOptions = dagreOptions
-        expandCollapseOptions = expandCollapseOptionsUndefined
         const loaded = await this.initialise(cy)
         if (loaded) {
           this.loading = false
@@ -619,11 +487,6 @@ export default {
         if (typeof cytoscape('core', 'undoRedo') !== 'function') {
           console.debug('registering undoRedo')
           undoRedo(cytoscape)
-        }
-
-        if (typeof cytoscape('core', 'expandCollapse') !== 'function') {
-          console.debug('registering expandCollapse')
-          expandCollapse(cytoscape)
         }
 
         if (typeof cytoscape('core', 'popper') !== 'function') {
@@ -744,24 +607,6 @@ export default {
               style: { opacity: '0.2' }
             },
             {
-              selector: 'node.cy-expand-collapse-collapsed-node',
-              style: {
-                'background-color': function memoize (node) {
-                  const nodeState = String(node.data('state'))
-                  const STATE = nodeState.toUpperCase()
-                  return states[STATE].colour || states.DEFAULT.colour
-                },
-                shape: 'rectangle'
-              }
-            },
-            {
-              selector: 'edge.cy-expand-collapse-meta-edge',
-              style: {
-                'background-color': 'green',
-                shape: 'rectangle'
-              }
-            },
-            {
               selector: ':parent',
               style: {
                 'background-opacity': 0.1,
@@ -811,17 +656,6 @@ export default {
       }
     },
 
-    async setupExpandCollapse (instance) {
-      try {
-        expandCollapseOptions = expandCollapseOptionsCoseBilkent
-        instance.expandCollapse(expandCollapseOptions)
-        layoutOptions = dagreOptions
-        return instance
-      } catch (error) {
-        console.error('setupExpandCollapse error', error)
-      }
-    },
-
     async initialise (instance) {
       try {
         console.debug('INITIALISING')
@@ -844,8 +678,6 @@ export default {
         await this.registerExtensions()
         layoutOptions = dagreOptions
         await this.runlayout(instance)
-        await this.setupExpandCollapse(instance)
-        instance.expandCollapse(expandCollapseOptions)
         ur = await this.setupUndo(instance)
         this.getPanzoom(instance)
         this.getNavigator(instance)
@@ -1010,28 +842,6 @@ export default {
 
     getInteractivity (instance) {
       try {
-        instance.nodes().on('expandcollapse.beforecollapse', (event) => {
-          if (tippy) {
-            tippy.hide()
-          }
-          this.setHtmlLabel(instance, states)
-        })
-      } catch (error) {
-        console.error('interactivity expandcollapse.beforecollapse error ', error)
-      }
-
-      try {
-        instance.nodes().on('expandcollapse.beforeexpand', (event) => {
-          if (tippy) {
-            tippy.hide()
-          }
-          this.setHtmlLabel(instance, states)
-        })
-      } catch (error) {
-        console.error('interactivity expandcollapse.beforeexpand error ', error)
-      }
-
-      try {
         instance.on('tap', 'node', (event) => {
           const node = event.target
           console.debug('tapped ' + node.id(), node.data())
@@ -1041,7 +851,6 @@ export default {
               const content = document.createElement('div')
               content.id = 'tooltip'
               content.classList.add('node-tooltip')
-              const children = node.data('collapsedChildren')
               let runpercent = 0
               if (has(node.data, 'runpercent')) {
                 runpercent = node.data('runpercent')
@@ -1257,19 +1066,16 @@ export default {
         const cy = this.cy
         switch (key) {
           case 'dagre':
-            expandCollapseOptions = expandCollapseOptionsUndefined
             layoutOptions = dagreOptions
-            this.doLayout(dagreOptions, expandCollapseOptionsUndefined, true)
+            this.doLayout(dagreOptions, true)
             break
           case 'cise':
-            expandCollapseOptions = expandCollapseOptionsCise
             layoutOptions = ciseOptions
-            this.doLayout(ciseOptions, expandCollapseOptionsCise, false)
+            this.doLayout(ciseOptions, false)
             break
           case 'cose-bilkent':
-            expandCollapseOptions = expandCollapseOptionsCoseBilkent
             layoutOptions = coseBilkentOptions
-            this.doLayout(coseBilkentOptions, expandCollapseOptionsCoseBilkent, false)
+            this.doLayout(coseBilkentOptions, false)
             break
           case 'hierarchical':
             cy.elements().hca({
@@ -1286,14 +1092,12 @@ export default {
                 }
               ]
             })
-            expandCollapseOptions = expandCollapseOptionsUndefined
             layoutOptions = hierarchicalOptions
-            this.doLayout(hierarchicalOptions, expandCollapseOptionsUndefined)
+            this.doLayout(hierarchicalOptions)
             break
           default:
-            expandCollapseOptions = expandCollapseOptionsUndefined
             layoutOptions = dagreOptions
-            this.doLayout(dagreOptions, expandCollapseOptionsUndefined)
+            this.doLayout(dagreOptions)
             break
         }
       } catch (error) {
@@ -1301,9 +1105,8 @@ export default {
       }
     },
 
-    doLayout (layoutOptions, expandCollapseOptions, collapse = false) {
+    doLayout (layoutOptions) {
       try {
-        collapse && initialised ? ur.do('collapseAll') : console.warn('not collapsing this layout')
         this.cy.elements()
           .layout(layoutOptions)
           .run()
@@ -1311,20 +1114,6 @@ export default {
         console.error('doLayout error', error)
         return false
       }
-    },
-
-    collapseAll () {
-      if (tippy) {
-        tippy.hide()
-      }
-      ur.do('collapseAll')
-    },
-
-    expandAll () {
-      if (tippy) {
-        tippy.hide()
-      }
-      ur.do('expandAll')
     },
 
     activateKeys (instance) {

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -40,14 +40,10 @@
         >
           {{ engine }}
         </v-btn>
-        <div
-          id='layout'
-          class='layout-title'
-        >
-          layout: {{layoutName}}
-          <span style="color:red" v-if='freeze'>(frozen)</span>
-        </div>
       </div>
+    </div>
+    <div class='graph-warning'>
+    <span>WARNING: POC Graph View: beware of large workflows!</span>
     </div>
     <div class='cytoscape-navigator-overlay'>
       <canvas></canvas>

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -221,7 +221,7 @@ export default {
       // layout engines
       layoutEngines: [
         'dagre',
-        'hierarchical',
+        'hierarchical'
       ]
     }
   },
@@ -445,15 +445,7 @@ export default {
                 'min-zoomed-font-size': '.8em',
                 shape: 'data(shape)',
                 width: '6em',
-                height: '6em',
-                // The diameter of the pie, measured as a percent of node size (e.g. 100%) or an absolute length (e.g. 25px).
-                'pie-size': '5.6em',
-                'pie-1-background-color': states.RUNNING.colour,
-                'pie-1-background-size': 'mapData(running, 0, 100, 0, 100)',
-                'pie-1-background-opacity': 0.5,
-                'pie-2-background-color': '#333',
-                'pie-2-background-size': 'mapData(todo, 0, 100, 0, 100)',
-                'pie-2-background-opacity': 0.5
+                height: '6em'
               }
             },
             {
@@ -511,8 +503,7 @@ export default {
                 'background-fit': 'contain contain',
                 'background-color': '#b7c0e8',
                 'border-color': '#999',
-                'border-width': '1px',
-                'pie-size': '5.6em'
+                'border-width': '1px'
               }
             }
           ],

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -443,7 +443,6 @@ export default {
                 'text-margin-x': 5,
                 'font-size': '.8em',
                 'min-zoomed-font-size': '.8em',
-                shape: 'data(shape)',
                 width: '6em',
                 height: '6em'
               }

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -62,7 +62,6 @@
 <script>
 import cytoscape from 'cytoscape'
 import dagre from 'cytoscape-dagre'
-import coseBilkent from 'cytoscape-cose-bilkent'
 import navigator from 'cytoscape-navigator'
 import panzoom from 'cytoscape-panzoom'
 import undoRedo from 'cytoscape-undo-redo'
@@ -151,39 +150,6 @@ const dagreOptions = {
   }
 }
 
-const coseBilkentOptions = {
-  name: 'cose-bilkent',
-  ready: function () {
-    this.layoutReady = true
-    this.layoutStopped = false
-  },
-  stop: function () {
-    this.layoutStopped = true
-    this.layoutReady = false
-    this.loading = false
-  },
-  quality: 'default',
-  nodeDimensionsIncludeLabels: false, // Whether to include labels in node dimensions. Useful for avoiding label overlap
-  refresh: 30, // number of ticks per frame higher is faster but more jerky
-  fit: false, // Whether to fit the network view after when done
-  padding: 10, // Padding on fit
-  randomize: true, // Whether to enable incremental mode
-  nodeRepulsion: 24000, // Node repulsion (non overlapping) multiplier
-  idealEdgeLength: 300, // Ideal (intra-graph) edge length
-  // edgeElasticity: 0.45, // Divisor to compute edge forces
-  nestingFactor: 0.1, // Nesting factor (multiplier) to compute ideal edge length for inter-graph edges
-  gravity: 0.5, // Gravity force (constant)
-  numIter: 2500, // Maximum number of iterations to perform
-  tile: true, // Whether to tile disconnected nodes
-  animate: false, // Type of layout animation. The option set is {'during', 'end', false}
-  tilingPaddingVertical: 10, // Amount of vertical space to put between degree zero nodes during tiling (can also be a function)
-  tilingPaddingHorizontal: 10, // Amount of horizontal space to put between degree zero nodes during tiling (can also be a function)
-  gravityRangeCompound: 1.5, // Gravity range (constant) for compounds
-  gravityCompound: 1.0, // Gravity force (constant) for compounds
-  gravityRange: 3.8, // Gravity range (constant)
-  initialEnergyOnIncremental: 0.5 // Initial cooling factor for incremental layout
-}
-
 const hierarchicalOptions = {
   name: 'breadthfirst',
   fit: false, // whether to fit the viewport to the graph
@@ -255,7 +221,6 @@ export default {
       // layout engines
       layoutEngines: [
         'dagre',
-        'cose-bilkent',
         'hierarchical',
       ]
     }
@@ -380,7 +345,6 @@ export default {
       try {
         console.debug('PRE-CONFIG')
         cytoscape.use(dagre)
-        cytoscape.use(coseBilkent)
         this.cy = cytoscape({
           container: document.getElementById('cytoscape')
         })
@@ -992,10 +956,6 @@ export default {
           case 'dagre':
             layoutOptions = dagreOptions
             this.doLayout(dagreOptions)
-            break
-          case 'cose-bilkent':
-            layoutOptions = coseBilkentOptions
-            this.doLayout(coseBilkentOptions)
             break
           case 'hierarchical':
             cy.elements().hca({

--- a/src/components/cylc/Graph.vue
+++ b/src/components/cylc/Graph.vue
@@ -14,10 +14,13 @@
         align-bottom
         justify-center
         :outlined='true'
-        class='freeze-button'
+        v-bind:class="{
+          'freeze-button': true,
+          'button-highlight': freeze
+          }"
         @click='freezeGraph("freeze", $event)'
       >
-        freeze
+        freeze layout
       </v-btn>
       <div>
         <v-btn
@@ -29,7 +32,10 @@
           justify-center
           :outlined='true'
           :name='engine'
-          :class='`${engine.replace("-", "")}-button`'
+           v-bind:class="{
+             'layout-button': true,
+             'button-highlight':(engine == layoutName)
+             }"
           @click='switchLayout(`${engine}`, $event)'
         >
           {{ engine }}
@@ -39,7 +45,7 @@
           class='layout-title'
         >
           layout: {{layoutName}}
-          <span v-if='freeze'>-frozen</span>
+          <span style="color:red" v-if='freeze'>(frozen)</span>
         </div>
       </div>
     </div>

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -45,7 +45,7 @@
     }
 
     .layout-button {
-      text-align: centre;
+      text-align: center;
       color: slategray;
       z-index: 4;
       height: 40px;
@@ -66,7 +66,7 @@
     }
 
    .freeze-button {
-      text-align: centre;
+      text-align: center;
       color: red;
       z-index: 4;
       height: 40px;

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -33,8 +33,8 @@
 
     .spinner {
       position: absolute;
-      top: 710px;
-      left: 130px;
+      top: 0px;
+      right: 0px;
       z-index: 99;
     }
 
@@ -44,14 +44,7 @@
       left: 1px;
     }
 
-    .dagre-button {
-      text-align: centre;
-      color: slategray;
-      z-index: 4;
-      height: 40px;
-    }
-
-    .hierarchical-button {
+    .layout-button {
       text-align: centre;
       color: slategray;
       z-index: 4;
@@ -59,38 +52,16 @@
       margin-left: 4px;
     }
 
+    .button-highlight {
+       background:yellow;
+    }
+
    .freeze-button {
       text-align: centre;
-      color: slategray;
-      size: 'small';
+      color: red;
       z-index: 4;
-      height: 10px;
-      margin-top: 1em;
-      margin-bottom: 1em;
-    }
-
-    .layout-title {
-      text-align: left;
-      font-size: .8em;
-      color: #2b2b2b;
-      /* background: #f2f2f2; */
-      text-transform: lowercase;
-      position: absolute;
-      bottom: 64px;
-      left: 1px;
-      z-index: 4;
-    }
-
-    .suite-title {
-      text-align: left;
-      font-size: .8em;
-      color: #2b2b2b;
-      /* background: #f2f2f2; */
-      text-transform: lowercase;
-      position: absolute;
-      bottom: 80px;
-      left: 1px;
-      z-index: 4;
+      height: 40px;
+      margin: 4px;
     }
 
     .node-tooltip {

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -33,8 +33,8 @@
 
     .spinner {
       position: absolute;
-      bottom: 10px;
-      left: 0px;
+      bottom: 21px;
+      left: 1px;
       z-index: 99;
     }
 

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -81,15 +81,6 @@
       margin-left: 4px;
     }
 
-    .cola-button {
-      text-align: centre;
-      color: slategray;
-      z-index: 4;
-      height: 40px;
-      width: 40px;
-      margin-left: 4px;
-    }
-
     .collapse-all-button {
       text-align: centre;
       color: slategray;

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -56,14 +56,6 @@
       height: 40px;
     }
 
-    .cosebilkent-button {
-      text-align: centre;
-      color: slategray;
-      z-index: 4;
-      height: 40px;
-      margin-left: 4px;
-    }
-
     .hierarchical-button {
       text-align: centre;
       color: slategray;

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -18,7 +18,7 @@
       z-index: 5;
       width: 200px;
       height: 150px;
-      bottom: 81px;
+      bottom: 0px;
       right: 0px;
       overflow: hidden;
     }
@@ -33,15 +33,15 @@
 
     .spinner {
       position: absolute;
-      top: 0px;
-      right: 0px;
+      bottom: 10px;
+      left: 0px;
       z-index: 99;
     }
 
    .switchlayout {
       position: absolute;
-      bottom: 83px;
-      left: 1px;
+      bottom: 40px;
+      left: 0px;
     }
 
     .layout-button {
@@ -54,6 +54,15 @@
 
     .button-highlight {
        background:yellow;
+    }
+
+    .graph-warning {
+       color:red;
+       background:white;
+       position: absolute;
+       bottom:0px;
+       left:0px;
+       z-index: 4;
     }
 
    .freeze-button {

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -38,12 +38,7 @@
       z-index: 99;
     }
 
-    .collapsed-child {
-      opacity: 0;
-      display: none
-      }
-
-    .switchlayout {
+   .switchlayout {
       position: absolute;
       bottom: 83px;
       left: 1px;
@@ -64,20 +59,7 @@
       margin-left: 4px;
     }
 
-    .collapse-all-button {
-      text-align: centre;
-      color: slategray;
-      font-size: .4em;
-      size: 'x-small';
-      z-index: 4;
-      height: 10px;
-      margin-left: 0.1em;
-      margin-top: 1em;
-      margin-bottom: 1em;
-      margin-right: .4em;
-    }
-
-    .freeze-button {
+   .freeze-button {
       text-align: centre;
       color: slategray;
       size: 'small';

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -56,15 +56,6 @@
       height: 40px;
     }
 
-    .cise-button {
-      text-align: centre;
-      color: slategray;
-      z-index: 4;
-      height: 40px;
-      width: 40px;
-      margin-left: 4px;
-    }
-
     .cosebilkent-button {
       text-align: centre;
       color: slategray;


### PR DESCRIPTION
Some graph view changes for the alpha-2 release:
- delete the 3 useless layouts
- delete the expand/collapse code
- fix the cytoscape errors spewed to the console
- improve the buttons a bit (highlight the chosen layout, and the freeze button when frozen)

![shot](https://user-images.githubusercontent.com/2362137/72398480-f81df380-37a7-11ea-92f2-add5635d0c25.png)
