### PR TITLE
Use eval-source-map for sourcemap with Vue in development

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -37,7 +37,7 @@ module.exports = {
       if (process.env.NODE_ENV === 'test') {
         config.devtool('eval')
       } else {
-        config.devtool('inline-cheap-module-source-map')
+        config.devtool('eval-source-map')
       }
     }
 


### PR DESCRIPTION
This is a small change with no associated Issue.

For a while I have been able to debug JS files like `gquery.js`, but not the JS code in Vue components like `Workflow.vue`. It worked before, but stopped some time ago.

After some searching, found in StackOverflow users saying that the `devtool` configuration had to be `eval-source-map` for the development mode. Tested, and it worked! With that I managed to finish writing the last part about the [ways to debug JS code in Cylc UI](https://gist.github.com/kinow/337c2af7b8bdfa58692d5e415f2876a5) that I am familiar with for the workshop.

Small change, one review should do? It affects only development mode... and only the sourcemap...

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? build change).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
