### PR TITLE
Use subscription instead of normal query in the Dashboard view

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -139,7 +139,7 @@ import { getHubUrl } from '@/utils/user'
 
 const QUERIES = {
   root: `
-    {
+    subscription {
       workflows {
         id
         name


### PR DESCRIPTION
These changes partially address #362 

Found while debugging the websockets connections. The queries must be sent as subscriptions, otherwise the client may use the HTTP link instead.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
