### PR TITLE
Debounce the GraphQL subscription request call in 0.5 second

### DIFF
--- a/src/services/workflow.service.js
+++ b/src/services/workflow.service.js
@@ -30,25 +30,26 @@ mutation StopWorkflowMutation($workflow: String!) {
 `
 
 class SubscriptionWorkflowService extends GQuery {
-  constructor () {
+  constructor (client = null) {
     super()
-    // TODO: revisit this and evaluate other ways to build the GraphQL URL - not safe to rely on window.location (?)
-    const baseUrl = `${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}${window.location.pathname}`
-    const httpUrl = `${window.location.protocol}//${baseUrl}graphql`
-    const wsUrl = `${window.location.protocol.startsWith('https') ? 'wss' : 'ws'}://${baseUrl}subscriptions`
-    this.apolloClient = createApolloClient(httpUrl, wsUrl)
+    if (client === null) {
+      // TODO: revisit this and evaluate other ways to build the GraphQL URL - not safe to rely on window.location (?)
+      const baseUrl = `${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}${window.location.pathname}`
+      const httpUrl = `${window.location.protocol}//${baseUrl}graphql`
+      const wsUrl = `${window.location.protocol.startsWith('https') ? 'wss' : 'ws'}://${baseUrl}subscriptions`
+      this.apolloClient = createApolloClient(httpUrl, wsUrl)
+    }
     /**
      * @type {object}
      */
     this.observable = null
+    this.request = debounce(this.request_, 500)
   }
 
   recompute () {
     super.recompute()
     this.request()
   }
-
-  request = debounce(this.request_, 1000)
 
   request_ () {
     /**

--- a/src/services/workflow.service.js
+++ b/src/services/workflow.service.js
@@ -3,6 +3,7 @@ import store from '@/store/'
 import Alert from '@/model/Alert.model'
 import { createApolloClient } from '@/utils/graphql'
 import gql from 'graphql-tag'
+import debounce from 'lodash.debounce'
 
 const HOLD_WORKFLOW = gql`
 mutation HoldWorkflowMutation($workflow: String!) {
@@ -47,7 +48,9 @@ class SubscriptionWorkflowService extends GQuery {
     this.request()
   }
 
-  request () {
+  request = debounce(this.request_, 1000)
+
+  request_ () {
     /**
      * Perform a REST GraphQL request for all subscriptions.
      */

--- a/tests/unit/services/workflow.service.spec.js
+++ b/tests/unit/services/workflow.service.spec.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai'
+// need the polyfill as otherwise ApolloClient fails to be imported as it checks for a global fetch object on import...
+import 'cross-fetch/polyfill'
+import sinon from 'sinon'
+import SubscriptionWorkflowService from '@/services/workflow.service'
+
+describe('SubscriptionWorkflowService', () => {
+  describe('request', () => {
+    it('should debounce the request function', () => {
+      // mocked createApolloClient because it will try to create a new ApolloClient and use a websocket
+      const fakeClient = sinon.mock()
+      const service = new SubscriptionWorkflowService(fakeClient)
+      // because we don't want to call or test the actual request_ implementation, which would try to use a websocket
+      const requestSpy = sinon.spy(service, 'request_')
+      for (let i = 0; i < 10; i++) {
+        service.request()
+      }
+      // now after 1 second the function should have been debounced
+      setTimeout(() => {
+        expect(requestSpy.callCount).to.equal(1)
+        requestSpy.restore()
+      }, 700)
+    })
+  })
+})


### PR DESCRIPTION
This is a small change with no associated Issue.

The rationale for this PR, is that we avoid at least one unnecessary call to the server. At the moment, when a user visits the main page of Cylc UI, a dashboard view is displayed.

Due to the lifecycle of components/routes, we will get `GScan` being created and put on the layout. `GScan` is a component that also triggers subscriptions. After a while, other components are created, and finally the view is done, and the other lifecycle methods are called in the `Dashboard` view.

One of these lifecycle methods being `created`, where the view will register itself, and start a new subscription. This new subscription forces the `WorkflowService` to update the existing query created by `GScan`, and combine with the `Dashboard` query.

But when that happens, the `GScan` query will have triggered at least one request to the server. The UI will stop the `GScan` subscription, and start a new one for `Dashboard`, which is not optimal.

This PR uses Lodash's [`debounce`](https://lodash.com/docs#debounce), with `1` second timeout. Meaning that the function will be called, after nobody has called it for at least 1 second.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
