### PR TITLE
Fix mutations in the Toolbar component buttons

### DIFF
--- a/src/services/workflow.service.js
+++ b/src/services/workflow.service.js
@@ -6,24 +6,24 @@ import gql from 'graphql-tag'
 
 // TODO: remove these once the api-on-the-fly mutations are hooked into the UI
 const HOLD_WORKFLOW = gql`
-mutation HoldWorkflowMutation($workflow: String!) {
-  holdWorkflow (workflows: [$workflow]) {
+mutation HoldWorkflowMutation($workflow: WorkflowID!) {
+  hold (workflows: [$workflow]) {
     result
   }
 }
 `
 
 const RELEASE_WORKFLOW = gql`
-mutation ReleaseWorkflowMutation($workflow: String!) {
-  releaseWorkflow(workflows: [$workflow]){
+mutation ReleaseWorkflowMutation($workflow: WorkflowID!) {
+  release (workflows: [$workflow]){
     result
   }
 }
 `
 
 const STOP_WORKFLOW = gql`
-mutation StopWorkflowMutation($workflow: String!) {
-  stopWorkflow (workflows: [$workflow]) {
+mutation StopWorkflowMutation($workflow: WorkflowID!) {
+  stop (workflows: [$workflow]) {
     result
   }
 }


### PR DESCRIPTION
This is a small change with no associated Issue.

@hjoliver noticed that the toolbar buttons were not calling the mutations any longer. It was due to some recent changes in the backend (for api-on-the-fly if I recall correctly, to simplify the schema).

@hjoliver I started by trying to add the `Mutation` component as a dropdown menu (as in the design sketches). That way we would move one step closer to what we have in the sketches, and use the same code used in the Mutations view (lumino widget).

Alas I started changing too many files, as I needed specific mutations (`hold`, `stop`, `release`) and these were within the `Workflow` view at the moment. After that gets moved to a place where it can be shared by components (Vuex store?), it should be easier to add the mutations to our views and components.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? manual tests should be enough? Soon this code will be scrapped by different UI/components, so even an e2e could be scrapped later too).
- [x] No change log entry required (why? e.g. invisible to users, i.e. was not broken in 0.1, should be the same in 0.2).
- [x] No documentation update required.
