### PR TITLE
Prepare for 0.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,31 @@ milestones](https://github.com/cylc/cylc-ui/milestones?state=closed) for each
 release.
 
 -------------------------------------------------------------------------------
+## __cylc-ui-0.3 (2020-??-??)__
+
+Release 0.3 of Cylc UI.
+
+### Backward incompatible changes
+
+None or N/A.
+
+### Enhancements
+
+None.
+
+### Fixes
+
+None.
+
+### Documentation
+
+None.
+
+### Security issues
+
+None.
+
+-------------------------------------------------------------------------------
 ## __cylc-ui-0.2 (2020-07-14)__
 
 Release 0.2 of Cylc UI.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cylc-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "GPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
This is a small change with no associated Issue.

p.s.: NPM semver schema is a bit more restrictive. I've seen projects using `-SNAPSHOT` or `-alpha.1`. But only the numeric parts are taking into account for the version. The modifier with `alpha.1` can be used too, but it could be confusing for us as we have that in the metapackage 8.0a3. So I just bumped up to the next release number.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
