### PR TITLE
Add a tree component by default when accessing the workflow page

### DIFF
--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -191,6 +191,13 @@ export default {
       this.$workflowService.unsubscribe(subscriptionId)
     })
   },
+  mounted () {
+    // Create a Tree View for the current workflow by default
+    const subscriptionId = this.subscribe('tree')
+    this.$nextTick(() => {
+      this.$refs['workflow-component'].addTreeWidget(`${subscriptionId}`)
+    })
+  },
   beforeDestroy () {
     EventBus.$off('add:tree')
     EventBus.$off('add:graph')


### PR DESCRIPTION
This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? let's with some e2e later for this view).
- [x] No change log entry required (why? e.g. the workflow component is new; so there is no change for the user, except for the workflow view, already in the changelog).
- [x] No documentation update required.
