### PR TITLE
Remove warning about GraphQL lint when building the project

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,6 +8,11 @@ module.exports = {
   indexPath: 'index.html',
   transpileDependencies: ['vuetify'],
   runtimeCompiler: true,
+  pluginOptions: {
+    apollo: {
+      lintGQL: false
+    }
+  },
   configureWebpack: {
     plugins: [
       new webpack.DefinePlugin({


### PR DESCRIPTION
This is a small change with no associated Issue.

From some time ago we started getting a message when building the project about GraphQL lint, and telling us how to disable that warning.

This PR simply disables that, as we are not linting GraphQL queries (which we can do later after #418 for example), removing the warning, and leaving the console output with no other warnings, only the build information now.

![image](https://user-images.githubusercontent.com/304786/76481823-5cdb8e80-6477-11ea-85d6-183e93250e9c.png)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? build only).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
