### PR TITLE
Sort tree view by cyclepoints and task names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ None or N/A.
 [#491](https://github.com/cylc/cylc-ui/pull/491) - Update apollo-client
 to @apollo/client (different package ID, also from 2.x to 3.x).
 
+[#492](https://github.com/cylc/cylc-ui/pull/492) - Sort tree view
+by cyclepoints and task names.
+
 [#458](https://github.com/cylc/cylc-ui/pull/458) - Add CylcTree and
 use deltas for the Tree view and component.
 

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -73,7 +73,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </v-layout>
     <!-- each workflow is a tree root -->
     <tree-item
-      v-for="workflow of workflows"
+      v-for="workflow of sortedChildren('workflow', workflows)"
       :key="workflow.id"
       :node="workflow"
       :hoverable="hoverable"
@@ -94,9 +94,13 @@ import Vue from 'vue'
 import TaskState from '@/model/TaskState.model'
 import Task from '@/components/cylc/Task'
 import clonedeep from 'lodash.clonedeep'
+import { treeitem } from '@/mixins/treeitem'
 
 export default {
   name: 'Tree',
+  mixins: [
+    treeitem
+  ],
   props: {
     workflows: {
       type: Array,

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <span v-show="isExpanded">
       <!-- component recursion -->
       <TreeItem
-          v-for="child in node.children"
+          v-for="child in sortedChildren(node.type, node.children)"
           ref="treeitem"
           :key="child.id"
           :node="child"
@@ -106,6 +106,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import Task from '@/components/cylc/Task'
 import Job from '@/components/cylc/Job'
+import { treeitem } from '@/mixins/treeitem'
 
 /**
  * Offset used to move nodes to the right or left, to represent the nodes hierarchy.
@@ -115,6 +116,9 @@ const NODE_DEPTH_OFFSET = 30
 
 export default {
   name: 'TreeItem',
+  mixins: [
+    treeitem
+  ],
   components: {
     task: Task,
     job: Job

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -215,9 +215,13 @@ class CylcTree {
     if (!this.lookup.has(cyclePoint.id)) {
       this.lookup.set(cyclePoint.id, cyclePoint)
       this.root.children.push(cyclePoint)
-      // sort cycle points
+      // Sort cycle points here.
+      // If the sorting is done in the query only, the first time we
+      // render the component it will be in the correct order. Then
+      // further updates will append to the list. That's why we have
+      // the sorting here and not in the query.
       this.root.children.sort((cyclepoint, anotherCyclepoint) => {
-        return cyclepoint.id.localeCompare(anotherCyclepoint.id)
+        return anotherCyclepoint.id.localeCompare(cyclepoint.id)
       })
     }
   }

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -215,14 +215,6 @@ class CylcTree {
     if (!this.lookup.has(cyclePoint.id)) {
       this.lookup.set(cyclePoint.id, cyclePoint)
       this.root.children.push(cyclePoint)
-      // Sort cycle points here.
-      // If the sorting is done in the query only, the first time we
-      // render the component it will be in the correct order. Then
-      // further updates will append to the list. That's why we have
-      // the sorting here and not in the query.
-      this.root.children.sort((cyclepoint, anotherCyclepoint) => {
-        return anotherCyclepoint.id.localeCompare(cyclepoint.id)
-      })
     }
   }
 

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -53,41 +53,41 @@ fragment WorkflowTreeDeltas on Deltas {
 fragment WorkflowTreeAddedData on Added {
   workflow {
     ...WorkflowData
-    cyclePoints: familyProxies(ids: ["root"], ghosts: true) {
+    cyclePoints: familyProxies (ids: ["root"], ghosts: true) {
       cyclePoint
     }
-    taskProxies(sort: { keys: ["cyclePoint"] }, ghosts: true) {
+    taskProxies (sort: { keys: ["name"], reverse: false }, ghosts: true) {
       ...TaskProxyData
       jobs(sort: { keys: ["submit_num"], reverse:true }) {
         ...JobData
       }
     }
-    familyProxies (exids: ["root"], sort: { keys: ["firstParent"]}, ghosts: true) {
+    familyProxies (exids: ["root"], sort: { keys: ["name"] }, ghosts: true) {
       ...FamilyProxyData
     }
   }
-  cyclePoints: familyProxies(ids: ["root"], ghosts: true) {
+  cyclePoints: familyProxies (ids: ["root"], ghosts: true) {
     cyclePoint
   }
-  familyProxies (exids: ["root"], sort: { keys: ["firstParent"]}, ghosts: true) {
+  familyProxies (exids: ["root"], sort: { keys: ["name"] }, ghosts: true) {
     ...FamilyProxyData
   }
-  taskProxies(sort: { keys: ["cyclePoint"] }, ghosts: true) {
+  taskProxies (sort: { keys: ["name"], reverse: false }, ghosts: true) {
     ...TaskProxyData
   }
-  jobs(sort: { keys: ["submit_num"], reverse:true }) {
+  jobs (sort: { keys: ["submit_num"], reverse:true }) {
     ...JobData
   }
 }
 
 fragment WorkflowTreeUpdatedData on Updated {
-  taskProxies(sort: { keys: ["cyclePoint"] }, ghosts: true) {
+  taskProxies (ghosts: true) {
     ...TaskProxyData
   }
-  jobs(sort: { keys: ["submit_num"], reverse:true }) {
+  jobs {
     ...JobData
   }
-  familyProxies (exids: ["root"], sort: { keys: ["firstParent"]}, ghosts: true) {
+  familyProxies (exids: ["root"], ghosts: true) {
     ...FamilyProxyData
   }
 }

--- a/src/mixins/treeitem.js
+++ b/src/mixins/treeitem.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import orderBy from 'lodash/orderBy'
+
+const treeitem = {
+  methods: {
+    /**
+     * Sort children based on the type of the node.
+     *
+     * Each type may have a different sorting strategy. For example,
+     * for nodes of type workflow, we know our children will be cycle points.
+     * So we may sort them by their `id`, and in ascending or descending
+     * order.
+     *
+     * Ditto for other types. This way we can control how to sort the children
+     * nodes of each node in the UI.
+     *
+     * Some elements are sorted in the GraphQL query, on the server-side. While
+     * some times these elements may have to be re-sorted, the best case
+     * scenario is that the elements are already in order, and the JS sorting
+     * algorithm doesn't have to sort anything.
+     *
+     * NOTE: the Array.sort algorithm implementation is browser-engine dependent,
+     * and also type dependent. One browser may use quick-sort for numeric arrays,
+     * and merge-sort for contiguous arrays of non-numeric types, and selection-sort for
+     * all the other cases (source: https://stackoverflow.com/questions/234683/javascript-array-sort-implementation
+     * and http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/runtime/ArrayPrototype.cpp?rev=138530#L647).
+     *
+     * @param type {string} - node type (e.g. 'workflow', 'cyclepoint', etc)
+     * @param children {Array} - node children (e.g. list of jobs of a task-proxy)
+     * @returns {Array} - sorted children
+     */
+    sortedChildren (type, children) {
+      if (children && children.length !== 0) {
+        switch (type) {
+        case 'workflow': {
+          // sort workflow children (cycle-points)
+          // sort by id descending, so '20100102' comes before '20100101'
+          return orderBy(children, ['id'], 'desc')
+        }
+        case 'cyclepoint': {
+          // sort cycle point children (family-proxies, and task-proxies)
+          // first we sort by type ascending, so 'family-proxy' types come before 'task-proxy'
+          // then we sort by node name ascending, so 'bar' comes before 'foo'
+          return orderBy(children, [child => child.type, child => child.node.name.toLowerCase()], ['asc', 'asc'])
+        }
+        case 'family-proxy': {
+          // sort family-proxy children (family-proxies, and task-proxies)
+          // first we sort by type ascending, so 'family-proxy' types come before 'task-proxy'
+          // then we sort by node name ascending, so 'bar' comes before 'foo'
+          return orderBy(children, [child => child.type, child => child.node.name.toLowerCase()], ['asc', 'asc'])
+        }
+        case 'task-proxy': {
+          // sort task-proxy children (jobs)
+          // sort by node submit  descending, so '4' comes before '3'
+          return orderBy(children, ['node.submitNum'], 'desc')
+        }
+        }
+      }
+      return children
+    }
+  }
+}
+
+export {
+  treeitem
+}

--- a/src/mixins/treeitem.js
+++ b/src/mixins/treeitem.js
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import orderBy from 'lodash/orderBy'
-
 const treeitem = {
   methods: {
     /**
@@ -51,24 +49,56 @@ const treeitem = {
         case 'workflow': {
           // sort workflow children (cycle-points)
           // sort by id descending, so '20100102' comes before '20100101'
-          return orderBy(children, ['id'], 'desc')
+          return [...children].sort((left, right) => {
+            return right.id.localeCompare(left.id)
+          })
         }
         case 'cyclepoint': {
           // sort cycle point children (family-proxies, and task-proxies)
           // first we sort by type ascending, so 'family-proxy' types come before 'task-proxy'
           // then we sort by node name ascending, so 'bar' comes before 'foo'
-          return orderBy(children, [child => child.type, child => child.node.name.toLowerCase()], ['asc', 'asc'])
+          return [...children].sort((left, right) => {
+            // node type
+            if (left.type < right.type) {
+              return -1
+            }
+            if (left.type > right.type) {
+              return 1
+            }
+            // name
+            return left.node.name.toLowerCase()
+              .localeCompare(
+                right.node.name.toLowerCase(),
+                undefined,
+                { numeric: true, sensitivity: 'base' })
+          })
         }
         case 'family-proxy': {
           // sort family-proxy children (family-proxies, and task-proxies)
           // first we sort by type ascending, so 'family-proxy' types come before 'task-proxy'
           // then we sort by node name ascending, so 'bar' comes before 'foo'
-          return orderBy(children, [child => child.type, child => child.node.name.toLowerCase()], ['asc', 'asc'])
+          return [...children].sort((left, right) => {
+            // node type
+            if (left.type < right.type) {
+              return -1
+            }
+            if (left.type > right.type) {
+              return 1
+            }
+            // name
+            return left.node.name.toLowerCase()
+              .localeCompare(
+                right.node.name.toLowerCase(),
+                undefined,
+                { numeric: true, sensitivity: 'base' })
+          })
         }
         case 'task-proxy': {
           // sort task-proxy children (jobs)
           // sort by node submit  descending, so '4' comes before '3'
-          return orderBy(children, ['node.submitNum'], 'desc')
+          return [...children].sort((left, right) => {
+            return right.node.submitNum - left.node.submitNum
+          })
         }
         }
       }

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -23,8 +23,8 @@ describe('Tree component', () => {
       .should(($div) => {
         // by default, in our expected viewport size for tests, both cycle points exist and are visible
         expect($div).to.have.length(2)
-        expect($div.get(0)).to.contain('20000101T0000Z')
-        expect($div.get(1)).to.contain('20000102T0000Z')
+        expect($div.get(0)).to.contain('20000102T0000Z')
+        expect($div.get(1)).to.contain('20000101T0000Z')
       })
     cy
       .get('.node-data-cyclepoint')

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -161,6 +161,25 @@ describe('TreeItem component', () => {
           { node: { name: 'foo' }, type: 'task-proxy' }
         ]
       },
+      {
+        args: {
+          type: 'family-proxy',
+          children: [
+            { node: { name: 'f01' }, type: 'task-proxy' },
+            { node: { name: 'f1' }, type: 'task-proxy' },
+            { node: { name: 'f10' }, type: 'task-proxy' },
+            { node: { name: 'f0' }, type: 'task-proxy' },
+            { node: { name: 'f2' }, type: 'task-proxy' }
+          ]
+        },
+        expected: [
+          { node: { name: 'f0' }, type: 'task-proxy' },
+          { node: { name: 'f01' }, type: 'task-proxy' },
+          { node: { name: 'f1' }, type: 'task-proxy' },
+          { node: { name: 'f2' }, type: 'task-proxy' },
+          { node: { name: 'f10' }, type: 'task-proxy' }
+        ]
+      },
       // task proxy children (jobs) are sorted by job submit number in descending order
       {
         args: {

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -27,6 +27,7 @@ import {
   simpleCyclepointNode,
   simpleTaskNode
 } from './tree.data'
+import { treeitem } from '@/mixins/treeitem'
 
 describe('TreeItem component', () => {
   const mountFunction = options => {
@@ -95,6 +96,93 @@ describe('TreeItem component', () => {
       const task = wrapper.findAllComponents({ name: 'TreeItem' })
       // 4 TreeItem components, 1 for workflow, 1 for cyclepoint, 1 for task, 1 for job
       expect(task.length).to.equal(4)
+    })
+  })
+  describe('mixin', () => {
+    const sortTestsData = [
+      // invalid values
+      {
+        args: {
+          type: '',
+          children: []
+        },
+        expected: []
+      },
+      {
+        args: {
+          type: null,
+          children: null
+        },
+        expected: null
+      },
+      // workflow children (cycle points) are sorted by ID in descending order
+      {
+        args: {
+          type: 'workflow',
+          children: [
+            { id: 'workflow|1' },
+            { id: 'workflow|2' }
+          ]
+        },
+        expected: [
+          { id: 'workflow|2' },
+          { id: 'workflow|1' }
+        ]
+      },
+      // cycle point children (family proxies and task proxies) are sorted by type in ascending order, and then name in ascending order
+      {
+        args: {
+          type: 'cyclepoint',
+          children: [
+            { node: { name: 'foo' }, type: 'task-proxy' },
+            { node: { name: 'FAM1' }, type: 'family-proxy' },
+            { node: { name: 'bar' }, type: 'task-proxy' }
+          ]
+        },
+        expected: [
+          { node: { name: 'FAM1' }, type: 'family-proxy' },
+          { node: { name: 'bar' }, type: 'task-proxy' },
+          { node: { name: 'foo' }, type: 'task-proxy' }
+        ]
+      },
+      // family proxy children (family proxies and task proxies) are sorted by type in ascending order, and then name in ascending order
+      {
+        args: {
+          type: 'family-proxy',
+          children: [
+            { node: { name: 'foo' }, type: 'task-proxy' },
+            { node: { name: 'FAM1' }, type: 'family-proxy' },
+            { node: { name: 'bar' }, type: 'task-proxy' }
+          ]
+        },
+        expected: [
+          { node: { name: 'FAM1' }, type: 'family-proxy' },
+          { node: { name: 'bar' }, type: 'task-proxy' },
+          { node: { name: 'foo' }, type: 'task-proxy' }
+        ]
+      },
+      // task proxy children (jobs) are sorted by job submit number in descending order
+      {
+        args: {
+          type: 'task-proxy',
+          children: [
+            { node: { submitNum: '2' } },
+            { node: { submitNum: '1' } },
+            { node: { submitNum: '3' } }
+          ]
+        },
+        expected: [
+          { node: { submitNum: '3' } },
+          { node: { submitNum: '2' } },
+          { node: { submitNum: '1' } }
+        ]
+      }
+    ]
+    sortTestsData.forEach((test) => {
+      it('should order elements correctly', () => {
+        const sorted = treeitem.methods.sortedChildren(test.args.type, test.args.children)
+        expect(sorted).to.deep.equal(test.expected)
+      })
     })
   })
 })


### PR DESCRIPTION
These changes close #469 

These changes partially address #333 (see https://github.com/cylc/cylc-ui/issues/333#issuecomment-651600058)

Cycle points showing newest data first. Tasks in alphabetical order, by name. Jobs by submit number, reverse (we display the first only, which is the latest).

We do not need to sort the deltas when updating or removing data. As the data returned is used to update existing data and nodes in the UI.

We are also not sorting the cycle points. The reason is that the cycle points are added to the tree one after the other. So if we already have data in the UI, adding new data, even if in order to the JS data, the browser won't display in order. It will just append the new data (in order) after the existing data.

So because of that, the cycle points are returned in any order. And then we modify the existing cycle point sorting code (i.e. we were already sorting in JS, so no performance issue here IMO) to just show the newest cycle point first.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.