### PR TITLE
Use a metadata field in each vue route instead of a list of strings

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,7 +53,7 @@ Vue.use(Meta)
 router.beforeResolve((to, from, next) => {
   NProgress.start()
   if (to.name) {
-    if (['tree', 'graph', 'workflow'].includes(to.name)) {
+    if (to.meta.toolbar) {
       // When a workflow is being displayed, we set the title to a
       // different value.
       store.commit('app/setTitle', to.params.workflowName)

--- a/src/router/paths.js
+++ b/src/router/paths.js
@@ -27,7 +27,8 @@ export default [
     view: 'Workflow',
     name: 'workflow',
     meta: {
-      layout: 'default'
+      layout: 'default',
+      toolbar: true
     },
     props: true
   },
@@ -53,7 +54,8 @@ export default [
     view: 'Tree',
     name: 'tree',
     meta: {
-      layout: 'default'
+      layout: 'default',
+      toolbar: true
     },
     props: true
   },
@@ -62,7 +64,8 @@ export default [
     view: 'Graph',
     name: 'graph',
     meta: {
-      layout: 'default'
+      layout: 'default',
+      toolbar: true
     },
     props: true
   },


### PR DESCRIPTION
This is a small change with no associated Issue.

This should be more clear to quickly see what enables the toolbar or not. I also think this should be less error prone.

This morning I was going to write a e2e test to confirm that the toolbar is present when you visit the workflow route (the one with the Lumino component). I remembered I had broken the toolbar a couple times in the past, and it was also due to renaming routes (workflows, then tree, or treeview, etc).

By not relying on the route name, and instead using a flag in the Route record metadata (also present, a feature of VueRouter) we should reduce the risk of I or others breaking the toolbar again. Will prepare a e2e test for that anyway later as well :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional). (I will add one test to #423)
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
