### PR TITLE
Add e2e tests for tree view (offline mode)

### DIFF
--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -224,7 +224,7 @@ export default {
     getNodeDataClass () {
       const classes = {}
       classes['node-data'] = true
-      classes[this.node.type] = true
+      classes[`node-data-${this.node.type}`] = true
       return classes
     }
   }

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -14,15 +14,15 @@
       >{{ isExpanded ? '&#9661;' : '&#9655;' }}</v-flex>
       <!-- the node value -->
       <!-- TODO: revisit these values that can be replaced by constants later (and in other components too). -->
-      <div class="node-data" @click="nodeClicked" v-if="node.type === 'cyclepoint'">
+      <div :class="getNodeDataClass()" @click="nodeClicked" v-if="node.type === 'cyclepoint'">
         <task :status="node.node.state" :progress=0 />
         <span class="mx-1">{{ node.node.name }}</span>
       </div>
-      <div class="node-data" @click="nodeClicked" v-else-if="node.type === 'family-proxy'">
+      <div :class="getNodeDataClass()" @click="nodeClicked" v-else-if="node.type === 'family-proxy'">
         <task :status="node.node.state" :progress="node.node.progress" />
         <span class="mx-1">{{ node.node.name }}</span>
       </div>
-      <div class="node-data" @click="nodeClicked" v-else-if="node.type === 'task-proxy'">
+      <div :class="getNodeDataClass()" @click="nodeClicked" v-else-if="node.type === 'task-proxy'">
         <task :status="node.node.state" :progress="node.node.progress" />
         <span class="mx-1">{{ node.node.name }}</span>
         <div v-if="!isExpanded" class="node-summary">
@@ -33,15 +33,15 @@
               :status="task.node.state" />
         </div>
       </div>
-      <div class="node-data" v-else-if="node.type === 'job'">
-        <div class="node-data" @click="jobNodeClicked">
+      <div :class="getNodeDataClass()" v-else-if="node.type === 'job'">
+        <div :class="getNodeDataClass()" @click="jobNodeClicked">
           <job :status="node.node.state" />
           <span class="mx-1">#{{ node.node.submitNum }}</span>
           <span class="grey--text">{{ node.node.host }}</span>
         </div>
         <!-- leaf node -->
       </div>
-      <div class="node-data" v-else>
+      <div :class="getNodeDataClass()" v-else>
         <span @click="nodeClicked" class="mx-1">{{ node.node.name }}</span>
       </div>
     </div>
@@ -220,6 +220,12 @@ export default {
         'node--active': this.active,
         'ml-3': true
       }
+    },
+    getNodeDataClass () {
+      const classes = {}
+      classes['node-data'] = true
+      classes[this.node.type] = true
+      return classes
     }
   }
 }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,5 +1,8 @@
 // Code related to GraphQL queries, fragments, variables, etc.
 
