### PR TITLE
Update action checkout from v1 to v2 (avoids possible race issue)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Cache node modules
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
This is a small change with no associated Issue.

Was going to checkout another branch when I noticed I had changes from yesterday. I was going to update actions to see if coverage was working again for PR's, but in the end didn't need to update anything (#328).

But had already updated the checkout action, and today I remembered v1 had an issue where if you push too many changes, the PR may get stuck without being able to check out the code. They fixed it in the v2, so it should be a good idea to update it.

One review should do. Best way to review is just wait for GitHub actions to run, and confirm it checked out the code with no issues.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? CI only).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
