### PR TITLE
Fix GraphQL alias simplify code, create cycle points from GraphQL, and revert __typename change

### DIFF
--- a/src/components/cylc/gscan/index.js
+++ b/src/components/cylc/gscan/index.js
@@ -9,15 +9,18 @@
 function getWorkflowSummary (workflow) {
   const states = new Map()
   for (const taskProxy of workflow.taskProxies) {
-    for (const job of taskProxy.jobs) {
-      // TODO: temporary fix, as the backend is sending ready jobs, but they will change in cylc flow&uiserver in the future
-      if (job.state === 'ready') {
-        continue
+    // a task in waiting, may not have any jobs
+    if (taskProxy.jobs) {
+      for (const job of taskProxy.jobs) {
+        // TODO: temporary fix, as the backend is sending ready jobs, but they will change in cylc flow&uiserver in the future
+        if (job.state === 'ready') {
+          continue
+        }
+        if (!states.has(job.state)) {
+          states.set(job.state, new Set())
+        }
+        states.get(job.state).add(`${taskProxy.name}.${taskProxy.cyclePoint}`)
       }
-      if (!states.has(job.state)) {
-        states.set(job.state, new Set())
-      }
-      states.get(job.state).add(`${taskProxy.name}.${taskProxy.cyclePoint}`)
     }
   }
   for (const [stateName, tasksSet] of states.entries()) {

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -14,15 +14,15 @@
       >{{ isExpanded ? '&#9661;' : '&#9655;' }}</v-flex>
       <!-- the node value -->
       <!-- TODO: revisit these values that can be replaced by constants later (and in other components too). -->
-      <div class="node-data" @click="nodeClicked" v-if="node.node.__typename === 'CyclePoint'">
+      <div class="node-data" @click="nodeClicked" v-if="node.type === 'cyclepoint'">
         <task :status="node.node.state" :progress=0 />
         <span class="mx-1">{{ node.node.name }}</span>
       </div>
-      <div class="node-data" @click="nodeClicked" v-else-if="node.node.__typename === 'FamilyProxy'">
+      <div class="node-data" @click="nodeClicked" v-else-if="node.type === 'family-proxy'">
         <task :status="node.node.state" :progress="node.node.progress" />
         <span class="mx-1">{{ node.node.name }}</span>
       </div>
-      <div class="node-data" @click="nodeClicked" v-else-if="node.node.__typename === 'TaskProxy'">
+      <div class="node-data" @click="nodeClicked" v-else-if="node.type === 'task-proxy'">
         <task :status="node.node.state" :progress="node.node.progress" />
         <span class="mx-1">{{ node.node.name }}</span>
         <div v-if="!isExpanded" class="node-summary">
@@ -33,7 +33,7 @@
               :status="task.node.state" />
         </div>
       </div>
-      <div class="node-data" v-else-if="node.node.__typename === 'Job'">
+      <div class="node-data" v-else-if="node.type === 'job'">
         <div class="node-data" @click="jobNodeClicked">
           <job :status="node.node.state" />
           <span class="mx-1">#{{ node.node.submitNum }}</span>
@@ -45,7 +45,7 @@
         <span @click="nodeClicked" class="mx-1">{{ node.node.name }}</span>
       </div>
     </div>
-    <div class="leaf" v-if="displayLeaf && node.node.__typename === 'Job'">
+    <div class="leaf" v-if="displayLeaf && node.type === 'job'">
       <div class="arrow-up" :style="getLeafTriangleStyle()"></div>
       <div class="leaf-data font-weight-light py-4 pl-2">
         <div v-for="leafProperty in leafProperties" :key="leafProperty.id" class="leaf-entry">
@@ -210,7 +210,7 @@ export default {
       return {
         // we add half the depth offset to compensate and move the arrow under the job icon, the another 2px
         // just to center-align it
-        'margin-left': `${(NODE_DEPTH_OFFSET / 2) + 2 + (this.$depth * NODE_DEPTH_OFFSET)}px`
+        'margin-left': `${(NODE_DEPTH_OFFSET / 2) + 2 + (this.depth * NODE_DEPTH_OFFSET)}px`
       }
     },
     getNodeClass () {

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -165,14 +165,6 @@ function convertGraphQLWorkflowToTree (workflow) {
   // build hierarchy of cycle-point with zero or many families, and each family with zero or many other families
   // TODO: most of this for-loop and code within might be removed later: https://github.com/cylc/cylc-ui/issues/354#issuecomment-585003621
   for (const familyProxy of rootNode.node.familyProxies) {
-    if (!lookup.get(familyProxy.cyclePoint)) {
-      // create cycle point node, using family's cycle point info
-      const cyclePointNode = createCyclePointNode(familyProxy)
-      lookup.set(cyclePointNode.id, cyclePointNode)
-      // a cycle point must go directly under the workflow
-      rootNode.children.push(cyclePointNode)
-    }
-
     const parent = familyProxy.firstParent
     // skip the root family, which has null as its first parent
     if (parent === null) {

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -166,8 +166,8 @@ function convertGraphQLWorkflowToTree (workflow) {
   // TODO: most of this for-loop and code within might be removed later: https://github.com/cylc/cylc-ui/issues/354#issuecomment-585003621
   for (const familyProxy of rootNode.node.familyProxies) {
     const parent = familyProxy.firstParent
-    // skip the root family, which has null as its first parent
-    if (parent === null) {
+    // skip the root family, which does not have a parent
+    if (parent === null || parent === undefined) {
       continue
     }
     if (!lookup.get(familyProxy.id)) {
@@ -204,9 +204,12 @@ function convertGraphQLWorkflowToTree (workflow) {
     } else {
       lookup.get(taskProxyNode.node.firstParent.id).children.push(taskProxyNode)
     }
-    for (const job of taskProxyNode.node.jobs) {
-      const jobNode = createJobNode(job, taskProxyNode.node.latestMessage)
-      taskProxyNode.children.push(jobNode)
+    // a task in waiting state may not have any jobs
+    if (taskProxyNode.node.jobs) {
+      for (const job of taskProxyNode.node.jobs) {
+        const jobNode = createJobNode(job, taskProxyNode.node.latestMessage)
+        taskProxyNode.children.push(jobNode)
+      }
     }
     computeTaskProgress(taskProxyNode.node)
   }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -13,6 +13,9 @@ subscription {
     owner
     host
     port
+    cyclePoints: familyProxies(ids: ["root"]) {
+      cyclePoint
+    }
     taskProxies(sort: { keys: ["cyclePoint"] }) {
       id
       name

--- a/src/services/gquery.js
+++ b/src/services/gquery.js
@@ -23,7 +23,11 @@ function getSelections (a) {
   const selections = {}
   for (const selection of a.selectionSet.selections) {
     if (selection.kind === 'Field') {
-      selections[selection.name.value] = selection
+      let key = selection.name.value
+      if (Object.hasOwnProperty.call(selection, 'alias') && selection.alias) {
+        key = selection.alias.value
+      }
+      selections[key] = selection
     }
   }
   return selections

--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -7,162 +7,17 @@ const checkpoint = {
             "name": "one",
             "status": "running",
             "owner": "cylc",
-            "host": "ranma",
-            "port": 43026,
+            "host": "cylc-VirtualBox",
+            "port": 43056,
+            "cyclePoints": [
+                {
+                    "cyclePoint": "20000102T0000Z"
+                },
+                {
+                    "cyclePoint": "20000101T0000Z"
+                }
+            ],
             "taskProxies": [
-                {
-                    "id": "cylc|one|20000101T0000Z|waiting",
-                    "name": "wating",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "waiting"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|waiting|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29872",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:17Z",
-                            "submittedTime": "2019-11-05T22:18:17Z",
-                            "finishedTime": "2019-11-05T22:18:18Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
-                    "name": "eventually_succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29727",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:02Z",
-                            "submittedTime": "2019-11-05T22:18:02Z",
-                            "finishedTime": "2019-11-05T22:18:03Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29689",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:17:58Z",
-                            "submittedTime": "2019-11-05T22:17:58Z",
-                            "finishedTime": "2019-11-05T22:17:59Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29651",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:17:54Z",
-                            "submittedTime": "2019-11-05T22:17:54Z",
-                            "finishedTime": "2019-11-05T22:17:55Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29542",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:17:50Z",
-                            "submittedTime": "2019-11-05T22:17:50Z",
-                            "finishedTime": "2019-11-05T22:17:51Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|checkpoint",
-                    name: "checkpoint",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 7.0,
-                        "name": "checkpoint"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|checkpoint|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29804",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:08Z",
-                            "submittedTime": "2019-11-05T22:18:08Z",
-                            "finishedTime": "2019-11-05T22:18:15Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|succeeded",
-                    "name": "succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29546",
-                            "host": "localhost",
-                            "startedTime": "2019-11-05T22:17:50Z",
-                            "submittedTime": "2019-11-05T22:17:50Z",
-                            "finishedTime": "2019-11-05T22:17:51Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
                 {
                     "id": "cylc|one|20000101T0000Z|sleepy",
                     "name": "sleepy",
@@ -183,11 +38,11 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|sleepy|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29871",
+                            "batchSysJobId": "30145",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:17Z",
-                            "submittedTime": "2019-11-05T22:18:17Z",
-                            "finishedTime": "2019-11-05T22:18:18Z",
+                            "startedTime": "2020-03-01T22:57:27Z",
+                            "submittedTime": "2020-03-01T22:57:25Z",
+                            "finishedTime": "2020-03-01T22:57:28Z",
                             "state": "succeeded",
                             "submitNum": 1
                         }
@@ -198,7 +53,7 @@ const checkpoint = {
                     "name": "retrying",
                     "state": "succeeded",
                     "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2019-11-05T22:22:51Z)",
+                    "latestMessage": "failed, retrying in PT5M (after 2020-03-01T23:01:45Z)",
                     "firstParent": {
                         "id": "cylc|one|20000101T0000Z|BAD",
                         "name": "BAD",
@@ -213,11 +68,11 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|retrying|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29543",
+                            "batchSysJobId": "29278",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:17:50Z",
-                            "submittedTime": "2019-11-05T22:17:50Z",
-                            "finishedTime": "2019-11-05T22:17:51Z",
+                            "startedTime": "2020-03-01T22:56:43Z",
+                            "submittedTime": "2020-03-01T22:56:41Z",
+                            "finishedTime": "2020-03-01T22:56:44Z",
                             "state": "failed",
                             "submitNum": 1
                         }
@@ -243,93 +98,165 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|failed|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29766",
+                            "batchSysJobId": "29813",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:05Z",
-                            "submittedTime": "2019-11-05T22:18:05Z",
-                            "finishedTime": "2019-11-05T22:18:06Z",
+                            "startedTime": "2020-03-01T22:57:08Z",
+                            "submittedTime": "2020-03-01T22:57:06Z",
+                            "finishedTime": "2020-03-01T22:57:09Z",
                             "state": "failed",
                             "submitNum": 1
                         }
                     ]
                 },
                 {
-                    "id": "cylc|one|20000102T0000Z|sleepy",
-                    "name": "sleepy",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
-                    "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": []
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
+                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
                     "name": "eventually_succeeded",
                     "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
+                    "cyclePoint": "20000101T0000Z",
                     "latestMessage": "succeeded",
                     "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|SUCCEEDED",
+                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
                         "name": "SUCCEEDED",
-                        "cyclePoint": "20000102T0000Z",
+                        "cyclePoint": "20000101T0000Z",
                         "state": "succeeded"
                     },
                     "task": {
-                        "meanElapsedTime": 1.0,
+                        "meanElapsedTime": 1.5,
                         "name": "eventually_succeeded"
                     },
                     "jobs": [
                         {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
                             "batchSysName": "background",
-                            "batchSysJobId": "30131",
+                            "batchSysJobId": "29742",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:33Z",
-                            "submittedTime": "2019-11-05T22:18:33Z",
-                            "finishedTime": "2019-11-05T22:18:34Z",
+                            "startedTime": "2020-03-01T22:57:02Z",
+                            "submittedTime": "2020-03-01T22:57:01Z",
+                            "finishedTime": "2020-03-01T22:57:04Z",
                             "state": "succeeded",
                             "submitNum": 4
                         },
                         {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
                             "batchSysName": "background",
-                            "batchSysJobId": "30093",
+                            "batchSysJobId": "29597",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:29Z",
-                            "submittedTime": "2019-11-05T22:18:29Z",
-                            "finishedTime": "2019-11-05T22:18:30Z",
+                            "startedTime": "2020-03-01T22:56:57Z",
+                            "submittedTime": "2020-03-01T22:56:55Z",
+                            "finishedTime": "2020-03-01T22:56:58Z",
                             "state": "failed",
                             "submitNum": 3
                         },
                         {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
                             "batchSysName": "background",
-                            "batchSysJobId": "30055",
+                            "batchSysJobId": "29453",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:25Z",
-                            "submittedTime": "2019-11-05T22:18:25Z",
-                            "finishedTime": "2019-11-05T22:18:26Z",
+                            "startedTime": "2020-03-01T22:56:50Z",
+                            "submittedTime": "2020-03-01T22:56:48Z",
+                            "finishedTime": "2020-03-01T22:56:51Z",
                             "state": "failed",
                             "submitNum": 2
                         },
                         {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29946",
+                            "batchSysJobId": "29277",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:21Z",
-                            "submittedTime": "2019-11-05T22:18:21Z",
-                            "finishedTime": "2019-11-05T22:18:22Z",
+                            "startedTime": "2020-03-01T22:56:43Z",
+                            "submittedTime": "2020-03-01T22:56:41Z",
+                            "finishedTime": "2020-03-01T22:56:44Z",
                             "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|succeeded",
+                    "name": "succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
+                        "cyclePoint": "20000101T0000Z",
+                        "state": "succeeded"
+                    },
+                    "task": {
+                        "meanElapsedTime": 2.0,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "29280",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:56:43Z",
+                            "submittedTime": "2020-03-01T22:56:41Z",
+                            "finishedTime": "2020-03-01T22:56:45Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|waiting",
+                    "name": "waiting",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000101T0000Z|root",
+                        "name": "root",
+                        "cyclePoint": "20000101T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|waiting|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "30146",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:57:27Z",
+                            "submittedTime": "2020-03-01T22:57:25Z",
+                            "finishedTime": "2020-03-01T22:57:28Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|checkpoint",
+                    "name": "checkpoint",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000101T0000Z|root",
+                        "name": "root",
+                        "cyclePoint": "20000101T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 9.0,
+                        "name": "checkpoint"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|checkpoint|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "29948",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:57:14Z",
+                            "submittedTime": "2020-03-01T22:57:13Z",
+                            "finishedTime": "2020-03-01T22:57:23Z",
+                            "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
@@ -347,18 +274,17 @@ const checkpoint = {
                         "state": "failed"
                     },
                     "task": {
-                        "meanElapsedTime": 7.0,
+                        "meanElapsedTime": 9.0,
                         "name": "checkpoint"
                     },
                     "jobs": [
                         {
                             "id": "cylc|one|20000102T0000Z|checkpoint|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "30210",
+                            "batchSysJobId": "31000",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:39Z",
-                            "submittedTime": "2019-11-05T22:18:39Z",
-                            "finishedTime": "",
+                            "startedTime": "2020-03-01T22:58:03Z",
+                            "submittedTime": "2020-03-01T22:58:01Z",
                             "state": "running",
                             "submitNum": 1
                         }
@@ -369,7 +295,6 @@ const checkpoint = {
                     "name": "waiting",
                     "state": "waiting",
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
                     "firstParent": {
                         "id": "cylc|one|20000102T0000Z|root",
                         "name": "root",
@@ -379,8 +304,53 @@ const checkpoint = {
                     "task": {
                         "meanElapsedTime": 1.0,
                         "name": "waiting"
+                    }
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|sleepy",
+                    "name": "sleepy",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|root",
+                        "name": "root",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "failed"
                     },
-                    "jobs": []
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    }
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|retrying",
+                    "name": "retrying",
+                    "state": "retrying",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "failed, retrying in PT5M (after 2020-03-01T23:02:35Z)",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|BAD",
+                        "name": "BAD",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "retrying"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|retrying|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "30334",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:57:33Z",
+                            "submittedTime": "2020-03-01T22:57:31Z",
+                            "finishedTime": "2020-03-01T22:57:34Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
                 },
                 {
                     "id": "cylc|one|20000102T0000Z|failed",
@@ -402,41 +372,74 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000102T0000Z|failed|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "30170",
+                            "batchSysJobId": "30862",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:36Z",
-                            "submittedTime": "2019-11-05T22:18:36Z",
-                            "finishedTime": "2019-11-05T22:18:37Z",
+                            "startedTime": "2020-03-01T22:57:57Z",
+                            "submittedTime": "2020-03-01T22:57:56Z",
+                            "finishedTime": "2020-03-01T22:57:58Z",
                             "state": "failed",
                             "submitNum": 1
                         }
                     ]
                 },
                 {
-                    "id": "cylc|one|20000102T0000Z|retrying",
-                    "name": "retrying",
-                    "state": "retrying",
+                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
+                    "name": "eventually_succeeded",
+                    "state": "succeeded",
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2019-11-05T22:23:22Z)",
+                    "latestMessage": "succeeded",
                     "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|BAD",
-                        "name": "BAD",
+                        "id": "cylc|one|20000102T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "succeeded"
                     },
                     "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "retrying"
+                        "meanElapsedTime": 1.5,
+                        "name": "eventually_succeeded"
                     },
                     "jobs": [
                         {
-                            "id": "cylc|one|20000102T0000Z|retrying|1",
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
                             "batchSysName": "background",
-                            "batchSysJobId": "29947",
+                            "batchSysJobId": "30791",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:21Z",
-                            "submittedTime": "2019-11-05T22:18:21Z",
-                            "finishedTime": "2019-11-05T22:18:22Z",
+                            "startedTime": "2020-03-01T22:57:52Z",
+                            "submittedTime": "2020-03-01T22:57:50Z",
+                            "finishedTime": "2020-03-01T22:57:53Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
+                            "batchSysName": "background",
+                            "batchSysJobId": "30654",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:57:46Z",
+                            "submittedTime": "2020-03-01T22:57:44Z",
+                            "finishedTime": "2020-03-01T22:57:47Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
+                            "batchSysName": "background",
+                            "batchSysJobId": "30506",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:57:39Z",
+                            "submittedTime": "2020-03-01T22:57:38Z",
+                            "finishedTime": "2020-03-01T22:57:40Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "30333",
+                            "host": "localhost",
+                            "startedTime": "2020-03-01T22:57:33Z",
+                            "submittedTime": "2020-03-01T22:57:31Z",
+                            "finishedTime": "2020-03-01T22:57:34Z",
                             "state": "failed",
                             "submitNum": 1
                         }
@@ -455,18 +458,18 @@ const checkpoint = {
                         "state": "succeeded"
                     },
                     "task": {
-                        "meanElapsedTime": 1.0,
+                        "meanElapsedTime": 2.0,
                         "name": "succeeded"
                     },
                     "jobs": [
                         {
                             "id": "cylc|one|20000102T0000Z|succeeded|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29950",
+                            "batchSysJobId": "30337",
                             "host": "localhost",
-                            "startedTime": "2019-11-05T22:18:21Z",
-                            "submittedTime": "2019-11-05T22:18:21Z",
-                            "finishedTime": "2019-11-05T22:18:22Z",
+                            "startedTime": "2020-03-01T22:57:33Z",
+                            "submittedTime": "2020-03-01T22:57:31Z",
+                            "finishedTime": "2020-03-01T22:57:35Z",
                             "state": "succeeded",
                             "submitNum": 1
                         }
@@ -478,15 +481,13 @@ const checkpoint = {
                     "id": "cylc|one|20000102T0000Z|root",
                     "name": "root",
                     "state": "failed",
-                    "cyclePoint": "20000102T0000Z",
-                    "firstParent": null
+                    "cyclePoint": "20000102T0000Z"
                 },
                 {
                     "id": "cylc|one|20000101T0000Z|root",
                     "name": "root",
                     "state": "failed",
-                    "cyclePoint": "20000101T0000Z",
-                    "firstParent": null
+                    "cyclePoint": "20000101T0000Z"
                 },
                 {
                     "id": "cylc|one|20000101T0000Z|SUCCEEDED",

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -7,8 +7,12 @@ query = '''
         owner
         host
         port
+        cyclePoints: familyProxies(ids: ["root"]) {
+          cyclePoint
+        }
         taskProxies(sort: { keys: ["cyclePoint"] }) {
             id
+            name
             state
             cyclePoint
             latestMessage

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -7,25 +7,13 @@ const state = {
 
 const getters = {
   currentWorkflow: state => {
-    if (state.workflowName !== null) {
-      for (const workflow of state.workflows) {
-        if (state.workflowName === workflow.name) {
-          return workflow
-        }
-      }
+    if (state.workflowName === null) {
+      return null
     }
-    return null
+    return state.workflows.find(workflow => workflow.name === state.workflowName) || null
   },
   workflowTree: (state, getters) => {
-    if (getters.currentWorkflow !== null && Object.hasOwnProperty.call(getters.currentWorkflow, 'familyProxies')) {
-      try {
-        return convertGraphQLWorkflowToTree(getters.currentWorkflow)
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e)
-      }
-    }
-    return []
+    return convertGraphQLWorkflowToTree(getters.currentWorkflow)
   }
 }
 

--- a/tests/unit/components/cylc/tree/index.spec.js
+++ b/tests/unit/components/cylc/tree/index.spec.js
@@ -3,33 +3,33 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 import { sampleWorkflow1 } from './tree.data'
 
-const CYCLEPOINT_TYPE = 'CyclePoint'
-const FAMILY_TYPE = 'FamilyProxy'
-const TASK_TYPE = 'TaskProxy'
+const CYCLEPOINT_TYPE = 'cyclepoint'
+const FAMILY_TYPE = 'family-proxy'
+const TASK_TYPE = 'task-proxy'
 
 describe('Tree component functions', () => {
   const workflowTree = convertGraphQLWorkflowToTree(sampleWorkflow1)
   it('should add cycle points as direct children of the workflow', () => {
     expect(workflowTree.length).to.equal(2)
-    expect(workflowTree[0].node.__typename).to.equal(CYCLEPOINT_TYPE)
-    expect(workflowTree[1].node.__typename).to.equal(CYCLEPOINT_TYPE)
+    expect(workflowTree[0].type).to.equal(CYCLEPOINT_TYPE)
+    expect(workflowTree[1].type).to.equal(CYCLEPOINT_TYPE)
   })
   it('should add families and tasks as children to cycle points correctly', () => {
     // the first cycle point in the example data contains two families, and two tasks
     const firstCyclePoint = workflowTree[0]
     const children = firstCyclePoint.children
     console.log(children)
-    expect(children[0].node.__typename).to.equal(FAMILY_TYPE)
-    expect(children[1].node.__typename).to.equal(FAMILY_TYPE)
-    expect(children[2].node.__typename).to.equal(TASK_TYPE)
-    expect(children[2].node.__typename).to.equal(TASK_TYPE)
+    expect(children[0].type).to.equal(FAMILY_TYPE)
+    expect(children[1].type).to.equal(FAMILY_TYPE)
+    expect(children[2].type).to.equal(TASK_TYPE)
+    expect(children[2].type).to.equal(TASK_TYPE)
   })
   it('should add families as children to families correctly', () => {
     const firstCyclePoint = workflowTree[0]
     const children = firstCyclePoint.children
-    expect(children[1].node.__typename).to.equal(FAMILY_TYPE)
+    expect(children[1].type).to.equal(FAMILY_TYPE)
     expect(children[1].node.name).to.equal('GOOD')
-    expect(children[1].children[0].node.__typename).to.equal(FAMILY_TYPE)
+    expect(children[1].children[0].type).to.equal(FAMILY_TYPE)
     expect(children[1].children[0].node.name).to.equal('SUCCEEDED')
   })
   it('should set the progress to 0 when meanElapsedTime is 0', () => {

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -54,6 +54,16 @@ const sampleWorkflow1 = {
   owner: 'cylc',
   host: 'ranma',
   port: 43066,
+  cyclePoints: [
+    {
+      __typename: 'FamilyProxy',
+      cyclePoint: '20000101T0000Z'
+    },
+    {
+      __typename: 'FamilyProxy',
+      cyclePoint: '20000102T0000Z'
+    }
+  ],
   taskProxies: [
     {
       id: 'cylc|one|20000101T0000Z|eventually_succeeded',

--- a/tests/unit/components/cylc/tree/tree.vue.spec.js
+++ b/tests/unit/components/cylc/tree/tree.vue.spec.js
@@ -8,32 +8,21 @@ import * as vuetify from '@/plugins/vuetify'
 import Tree from '@/components/cylc/tree/Tree'
 import { simpleWorkflowTree4Nodes } from './tree.data'
 
-const cycles = new Map([
-  [
-    'user/workflow1',
-    new Set([
-      '20100101T0000Z'
-    ])
-  ]
-])
-
 describe('Tree component', () => {
   it('should display the tree with valid data', () => {
     const wrapper = mount(Tree, {
       propsData: {
-        workflows: simpleWorkflowTree4Nodes,
-        cycles: cycles
+        workflows: simpleWorkflowTree4Nodes[0].children
       }
     })
-    expect(wrapper.props().workflows[0].node.__typename).to.equal('Workflow')
+    expect(wrapper.props().workflows[0].node.__typename).to.equal('CyclePoint')
     expect(wrapper.contains('div')).to.equal(true)
   })
   describe('activable', () => {
     it('should not activate by default', () => {
       const wrapper = mount(Tree, {
         propsData: {
-          workflows: simpleWorkflowTree4Nodes,
-          cycles: cycles
+          workflows: simpleWorkflowTree4Nodes[0].children
         }
       })
       const treeItems = wrapper.findAll({ name: 'TreeItem' })
@@ -48,8 +37,7 @@ describe('Tree component', () => {
     it('should activate correctly', async () => {
       const wrapper = mount(Tree, {
         propsData: {
-          workflows: simpleWorkflowTree4Nodes,
-          cycles: cycles,
+          workflows: simpleWorkflowTree4Nodes[0].children,
           activable: true
         }
       })


### PR DESCRIPTION
These changes close #403, and revert #232 (so that offline mode works again, as `__typename` is created by `ApolloClient` only - i.e. unless you are querying a real endpoint with the client, no `__typename`s are created).

It also creates cyclepoints using GraphQL, instead of iterating over family proxy data in JS (thanks to @dwsutherland).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
