### PR TITLE
Tweak workflows component sizes.

### DIFF
--- a/src/styles/cylc/_workflow.scss
+++ b/src/styles/cylc/_workflow.scss
@@ -4,10 +4,10 @@
 #workflow-panel {
   #main {
     display: flex;
-    min-height: calc(100vh - 82px - 56px);
+    min-height: calc(100vh - 48px);
     .content {
-      min-width: 500px;
-      min-height: 400px;
+      min-width: 300px;
+      min-height: 300px;
       display: flex;
       flex-direction: column;
       padding: 0;


### PR DESCRIPTION
Address comments (somewhere) on unused space at the bottom of the workflows component.  It was still sized as if the old footer existed.

Also shrunk the minimum tab size a bit.

![shot](https://user-images.githubusercontent.com/2362137/72497825-79ea4b80-3892-11ea-870d-b2921c23d6a4.png)
