### PR TITLE
Fix JSDoc param name

### DIFF
--- a/src/model/TaskState.model.js
+++ b/src/model/TaskState.model.js
@@ -40,7 +40,7 @@ class TaskState extends Enumify {
 
   /**
    * Constructor.
-   * @param {String} text
+   * @param {String} name
    */
   constructor (name) {
     super()


### PR DESCRIPTION
This is a small change with no associated Issue.

Mea culpa. Updated the enum but used the wrong param name. One review should do.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? code comments only).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
