### PR TITLE
Remove unnecessary JS code handled in GraphQL query, and fix lint issues

### DIFF
--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -146,7 +146,7 @@ function computeCyclePointsStates (cyclePointNodes) {
  * Every node has data, and a .name property used to display the node in the tree in the UI.
  *
  * @param workflow {object}
- * @returns Object
+ * @returns Array
  */
 function convertGraphQLWorkflowToTree (workflow) {
   if (workflow === null || !workflow.cyclePoints || !workflow.familyProxies || !workflow.taskProxies) {
@@ -165,17 +165,14 @@ function convertGraphQLWorkflowToTree (workflow) {
   // build hierarchy of cycle-point with zero or many families, and each family with zero or many other families
   // TODO: most of this for-loop and code within might be removed later: https://github.com/cylc/cylc-ui/issues/354#issuecomment-585003621
   for (const familyProxy of rootNode.node.familyProxies) {
-    const parent = familyProxy.firstParent
-    // skip the root family, which does not have a parent
-    if (parent === null || parent === undefined) {
-      continue
-    }
     if (!lookup.get(familyProxy.id)) {
       const familyProxyNode = createFamilyProxyNode(familyProxy)
       lookup.set(familyProxyNode.id, familyProxyNode)
       // we add to the lookup table, but we should not add to the parent just yet, as it could a) not exist, or b) be the root family
     }
 
+    // root family is excluded in the GraphQL query, so firstParent mustn't be null
+    const parent = familyProxy.firstParent
     // if the parent is root, we use the cyclepoint as the parent
     if (parent.name === 'root') {
       lookup.get(familyProxy.cyclePoint).children.push(lookup.get(familyProxy.id))

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -44,7 +44,7 @@ subscription {
         submitNum
       }
     }
-    familyProxies (sort: { keys: ["firstParent"]}) {
+    familyProxies (exids: ["root"], sort: { keys: ["firstParent"]}) {
       id
       name
       state

--- a/src/services/workflow.service.js
+++ b/src/services/workflow.service.js
@@ -51,6 +51,7 @@ class SubscriptionWorkflowService extends GQuery {
      * Perform a REST GraphQL request for all subscriptions.
      */
     if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
       console.debug('graphql request:', this.query)
     }
     if (!this.query) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -32,6 +32,7 @@ const actions = {
   setAlert ({ state, commit }, alert) {
     // log to console when the alert is not null (null can mean to remove the alert)
     if (alert !== null) {
+      // eslint-disable-next-line no-console
       console.log(alert)
     }
     if (alert === null || state.alert === null || state.alert.getText() !== alert.getText()) {

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -608,22 +608,6 @@ const sampleWorkflow1 = {
   ],
   familyProxies: [
     {
-      id: 'cylc|one|20000102T0000Z|root',
-      __typename: 'FamilyProxy',
-      name: 'root',
-      cyclePoint: '20000102T0000Z',
-      state: 'failed',
-      firstParent: null
-    },
-    {
-      id: 'cylc|one|20000101T0000Z|root',
-      __typename: 'FamilyProxy',
-      name: 'root',
-      cyclePoint: '20000101T0000Z',
-      state: 'failed',
-      firstParent: null
-    },
-    {
       id: 'cylc|one|20000101T0000Z|SUCCEEDED',
       __typename: 'FamilyProxy',
       name: 'SUCCEEDED',


### PR DESCRIPTION
This is a small change with no associated Issue.

We can use a filter in the GraphQL query to filter familyProxies and exclude the `root` family. This removes the need to have an `if` in JS for that.

Also removes a couple of linter issues raised when the dependencies are updated. These changes are from the infinite tree branch, which has several conflicts, but since it depends on the incremental updates, might need more time before it is ready for review and merge.

So applying these changes earlier should allow us to reduce more the size of the infinite tree pull request, making it easier for reviewers later.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
