### PR TITLE
Add global error catcher with Vue's errorCaptured

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ None or N/A.
 
 ### Enhancements
 
+[#497](https://github.com/cylc/cylc-ui/pull/497) - Add a global error
+catcher to the Default layout, to show uncaught errors.
+
 [#491](https://github.com/cylc/cylc-ui/pull/491) - Update apollo-client
 to @apollo/client (different package ID, also from 2.x to 3.x).
 

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -38,6 +38,8 @@ import Drawer from '@/components/cylc/Drawer'
 import Toolbar from '@/components/cylc/Toolbar'
 import ConnectionStatus from '@/components/cylc/ConnectionStatus'
 import { mapState } from 'vuex'
+import store from '@/store/'
+import AlertModel from '@/model/Alert.model'
 
 export default {
   name: 'Default',
@@ -51,6 +53,12 @@ export default {
 
   computed: {
     ...mapState(['offline'])
+  },
+
+  errorCaptured (error, vm, info) {
+    if (process.env.NODE_ENV !== 'production') {
+      store.dispatch('setAlert', new AlertModel(error, null, 'error'))
+    }
   }
 }
 </script>

--- a/tests/e2e/specs/layout.js
+++ b/tests/e2e/specs/layout.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+describe('Default layout', () => {
+  it('Should display errors from children elements captured at the Default layout level', () => {
+    // visit any page first, so that we create the window.app reference
+    cy.visit('/#/workflows/one')
+    cy
+      .get('.v-alert')
+      .should('not.be.visible')
+    cy.window().its('app.$workflowService').then(service => {
+      // mock service so that it returns an error
+      cy.stub(service, 'subscribe', () => {
+        throw new Error('Error raised in Cypress stub!')
+      })
+      // now visit dashboard, that calls service.subscribe, which will raise an uncaught error...
+      cy.visit('/#/')
+      cy
+        .get('.v-alert')
+        .should('be.visible')
+    })
+  })
+})


### PR DESCRIPTION
These changes close #465 

Now if an error occurs in the browser console, and if you are not in production mode (we can change this later if others think we should always display the message) it will display an error message.

I hope this will be useful specially when testing the UI with workflows during development. Sometimes the UI may look OK, but you could have hidden errors such as deltas no being applied. Ideally, we should never see that error message. 

This captures errors from children elements of the `Default` layout, that were not captured. Think of it as a `try { renderChildrenOfDefaultLayout } catch { # display error message }`.

![image](https://user-images.githubusercontent.com/304786/93413352-364d5300-f8f3-11ea-9f93-670b86d81157.png)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
