### PR TITLE
Fix Graph component CSS height, and remove cytoscape-navigator

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cytoscape": "^3.9.0",
     "cytoscape-dagre": "^2.2.2",
     "cytoscape-expand-collapse": "^3.1.2",
-    "cytoscape-navigator": "^2.0.0",
     "cytoscape-node-html-label": "^1.1.5",
     "cytoscape-panzoom": "^2.5.3",
     "cytoscape-popper": "^1.0.4",

--- a/src/components/cylc/graph/Graph.vue
+++ b/src/components/cylc/graph/Graph.vue
@@ -63,18 +63,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         text
         @click="warning = false"><v-icon>mdi mdi-close</v-icon></v-btn>
     </v-snackbar>
-    <div class='cytoscape-navigator-overlay' ref="cytoscape-navigator-overlay">
-      <canvas></canvas>
-      <div class='cytoscape-navigatorView'></div>
-      <div class='cytoscape-navigatorOverlay'></div>
-    </div>
   </div>
 </template>
 
 <script>
 import cytoscape from 'cytoscape'
 import dagre from 'cytoscape-dagre'
-import navigator from 'cytoscape-navigator'
 import panzoom from 'cytoscape-panzoom'
 import undoRedo from 'cytoscape-undo-redo'
 import popper from 'cytoscape-popper'
@@ -207,7 +201,6 @@ export default {
     this.runLayout(this.cytoscapeInstance)
     this.setupUndoRedo(this.cytoscapeInstance)
     this.setupPanzoom(this.cytoscapeInstance)
-    this.setupNavigator(this.cytoscapeInstance)
     this.setupInteractivity(this.cytoscapeInstance)
     this.setupHtmlLabel(this.cytoscapeInstance, states)
     // set the initial zoom-level and pan (position) of the graph
@@ -294,9 +287,6 @@ export default {
      * Register the extensions used by Cytoscape for this component.
      */
     registerExtensions () {
-      if (typeof cytoscape('core', 'navigator') !== 'function') {
-        navigator(cytoscape)
-      }
       if (typeof cytoscape('core', 'panzoom') !== 'function') {
         panzoom(cytoscape)
       }
@@ -359,22 +349,6 @@ export default {
      */
     setupPanzoom (instance) {
       instance.panzoom(panzoomDefaults)
-    },
-
-    /**
-     * Sets up the navigator plugin in the instance.
-     * @param {cytoscape} instance - the cytoscape instance
-     */
-    setupNavigator (instance) {
-      instance.navigator({
-        container: this.$refs['cytoscape-navigator-overlay'],
-        viewLiveFramerate: 0, // set false to update graph pan only on drag end set 0 to do it instantly set a number (frames per second) to update not more than N times per second
-        thumbnailEventFramerate: 30, // max thumbnail's updates per second triggered by graph updates
-        thumbnailLiveFramerate: false, // max thumbnail's updates per second. Set false to disable
-        dblClickDelay: 200, // milliseconds
-        removeCustomContainer: true, // destroy the container specified by user on plugin destroy
-        rerenderDelay: 100 // ms to throttle rerender updates to the panzoom for performance
-      })
     },
 
     /**

--- a/src/styles/cytoscape/cytoscape-custom.scss
+++ b/src/styles/cytoscape/cytoscape-custom.scss
@@ -17,10 +17,12 @@
 
 .c-graph {
   width: 100%;
-  // the height of the graph area is 100 viewport-height, minus the height of the toolbar
-  height: calc(100vh - 48px);
+  height: 100%;
   background-color: #fff;
   overflow: hidden;
+  display: flex;
+  flex: 1;
+  align-items: stretch;
   z-index: 1;
 
   .cytoscape {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -33,6 +33,16 @@
   }
 }
 
+// The following two entries are used to set the height of the content view (core-view), under the
+// toolbar, to the maximum. And the skeleton needs to maintain the height 100% otherwise its children
+// nodes with height: 100% or auto won't be displayed at all.
+#core-view {
+  height: calc(100vh - 48px);
+}
+.v-skeleton-loader {
+  height: 100%;
+}
+
 :export {
   fontRootSize: $font-size-root;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5420,11 +5420,6 @@ cytoscape-expand-collapse@^3.1.2:
   resolved "https://registry.yarnpkg.com/cytoscape-expand-collapse/-/cytoscape-expand-collapse-3.2.1.tgz#6bdbedf67834ad3491a6abd3248a8959c5aea57c"
   integrity sha512-jJlCW1VJaaU0nhPLqSWYrK+9dltdtpSBZjWk5BxFvA0w2GWp32u3zDv6uvyX0Um7RDN3lqv/7M4eo2LL1V36CQ==
 
-cytoscape-navigator@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cytoscape-navigator/-/cytoscape-navigator-2.0.1.tgz#c3b82a5329e5e561d91992f6162ea576c03fa7c4"
-  integrity sha512-csflZi8BaUmEr1f6y2xKg9CufpU18Du9CzwA3ybjISClaJcuKMJkIDHLE3sg6GKOdxBVUcHX6aeR5gjTQ66Z6w==
-
 cytoscape-node-html-label@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/cytoscape-node-html-label/-/cytoscape-node-html-label-1.2.0.tgz#584bb5a222a3a566348e8958dcde2961bb6967ac"


### PR DESCRIPTION
This is a small change with no associated Issue.

Fixing issues found by @hjoliver and posted on RIOT.

1. Scroll bar displayed in the Graph, when viewed in the tabbed/Lumino view (`/#/workflow/five`)

- The `views/Graph.vue` displays the Graph component in full screen, which computes the height as `calc(100vh - 48)`
- The `views/Workflow.vue` displays the Graph component within Lumino, with extra margin/paddings. So `calc(100vh - 48px)` gives a height that is not taking the margin/padding in account, so a scroll bar is displayed.
- This PR changes that so that the Graph HTML element simply does a `height: 100%`, and its parents are CSS-flex. Also sets the layout `core-view` element to have `height: calc(100 - 48px)`, although later we may move this to another element as the toolbar is not present in all views (?)

2. Cytoscape navigator is blank, not working

- See this issue about the navigator and Vue: https://github.com/cytoscape/cytoscape.js-navigator/issues/45
- We customized the navigator CSS in our `cytoscape-custom.scss`
- We updated the Cytoscape versions since the code was initially written
- In one of these updates, the library changed the CSS classes of the navigator, making our custom CSS invalid, hence the empty navigator
- Re-enabling it is not too hard, but then it breaks in the tabbed view:

![image](https://user-images.githubusercontent.com/304786/84337337-6ba81d80-abed-11ea-93de-ff291db0f143.png)

![image](https://user-images.githubusercontent.com/304786/84337346-71056800-abed-11ea-8297-da3b1751eb3d.png)

So I think it's safer to go with the suggestion of @hjoliver , and remove the cytoscape-navigator for now? We can add it again later if we decide to keep using Cytoscape :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? visual/style changes).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
