### PR TITLE
Use the Drawer component "append" slot from Vuetify to append a version string, as in their documentation page

### DIFF
--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -54,6 +54,13 @@
         :workflows="workflows"
       />
     </v-layout>
+    <template v-slot:append>
+      <div class="px-4 py-2 d-flex justify-center">
+        <span class="grey--text text--darken-2">
+            <strong v-if="environment !== 'PRODUCTION'">{{ environment }}</strong> {{ $t('App.name') }} {{ packageJson.version }}
+          </span>
+      </div>
+    </template>
   </v-navigation-drawer>
 </template>
 
@@ -86,6 +93,7 @@ export default {
   }),
   computed: {
     ...mapState('workflows', ['workflows']),
+    ...mapState(['packageJson', 'environment']),
     drawer: {
       get: function () {
         return this.$store.state.app.drawer


### PR DESCRIPTION
These changes close #369 

A possible fix for #369, adding the old version&node env string to the GScan footer. This could be moved under the logo if it looks better. I moved under the `Drawer` items, as the Vuetify component already offers an "append" slot, that they also use for their documentation. But happy to amend this change if necessary :+1: 

Leaving as 0.3, same milestone as #369.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? can be covered later by a functional test).
- [ ] Appropriate change log entry included. (will add it later once the milestone has been confirmed)
- [x] No documentation update required.
