### PR TITLE
Fix mocked WorkflowService

### DIFF
--- a/src/services/mock/workflow.service.mock.js
+++ b/src/services/mock/workflow.service.mock.js
@@ -22,7 +22,7 @@ class MockWorkflowService extends GQuery {
    */
   subscribe (view, query) {
     const id = super.subscribe(view, query)
-    this.subscriptions.every(s => {
+    this.subscriptions.forEach(s => {
       s.active = true
     })
     this.callbackActive()


### PR DESCRIPTION
This is a small change with no associated Issue.

The e2e tests are currently broken on `master`. This PR should fix that :crossed_fingers: . To review, just wait for GitHub actions and confirm both workflows pass (there's one that runs only the e2e tests).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
