### PR TITLE
Fix PR link in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ view and component.
 
 [#301](https://github.com/cylc/cylc-ui/pull/301) - Add GScan component.
 
-[#327](https://github.com/cylc/cylc-ui/pull/301) - Use live data for the
+[#327](https://github.com/cylc/cylc-ui/pull/327) - Use live data for the
 dashboard workflows summary.
 
 [#307](https://github.com/cylc/cylc-ui/pull/307) - Invoke mutations to


### PR DESCRIPTION
This is a small change with no associated Issue.

Found one PR with the wrong link in the changes. One review should do, ignore GitHub actions.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
