### PR TITLE
Add loading state to Lumino widgets with skeleton loaders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,10 @@ view and move access to the dashboard.
 [#396](https://github.com/cylc/cylc-ui/pull/396) - Fix leaf and other tree
 nodes layout.
 
+[#432](https://github.com/cylc/cylc-ui/pull/432) - Add loading state to
+Lumino widgets with skeleton loaders, preventing it from displaying the
+data of other workflows for a brief moment.
+
 ### Documentation
 
 [#215](https://github.com/cylc/cylc-ui/pull/215) - guide: add beginnings

--- a/src/components/cylc/workflow/Workflow.vue
+++ b/src/components/cylc/workflow/Workflow.vue
@@ -7,18 +7,21 @@
           :key="widgetId"
           :workflows="workflowTree"
           :widgetId="widgetId"
+          :is-loading="isLoading"
       />
       <graph-wrapper
           v-for="widgetId of this.graphWidgetIds"
           :key="widgetId"
           :workflow-name="workflowName"
           :widgetId="widgetId"
+          :is-loading="isLoading"
       />
       <mutations-wrapper
           v-for="widgetId of this.mutationsWidgetIds"
           :key="widgetId"
           :workflow-name="workflowName"
           :widgetId="widgetId"
+          :is-loading="isLoading"
       />
     </div>
   </div>
@@ -43,6 +46,10 @@ export default {
     workflowName: {
       type: String,
       required: true
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
     }
   },
   components: {

--- a/src/components/cylc/workflow/index.js
+++ b/src/components/cylc/workflow/index.js
@@ -4,6 +4,7 @@ import Tree from '@/components/cylc/tree/Tree'
 import Graph from '@/components/cylc/graph/Graph'
 // import Mutations from '@/components/cylc/Mutations'
 import Mutations from '@/views/Mutations'
+import VSkeletonLoader from 'vuetify/lib/components/VSkeletonLoader'
 
 /**
  * A widget that will have just a single HTML element to be referenced by the Vue component.
@@ -62,10 +63,15 @@ const TreeWrapper = Vue.component('tree-wrapper', {
     workflows: {
       type: Array,
       required: true
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
     }
   },
   components: {
-    tree: Tree
+    tree: Tree,
+    VSkeletonLoader
   },
   mounted () {
     const widgetElement = document.getElementById(this.widgetId)
@@ -84,7 +90,13 @@ const TreeWrapper = Vue.component('tree-wrapper', {
   },
   template: `
     <div>
-      <tree :workflows="workflows" :ref="widgetId"/>
+      <v-skeleton-loader
+        :ref="widgetId"
+        :loading="isLoading"
+        type="list-item-avatar-three-line"
+        >
+        <tree :workflows="workflows" />
+      </v-skeleton-loader>
     </div>
   `
 })
@@ -99,10 +111,15 @@ const GraphWrapper = Vue.component('graph-wrapper', {
     workflowName: {
       type: String,
       required: true
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
     }
   },
   components: {
-    graph: Graph
+    graph: Graph,
+    VSkeletonLoader
   },
   mounted () {
     const widgetElement = document.getElementById(this.widgetId)
@@ -122,12 +139,22 @@ const GraphWrapper = Vue.component('graph-wrapper', {
     },
     activate () {
       // when this widget is activated, we want to tell the wrapped graph that it needs to force-repaint to avoid blank graphs
-      this.$refs[this.widgetId].resizeGraph()
+      const children = this.$refs[this.widgetId].$children
+      if (children && children.length > 0) {
+        children[0].resizeGraph()
+      }
     }
   },
   template: `
     <div>
-      <graph :workflow-name="workflowName" :ref="widgetId"/>
+      <v-skeleton-loader
+        :ref="widgetId"
+        :loading="isLoading"
+        height="100"
+        type="list-item-avatar-three-line"
+      >
+        <graph :workflow-name="workflowName" />
+      </v-skeleton-loader>
     </div>
   `
 })
@@ -142,10 +169,15 @@ const MutationsWrapper = Vue.component('mutations-wrapper', {
     workflowName: {
       type: String,
       required: true
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
     }
   },
   components: {
-    Mutations
+    Mutations,
+    VSkeletonLoader
   },
   methods: {
     delete () {
@@ -169,7 +201,15 @@ const MutationsWrapper = Vue.component('mutations-wrapper', {
   },
   template: `
     <div>
-      <Mutations :workflow-name="workflowName" :ref="widgetId" />
+      <component
+        is="VSkeletonLoader"
+        :ref="widgetId"
+        :loading="isLoading"
+        height="100"
+        type="list-item-avatar-three-line"
+      >
+        <Mutations :workflow-name="workflowName" />
+      </component>
     </div>
   `
 })

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -79,7 +79,7 @@ export default {
       this.$refs['workflow-component'].addTreeWidget(`${subscriptionId}`)
     })
   },
-  beforeDestroy () {
+  beforeRouteLeave () {
     EventBus.$off('add:tree')
     EventBus.$off('add:graph')
     EventBus.$off('add:mutations')

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -72,19 +72,26 @@ export default {
       this.$workflowService.unsubscribe(subscriptionId)
     })
   },
-  mounted () {
-    // Create a Tree View for the current workflow by default
-    const subscriptionId = this.subscribe('tree')
-    this.$nextTick(() => {
-      this.$refs['workflow-component'].addTreeWidget(`${subscriptionId}`)
+  beforeRouteEnter (to, from, next) {
+    next(vm => {
+      // Create a Tree View for the current workflow by default
+      const subscriptionId = vm.subscribe('tree')
+      vm.$nextTick(() => {
+        vm.$refs['workflow-component'].addTreeWidget(`${subscriptionId}`)
+      })
     })
   },
-  beforeRouteLeave () {
+  beforeRouteUpdate (to, from, next) {
+    this.isLoading = true
+    next()
+  },
+  beforeRouteLeave (to, from, next) {
     EventBus.$off('add:tree')
     EventBus.$off('add:graph')
     EventBus.$off('add:mutations')
     EventBus.$off('delete:widget')
     this.$workflowService.unregister(this)
+    next()
   },
   methods: {
     /**

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -3,6 +3,7 @@
     <workflow
       :workflow-name="workflowName"
       :workflow-tree="workflowTree"
+      :is-loading="isLoading"
       ref="workflow-component" />
   </div>
 </template>


### PR DESCRIPTION
These changes close #431 

Use existing views data `isLoading` that is updated by the `WorkflowService`. When we subscribe a query/view to the service, we pass a callback. So far, the callback has been the same for every view, simply updating a data state for loading.

Then this value gets passed down via props to other components, all the way down to the Lumino widget wrapper component. Which uses that reactive value to display a Vuetify [Skeleton Loader](https://vuetifyjs.com/en/components/skeleton-loaders/). Once data has been received, the service calls the callback which updates the loading state (to false).

And then the skeleton loader disappears and the original component is displayed.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