+// IMPORTANT: queries here may be used in the offline mode to create mock data. Before removing or renaming
+// queries here, please check under the services/mock folder for occurrences of the variable name.
+
 /**
  * Query used to retrieve data for a workflow Tree view.
  * @type {string}

--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -7,53 +7,23 @@ const checkpoint = {
             "name": "one",
             "status": "running",
             "owner": "cylc",
-            "host": "cylc-VirtualBox",
-            "port": 43056,
+            "host": "ranma",
+            "port": 43098,
             "cyclePoints": [
                 {
-                    "cyclePoint": "20000102T0000Z"
+                    "cyclePoint": "20000101T0000Z"
                 },
                 {
-                    "cyclePoint": "20000101T0000Z"
+                    "cyclePoint": "20000102T0000Z"
                 }
             ],
             "taskProxies": [
-                {
-                    "id": "cylc|one|20000101T0000Z|sleepy",
-                    "name": "sleepy",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|sleepy|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "30145",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:27Z",
-                            "submittedTime": "2020-03-01T22:57:25Z",
-                            "finishedTime": "2020-03-01T22:57:28Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
                 {
                     "id": "cylc|one|20000101T0000Z|retrying",
                     "name": "retrying",
                     "state": "succeeded",
                     "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2020-03-01T23:01:45Z)",
+                    "latestMessage": "failed, retrying in PT5M (after 2020-03-22T22:16:24Z)",
                     "firstParent": {
                         "id": "cylc|one|20000101T0000Z|BAD",
                         "name": "BAD",
@@ -68,135 +38,12 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|retrying|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29278",
+                            "batchSysJobId": "11743",
                             "host": "localhost",
-                            "startedTime": "2020-03-01T22:56:43Z",
-                            "submittedTime": "2020-03-01T22:56:41Z",
-                            "finishedTime": "2020-03-01T22:56:44Z",
+                            "startedTime": "2020-03-22T22:11:23Z",
+                            "submittedTime": "2020-03-22T22:11:23Z",
+                            "finishedTime": "2020-03-22T22:11:24Z",
                             "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|failed",
-                    "name": "failed",
-                    "state": "failed",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "failed/EXIT",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|BAD",
-                        "name": "BAD",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "failed"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|failed|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29813",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:08Z",
-                            "submittedTime": "2020-03-01T22:57:06Z",
-                            "finishedTime": "2020-03-01T22:57:09Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
-                    "name": "eventually_succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.5,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29742",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:02Z",
-                            "submittedTime": "2020-03-01T22:57:01Z",
-                            "finishedTime": "2020-03-01T22:57:04Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29597",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:56:57Z",
-                            "submittedTime": "2020-03-01T22:56:55Z",
-                            "finishedTime": "2020-03-01T22:56:58Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29453",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:56:50Z",
-                            "submittedTime": "2020-03-01T22:56:48Z",
-                            "finishedTime": "2020-03-01T22:56:51Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29277",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:56:43Z",
-                            "submittedTime": "2020-03-01T22:56:41Z",
-                            "finishedTime": "2020-03-01T22:56:44Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|succeeded",
-                    "name": "succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 2.0,
-                        "name": "succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000101T0000Z|succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "29280",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:56:43Z",
-                            "submittedTime": "2020-03-01T22:56:41Z",
-                            "finishedTime": "2020-03-01T22:56:45Z",
-                            "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
@@ -221,12 +68,72 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000101T0000Z|waiting|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "30146",
+                            "batchSysJobId": "12063",
                             "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:27Z",
-                            "submittedTime": "2020-03-01T22:57:25Z",
-                            "finishedTime": "2020-03-01T22:57:28Z",
+                            "startedTime": "2020-03-22T22:11:54Z",
+                            "submittedTime": "2020-03-22T22:11:54Z",
+                            "finishedTime": "2020-03-22T22:11:55Z",
                             "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|succeeded",
+                    "name": "succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
+                        "cyclePoint": "20000101T0000Z",
+                        "state": "succeeded"
+                    },
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "11746",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:23Z",
+                            "submittedTime": "2020-03-22T22:11:23Z",
+                            "finishedTime": "2020-03-22T22:11:24Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|failed",
+                    "name": "failed",
+                    "state": "failed",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "failed/EXIT",
+                    "firstParent": {
+                        "id": "cylc|one|20000101T0000Z|BAD",
+                        "name": "BAD",
+                        "cyclePoint": "20000101T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 0.0,
+                        "name": "failed"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|failed|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "11951",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:40Z",
+                            "submittedTime": "2020-03-22T22:11:40Z",
+                            "finishedTime": "2020-03-22T22:11:41Z",
+                            "state": "failed",
                             "submitNum": 1
                         }
                     ]
@@ -244,90 +151,122 @@ const checkpoint = {
                         "state": "failed"
                     },
                     "task": {
-                        "meanElapsedTime": 9.0,
+                        "meanElapsedTime": 7.0,
                         "name": "checkpoint"
                     },
                     "jobs": [
                         {
                             "id": "cylc|one|20000101T0000Z|checkpoint|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "29948",
+                            "batchSysJobId": "11986",
                             "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:14Z",
-                            "submittedTime": "2020-03-01T22:57:13Z",
-                            "finishedTime": "2020-03-01T22:57:23Z",
+                            "startedTime": "2020-03-22T22:11:44Z",
+                            "submittedTime": "2020-03-22T22:11:43Z",
+                            "finishedTime": "2020-03-22T22:11:51Z",
                             "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
                 },
                 {
-                    "id": "cylc|one|20000102T0000Z|checkpoint",
-                    "name": "checkpoint",
-                    "state": "running",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "started",
-                    "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 9.0,
-                        "name": "checkpoint"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|checkpoint|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "31000",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:58:03Z",
-                            "submittedTime": "2020-03-01T22:58:01Z",
-                            "state": "running",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|waiting",
-                    "name": "waiting",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
-                    "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "waiting"
-                    }
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|sleepy",
+                    "id": "cylc|one|20000101T0000Z|sleepy",
                     "name": "sleepy",
-                    "state": "waiting",
-                    "cyclePoint": "20000102T0000Z",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
                     "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|root",
+                        "id": "cylc|one|20000101T0000Z|root",
                         "name": "root",
-                        "cyclePoint": "20000102T0000Z",
+                        "cyclePoint": "20000101T0000Z",
                         "state": "failed"
                     },
                     "task": {
                         "meanElapsedTime": 1.0,
                         "name": "sleepy"
-                    }
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|sleepy|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12062",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:54Z",
+                            "submittedTime": "2020-03-22T22:11:54Z",
+                            "finishedTime": "2020-03-22T22:11:55Z",
+                            "state": "succeeded",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000101T0000Z|eventually_succeeded",
+                    "name": "eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000101T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000101T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
+                        "cyclePoint": "20000101T0000Z",
+                        "state": "succeeded"
+                    },
+                    "task": {
+                        "meanElapsedTime": 0.5,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|4",
+                            "batchSysName": "background",
+                            "batchSysJobId": "11915",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:37Z",
+                            "submittedTime": "2020-03-22T22:11:36Z",
+                            "finishedTime": "2020-03-22T22:11:37Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|3",
+                            "batchSysName": "background",
+                            "batchSysJobId": "11880",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:32Z",
+                            "submittedTime": "2020-03-22T22:11:32Z",
+                            "finishedTime": "2020-03-22T22:11:33Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|2",
+                            "batchSysName": "background",
+                            "batchSysJobId": "11843",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:28Z",
+                            "submittedTime": "2020-03-22T22:11:27Z",
+                            "finishedTime": "2020-03-22T22:11:28Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000101T0000Z|eventually_succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "11742",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:23Z",
+                            "submittedTime": "2020-03-22T22:11:23Z",
+                            "finishedTime": "2020-03-22T22:11:24Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
                 },
                 {
                     "id": "cylc|one|20000102T0000Z|retrying",
                     "name": "retrying",
                     "state": "retrying",
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2020-03-01T23:02:35Z)",
+                    "latestMessage": "failed, retrying in PT5M (after 2020-03-22T22:17:00Z)",
                     "firstParent": {
                         "id": "cylc|one|20000102T0000Z|BAD",
                         "name": "BAD",
@@ -342,12 +281,171 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000102T0000Z|retrying|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "30334",
+                            "batchSysJobId": "12135",
                             "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:33Z",
-                            "submittedTime": "2020-03-01T22:57:31Z",
-                            "finishedTime": "2020-03-01T22:57:34Z",
+                            "startedTime": "2020-03-22T22:11:59Z",
+                            "submittedTime": "2020-03-22T22:11:58Z",
+                            "finishedTime": "2020-03-22T22:12:00Z",
                             "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|sleepy",
+                    "name": "sleepy",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|root",
+                        "name": "root",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "sleepy"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|waiting",
+                    "name": "waiting",
+                    "state": "waiting",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|root",
+                        "name": "root",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "waiting"
+                    },
+                    "jobs": []
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|checkpoint",
+                    "name": "checkpoint",
+                    "state": "running",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "started",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|root",
+                        "name": "root",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "failed"
+                    },
+                    "task": {
+                        "meanElapsedTime": 7.0,
+                        "name": "checkpoint"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|checkpoint|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12395",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:12:19Z",
+                            "submittedTime": "2020-03-22T22:12:19Z",
+                            "finishedTime": "",
+                            "state": "running",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
+                    "name": "eventually_succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "succeeded"
+                    },
+                    "task": {
+                        "meanElapsedTime": 0.5,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12324",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:12:12Z",
+                            "submittedTime": "2020-03-22T22:12:12Z",
+                            "finishedTime": "2020-03-22T22:12:13Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12289",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:12:08Z",
+                            "submittedTime": "2020-03-22T22:12:07Z",
+                            "finishedTime": "2020-03-22T22:12:08Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12238",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:12:03Z",
+                            "submittedTime": "2020-03-22T22:12:03Z",
+                            "finishedTime": "2020-03-22T22:12:04Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12134",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:59Z",
+                            "submittedTime": "2020-03-22T22:11:58Z",
+                            "finishedTime": "2020-03-22T22:12:00Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "cylc|one|20000102T0000Z|succeeded",
+                    "name": "succeeded",
+                    "state": "succeeded",
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "succeeded",
+                    "firstParent": {
+                        "id": "cylc|one|20000102T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "succeeded"
+                    },
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "cylc|one|20000102T0000Z|succeeded|1",
+                            "batchSysName": "background",
+                            "batchSysJobId": "12138",
+                            "host": "localhost",
+                            "startedTime": "2020-03-22T22:11:59Z",
+                            "submittedTime": "2020-03-22T22:11:58Z",
+                            "finishedTime": "2020-03-22T22:12:00Z",
+                            "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
@@ -372,123 +470,18 @@ const checkpoint = {
                         {
                             "id": "cylc|one|20000102T0000Z|failed|1",
                             "batchSysName": "background",
-                            "batchSysJobId": "30862",
+                            "batchSysJobId": "12360",
                             "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:57Z",
-                            "submittedTime": "2020-03-01T22:57:56Z",
-                            "finishedTime": "2020-03-01T22:57:58Z",
+                            "startedTime": "2020-03-22T22:12:16Z",
+                            "submittedTime": "2020-03-22T22:12:15Z",
+                            "finishedTime": "2020-03-22T22:12:16Z",
                             "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|eventually_succeeded",
-                    "name": "eventually_succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000102T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.5,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|4",
-                            "batchSysName": "background",
-                            "batchSysJobId": "30791",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:52Z",
-                            "submittedTime": "2020-03-01T22:57:50Z",
-                            "finishedTime": "2020-03-01T22:57:53Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|3",
-                            "batchSysName": "background",
-                            "batchSysJobId": "30654",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:46Z",
-                            "submittedTime": "2020-03-01T22:57:44Z",
-                            "finishedTime": "2020-03-01T22:57:47Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|2",
-                            "batchSysName": "background",
-                            "batchSysJobId": "30506",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:39Z",
-                            "submittedTime": "2020-03-01T22:57:38Z",
-                            "finishedTime": "2020-03-01T22:57:40Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "cylc|one|20000102T0000Z|eventually_succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "30333",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:33Z",
-                            "submittedTime": "2020-03-01T22:57:31Z",
-                            "finishedTime": "2020-03-01T22:57:34Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "cylc|one|20000102T0000Z|succeeded",
-                    "name": "succeeded",
-                    "state": "succeeded",
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "cylc|one|20000102T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000102T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 2.0,
-                        "name": "succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "cylc|one|20000102T0000Z|succeeded|1",
-                            "batchSysName": "background",
-                            "batchSysJobId": "30337",
-                            "host": "localhost",
-                            "startedTime": "2020-03-01T22:57:33Z",
-                            "submittedTime": "2020-03-01T22:57:31Z",
-                            "finishedTime": "2020-03-01T22:57:35Z",
-                            "state": "succeeded",
                             "submitNum": 1
                         }
                     ]
                 }
             ],
             "familyProxies": [
-                {
-                    "id": "cylc|one|20000102T0000Z|root",
-                    "name": "root",
-                    "state": "failed",
-                    "cyclePoint": "20000102T0000Z"
-                },
-                {
-                    "id": "cylc|one|20000101T0000Z|root",
-                    "name": "root",
-                    "state": "failed",
-                    "cyclePoint": "20000101T0000Z"
-                },
                 {
                     "id": "cylc|one|20000101T0000Z|SUCCEEDED",
                     "name": "SUCCEEDED",
@@ -502,9 +495,9 @@ const checkpoint = {
                     }
                 },
                 {
-                    "id": "cylc|one|20000101T0000Z|BAD",
-                    "name": "BAD",
-                    "state": "failed",
+                    "id": "cylc|one|20000101T0000Z|GOOD",
+                    "name": "GOOD",
+                    "state": "succeeded",
                     "cyclePoint": "20000101T0000Z",
                     "firstParent": {
                         "id": "cylc|one|20000101T0000Z|root",
@@ -514,9 +507,9 @@ const checkpoint = {
                     }
                 },
                 {
-                    "id": "cylc|one|20000101T0000Z|GOOD",
-                    "name": "GOOD",
-                    "state": "succeeded",
+                    "id": "cylc|one|20000101T0000Z|BAD",
+                    "name": "BAD",
+                    "state": "failed",
                     "cyclePoint": "20000101T0000Z",
                     "firstParent": {
                         "id": "cylc|one|20000101T0000Z|root",
@@ -538,9 +531,9 @@ const checkpoint = {
                     }
                 },
                 {
-                    "id": "cylc|one|20000102T0000Z|GOOD",
-                    "name": "GOOD",
-                    "state": "succeeded",
+                    "id": "cylc|one|20000102T0000Z|BAD",
+                    "name": "BAD",
+                    "state": "failed",
                     "cyclePoint": "20000102T0000Z",
                     "firstParent": {
                         "id": "cylc|one|20000102T0000Z|root",
@@ -550,9 +543,9 @@ const checkpoint = {
                     }
                 },
                 {
-                    "id": "cylc|one|20000102T0000Z|BAD",
-                    "name": "BAD",
-                    "state": "failed",
+                    "id": "cylc|one|20000102T0000Z|GOOD",
+                    "name": "GOOD",
+                    "state": "succeeded",
                     "cyclePoint": "20000102T0000Z",
                     "firstParent": {
                         "id": "cylc|one|20000102T0000Z|root",

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -1,58 +1,26 @@
-query = '''
-{
-    workflows {
-        id
-        name
-        status
-        owner
-        host
-        port
-        cyclePoints: familyProxies(ids: ["root"]) {
-          cyclePoint
-        }
-        taskProxies(sort: { keys: ["cyclePoint"] }) {
-            id
-            name
-            state
-            cyclePoint
-            latestMessage
-            firstParent {
-                id
-                name
-                cyclePoint
-                state
-            }
-            task {
-                meanElapsedTime
-                name
-            }
-            jobs(sort: { keys: ["submit_num"], reverse:true }) {
-                id
-                batchSysName
-                batchSysJobId
-                host
-                startedTime
-                submittedTime
-                finishedTime
-                state
-                submitNum
-            }
-        }
-        familyProxies (sort: { keys: ["firstParent"]}) {
-            id
-            name
-            state
-            cyclePoint
-            firstParent {
-                id
-                name
-                cyclePoint
-                state
-            }
-        }
-    }
-}
-'''
+from os.path import dirname
+from pathlib import Path
+import re
+
+graphql_module_path = Path(f'{dirname(__file__)}/../../../graphql/')
+queries_file = graphql_module_path / 'queries.js'
+
+workflows_query_variable = 'WORKFLOW_TREE_QUERY'
+
+query = ''
+
+# use a regex to match anything after the variable name and within ``
+# for js multiline variable
+with queries_file.open() as f:
+    query = re.search(
+        rf'const\s+{workflows_query_variable}\s*=\s*`([^`]+)`',
+        f.read(),
+        re.MULTILINE).group(1).strip()
+    # replace the placeholder for the workflow ID
+    query = query.replace('(ids: ["WORKFLOW_ID"])', '', 1)
+    if query.startswith('subscription'):
+        query = query.replace('subscription', '', 1)
+
 
 wrapper = {
     'request_string': query

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -1,15 +1,15 @@
 describe('Tree component', () => {
-  it('Should display leaf node with a triangle with left padding', () => {
-    // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node
+  it('Should display two cycle points for the mocked workflow', () => {
     cy.visit('/#/workflows/one')
     cy
-      .get('#core-app-bar')
-      .should('be.visible')
-  })
-  it('Is NOT displayed when looking at the dashboard', () => {
-    cy.visit('/#/')
-    cy
-      .get('#core-app-bar')
-      .should('not.be.visible')
+      .get('.cyclepoint')
+      .should(($div) => {
+        // by default, in our expected viewport size for tests, both cycle points exist and are visible
+        expect($div).to.have.length(2)
+        expect($div.get(0)).to.contain('20000101T0000Z')
+        expect($div.get(0)).to.be('visible')
+        expect($div.get(1)).to.contain('20000102T0000Z')
+        expect($div.get(1)).to.be('visible')
+      })
   })
 })

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -1,0 +1,15 @@
+describe('Tree component', () => {
+  it('Should display leaf node with a triangle with left padding', () => {
+    // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node
+    cy.visit('/#/workflows/one')
+    cy
+      .get('#core-app-bar')
+      .should('be.visible')
+  })
+  it('Is NOT displayed when looking at the dashboard', () => {
+    cy.visit('/#/')
+    cy
+      .get('#core-app-bar')
+      .should('not.be.visible')
+  })
+})

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -2,14 +2,15 @@ describe('Tree component', () => {
   it('Should display two cycle points for the mocked workflow', () => {
     cy.visit('/#/workflows/one')
     cy
-      .get('.cyclepoint')
+      .get('.node-data-cyclepoint')
       .should(($div) => {
         // by default, in our expected viewport size for tests, both cycle points exist and are visible
         expect($div).to.have.length(2)
         expect($div.get(0)).to.contain('20000101T0000Z')
-        expect($div.get(0)).to.be('visible')
         expect($div.get(1)).to.contain('20000102T0000Z')
-        expect($div.get(1)).to.be('visible')
       })
   })
+  // it('Should display leaf node triangle with padding', () => {
+  //   // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node
+  // }
 })

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -19,6 +19,21 @@ describe('Tree component', () => {
       .get('.node-data-job')
       .should('not.be.visible')
   })
+  it('Should make jobs visible when clicking on tasks', () => {
+    cy.visit('/#/workflows/one')
+    cy
+      .get('.node-data-job:first')
+      .should('not.be.visible')
+    // expand the first task proxy we have
+    cy
+      .get('.node-data-task-proxy:first')
+      .prev()
+      .click()
+    // now, consequentially, the first job that we have should also be visible
+    cy
+      .get('.node-data-job:first')
+      .should('be.visible')
+  })
   // it('Should display leaf node triangle with padding', () => {
   //   // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node
   // }

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -9,6 +9,9 @@ describe('Tree component', () => {
         expect($div.get(0)).to.contain('20000101T0000Z')
         expect($div.get(1)).to.contain('20000102T0000Z')
       })
+    cy
+      .get('.node-data-cyclepoint')
+      .should('be.visible')
   })
   // it('Should display leaf node triangle with padding', () => {
   //   // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -34,7 +34,39 @@ describe('Tree component', () => {
       .get('.node-data-job:first')
       .should('be.visible')
   })
-  // it('Should display leaf node triangle with padding', () => {
-  //   // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node
-  // }
+  it('Should display leaf node triangle with margin', () => {
+    // this is testing that there is a margin, not necessarily that the leaf node's triangle is exactly under the node
+    cy.visit('/#/workflows/one')
+    cy
+      .get('.node-data-task-proxy:first')
+      .prev()
+      .click()
+    // no jobs, and no leaves are visible initially
+    cy
+      .get('.leaf:first')
+      .should('not.be.visible')
+    // but clicking on a visible job should display its leaf node
+    cy
+      .get('.node-data-job:first')
+      .click()
+    cy
+      .get('.leaf:first')
+      .should('be.visible')
+    // and, important, the leaf node has a triangle, as a helper to quickly point the user to its parent
+    // job in the tree - i.e. the leaf has a left margin... as the leaves are not root nodes, we
+    // **always** have a margin > 0, unless a bug broke it (which happened before due to a wrong vairable name).
+    cy
+      .get('.leaf:first > .arrow-up')
+      .should(($div) => {
+        const marginLeft = $div.get(0).style.marginLeft
+        if (
+          marginLeft === undefined ||
+          marginLeft === '' ||
+          marginLeft === '0' ||
+          marginLeft === '0px'
+        ) {
+          throw new Error(`Invalid leaf node margin-left: "${marginLeft}"`)
+        }
+      })
+  })
 })

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -13,6 +13,12 @@ describe('Tree component', () => {
       .get('.node-data-cyclepoint')
       .should('be.visible')
   })
+  it('Should hide jobs by default', () => {
+    cy.visit('/#/workflows/one')
+    cy
+      .get('.node-data-job')
+      .should('not.be.visible')
+  })
   // it('Should display leaf node triangle with padding', () => {
   //   // this is testing that there is a padding, not necessarily that the leaf node's triangle is exactly under the node
   // }


### PR DESCRIPTION
This is a small change with no associated Issue.

The offline mode is broken again, no big news. **However**, as we now have e2e tests, it is much easier to have a test to confirm that the offline mode is working. Here's what we will have in this PR:

1. Right now it is broken because the GraphQL query used to create mocked data was not updated. So now we parse (Python `re` module) the query value from `src/graphql/queries.js` and use it when generating the mocked data.

2. Functional tests will confirm that the tree component is working in the offline mode. Meaning that if anything breaks it again, the CI will fail in GitHub, and then we can fix before merging the PR.

Hopefully no more PR's from me to fix the offline mode :crossed_fingers: :grimacing: 

Tried to test the things I remember breaking with more frequency during when changing the code of the current tree view:

1. No nodes are displayed by some accidental change
2. Nodes are displayed, but clicking on the expand/collapse icon nothing happens
3. Missing job node details (leaf nodes)
4. The triangle of leaf nodes is not displayed correctly (e.g. the `margin-left` CSS attribute is broken for some reason).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
