### PR TITLE
Workflows table tidy and hide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,9 @@ mode and drawer)
 [#361](https://github.com/cylc/cylc-ui/pull/361) - Remove the unneeded footer
 component
 
+[#370](https://github.com/cylc/cylc-ui/pull/370) - Fix up the old gscan table
+view and move access to the dashboard.
+
 ### Documentation
 
 [#215](https://github.com/cylc/cylc-ui/pull/215) - guide: add beginnings

--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -34,7 +34,8 @@
         </v-list-item-action>
         <v-list-item-title>Dashboard</v-list-item-title>
       </v-list-item>
-      <v-subheader>Views</v-subheader>
+      <v-divider />
+      <v-subheader>Workflows</v-subheader>
       <v-list-item
         v-for="(link, index) in viewLinks"
         :key="index+link.text"
@@ -79,12 +80,6 @@ export default {
         icon: 'mdi-view-dashboard',
         text: i18n.t('App.dashboard'),
         view: false
-      },
-      {
-        to: '/workflows',
-        icon: 'mdi-vector-circle',
-        text: i18n.t('App.workflows'),
-        view: true
       }
     ],
     responsive: false

--- a/src/lang/en-GB/Workflows.json
+++ b/src/lang/en-GB/Workflows.json
@@ -1,5 +1,5 @@
 {
-  "tableHeader": "Your Workflows",
+  "tableHeader": "Workflows",
   "tableColumnName": "Name",
   "tableColumnOwner": "Owner",
   "tableColumnHost": "Host",

--- a/src/lang/pt-BR/Workflows.json
+++ b/src/lang/pt-BR/Workflows.json
@@ -1,5 +1,5 @@
 {
-  "tableHeader": "Seus Workflows",
+  "tableHeader": "Workflows",
   "tableColumnName": "Nome",
   "tableColumnOwner": "Usuário",
   "tableColumnHost": "Servidor",

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -44,6 +44,19 @@
     <v-layout wrap>
       <v-flex xs12 md6 lg6>
         <v-list three-line>
+          <v-list-item to="/workflows">
+            <v-list-item-avatar size="60" style="font-size: 2em;">
+              <v-icon medium>mdi-table</v-icon>
+            </v-list-item-avatar>
+            <v-list-item-content>
+              <v-list-item-title class="title font-weight-thin">
+                Workflows Table
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                View name, host, port, etc. of your workflows
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
           <v-list-item to="/user-profile">
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon medium>mdi-settings</v-icon>

--- a/src/views/GScan.vue
+++ b/src/views/GScan.vue
@@ -44,15 +44,11 @@
               slot="item"
               slot-scope="{ item }"
             >
-              <tr>
+              <tr @click="viewWorkflow(item)">
                 <td>{{ item.name }}</td>
                 <td>{{ item.owner }}</td>
                 <td>{{ item.host }}</td>
                 <td>{{ item.port }}</td>
-                <td class="justify-center">
-                  <v-icon small class="mr-2" @click="viewWorkflow(item)">mdi-table-edit</v-icon>
-                  <v-icon small class="mr-2" @click="viewGraph(item)">mdi-vector-polyline</v-icon>
-                </td>
               </tr>
             </template>
           </v-data-table>
@@ -116,11 +112,6 @@ export default {
         sortable: false,
         text: i18n.t('Workflows.tableColumnPort'),
         value: 'port'
-      },
-      {
-        sortable: false,
-        text: i18n.t('Workflows.tableColumnActions'),
-        value: 'actions'
       }
     ]
   }),
@@ -146,10 +137,6 @@ export default {
   methods: {
     viewWorkflow (workflow) {
       this.$router.push({ path: `/workflows/${workflow.name}` })
-    },
-
-    viewGraph (workflow) {
-      this.$router.push({ path: `/graph/${workflow.name}` })
     },
 
     subscribe (queryName) {

--- a/src/views/GScan.vue
+++ b/src/views/GScan.vue
@@ -44,7 +44,7 @@
               slot="item"
               slot-scope="{ item }"
             >
-              <tr @click="viewWorkflow(item)">
+              <tr style="cursor:pointer" @click="viewWorkflow(item)">
                 <td>{{ item.name }}</td>
                 <td>{{ item.owner }}</td>
                 <td>{{ item.host }}</td>


### PR DESCRIPTION
This is a small change with no associated Issue.

The old "gscan table view" is not part of our UI design plans, is now somewhat redundant with the new gscan side-bar (and the Actions links in it are broken since lumino,and not needed since gscan side-bar).

However, we **may** want to keep it as a convenient way to show workflow-level detail that users normally don't need to care about (host, port, etc.) ... at least until we figure out if the same info can be dropped from UI or incorporated un-intrusively into the side-bar (e.g. - offline chat with @oliver-sanders - we could optionally put host as a top level tree item).

For the moment, this fixes up the table and hides it away a bit, in the Dashboard:
- remove the Actions column
- make rows clickable (with same result as clicking on the same suite in the side bar)
- move access to the to the dashboard

Table:
![shot1](https://user-images.githubusercontent.com/2362137/72495105-adc17300-388a-11ea-9984-32fae7caa5df.png)

Dashboard:
![shot2](https://user-images.githubusercontent.com/2362137/72494811-e14fcd80-3889-11ea-8518-a95501f153d7.png)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests 
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
