### PR TITLE
Hierarchical GScan

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@ to receive the deltas of workflow-subscriptions.
 [#625](https://github.com/cylc/cylc-ui/pull/625) - alert: repeated errors
 are ignored.
 
+[#502](https://github.com/cylc/cylc-ui/pull/502) - Hierarchical GScan.
+
 ### Fixes
 
 [#691](https://github.com/cylc/cylc-ui/pull/691) -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@ milestones](https://github.com/cylc/cylc-ui/milestones?state=closed) for each
 release.
 
 -------------------------------------------------------------------------------
+## __cylc-ui-0.6 (<span actions:bind='release-date'>Released 2021-??-??</span>)__
+
+### Enhancements
+
+[#502](https://github.com/cylc/cylc-ui/pull/502) - Hierarchical GScan.
+
+### Fixes
+
+-------------------------------------------------------------------------------
 ## __cylc-ui-0.5 (<span actions:bind='release-date'>Released 2021-07-28</span>)__
 
 ### Enhancements
@@ -47,8 +56,6 @@ to receive the deltas of workflow-subscriptions.
 
 [#625](https://github.com/cylc/cylc-ui/pull/625) - alert: repeated errors
 are ignored.
-
-[#502](https://github.com/cylc/cylc-ui/pull/502) - Hierarchical GScan.
 
 ### Fixes
 

--- a/src/components/cylc/common/deltas.js
+++ b/src/components/cylc/common/deltas.js
@@ -29,8 +29,30 @@
  */
 
 /**
- * @typedef {Object} WorkflowGraphQLData
- * @property {string} id
+ * A GraphQLData object represents an object from a GraphQL response as-is.
+ * It is wrapped within a Tree node, for instance, (i.e. a tree-node has a node), for
+ * when components need the raw object data from fetched with a query
+ * (e.g. the state of a task).
+ *
+ * The properties of this object vary depending on the query parameters,
+ * and the GraphQL schema. Use GraphiQL to confirm the data if necessary.
+ *
+ * @typedef {Object} GraphQLData
+ * @property {string} id - node ID
+ */
+
+/**
+ * @typedef {GraphQLData} WorkflowGraphQLData
+ * @property {string} name
+ * @property {string} status
+ * @property {string} owner
+ * @property {string} host
+ * @property {string} port
+ * @property {Object} stateTotals
+ * @property {Array<string>} latestStateTasks
+ * @property {?Array<GraphQLData>} cyclePoints
+ * @property {?Array<GraphQLData>} familyProxies
+ * @property {?Array<GraphQLData>} taskProxies
  */
 
 /**

--- a/src/components/cylc/common/sort.js
+++ b/src/components/cylc/common/sort.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Declare function used in sortedIndexBy as a comparator.
+ *
+ * @callback SortedIndexByComparator
+ * @param {object} leftObject - left parameter object
+ * @param {string} leftValue - left parameter value
+ * @param {object} rightObject - right parameter object
+ * @param {string} rightValue - right parameter value
+ * @returns {boolean} - true if leftValue is higher than rightValue
+ */
+
+/**
+ * The default comparator used to compare strings for cycle points, family proxies names,
+ * task proxies names, and jobs.
+ *
+ * @param left {string}
+ * @param right {string}
+ * @returns {number}
+ * @constructor
+ */
+export const DEFAULT_COMPARATOR = (left, right) => {
+  return left.toLowerCase()
+    .localeCompare(
+      right.toLowerCase(),
+      undefined,
+      {
+        numeric: true,
+        sensitivity: 'base'
+      }
+    )
+}
+
+/**
+ * Declare function used in sortedIndexBy for creating the iteratee.
+ *
+ * @callback SortedIndexByIteratee
+ * @param {Object} value - any object
+ * @returns {string}
+ */
+
+/**
+ * Given a list of elements, and a value to be added to the list, we
+ * perform a simple binary search of the list to determine the next
+ * index where the value can be inserted, so that the list remains
+ * sorted.
+ *
+ * This function uses localeCompare, which will respect the numeric
+ * collation.
+ *
+ * This is a simplified version of lodash's function with the same
+ * name, but that respects natural order for numbers, i.e. [1, 2, 10].
+ * Not [1, 10, 2].
+ *
+ * @param array {Array<object>} - list of string values, or of objects with string values
+ * @param value {object} - a value to be inserted in the list, or an object wrapping the value (see iteratee)
+ * @param iteratee {SortedIndexByIteratee=} - an optional function used to return the value of the element of the list}
+ * @param comparator {SortedIndexByComparator=} - function used to compare the newValue with otherValues in the list
+ * @return {number} - sorted index
+ */
+export function sortedIndexBy (array, value, iteratee, comparator) {
+  if (array.length === 0) {
+    return 0
+  }
+  // If given a function, use it. Otherwise, simply use identity function.
+  const iterateeFunction = iteratee || ((value) => value)
+  // If given a function, use it. Otherwise, simply use locale sort with numeric enabled
+  const comparatorFunction = comparator || ((leftObject, leftValue, rightObject, rightValue) => DEFAULT_COMPARATOR(leftValue, rightValue) > 0)
+  let low = 0
+  let high = array.length
+
+  const newValue = iterateeFunction(value)
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    const midValue = iterateeFunction(array[mid])
+    const higher = comparatorFunction(value, newValue, array[mid], midValue)
+    if (higher) {
+      low = mid + 1
+    } else {
+      high = mid
+    }
+  }
+  return high
+}

--- a/src/components/cylc/common/sort.js
+++ b/src/components/cylc/common/sort.js
@@ -81,7 +81,7 @@ export function sortedIndexBy (array, value, iteratee, comparator) {
   // If given a function, use it. Otherwise, simply use identity function.
   const iterateeFunction = iteratee || ((value) => value)
   // If given a function, use it. Otherwise, simply use locale sort with numeric enabled
-  const comparatorFunction = comparator || ((leftObject, leftValue, rightObject, rightValue) => DEFAULT_COMPARATOR(leftValue, rightValue) > 0)
+  const comparatorFunction = comparator || ((leftObject, leftValue, rightObject, rightValue) => DEFAULT_COMPARATOR(leftValue, rightValue))
   let low = 0
   let high = array.length
 
@@ -91,7 +91,7 @@ export function sortedIndexBy (array, value, iteratee, comparator) {
     const mid = Math.floor((low + high) / 2)
     const midValue = iterateeFunction(array[mid])
     const higher = comparatorFunction(value, newValue, array[mid], midValue)
-    if (higher) {
+    if (higher > 0) {
       low = mid + 1
     } else {
       high = mid

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -102,13 +102,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </div>
       <!-- data -->
       <div
-        v-if="!isLoading && sortedWorkflows && sortedWorkflows.length > 0"
+        v-if="!isLoading && filteredWorkflows && filteredWorkflows.length > 0"
         class="c-gscan-workflows"
       >
         <tree
           :filterable="false"
           :expand-collapse-toggle="false"
-          :workflows="sortedWorkflows"
+          :workflows="filteredWorkflows"
           class="c-gscan-workflow"
         >
           <template v-slot:node="scope">

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -119,7 +119,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <v-list-item-title>
                 <v-layout align-center align-content-center d-flex flex-nowrap>
                   <v-flex
-                    v-if="scope.node.type === 'workflow'"
+                    v-if="scope.node.type === 'workflow-name-part'"
+                    class="c-gscan-workflow-name"
+                  >
+                    <span>{{ scope.node.node.name || scope.node.id }}</span>
+                  </v-flex>
+                  <v-flex
+                    v-else-if="scope.node.type === 'workflow'"
                     class="c-gscan-workflow-name"
                   >
                     <workflow-icon
@@ -199,7 +205,7 @@ import { WorkflowState, WorkflowStateOrder } from '@/model/WorkflowState.model'
 import Job from '@/components/cylc/Job'
 import Tree from '@/components/cylc/tree/Tree'
 import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon'
-import { createWorkflowHierarchyFromName } from '@/components/cylc/gscan/nodes'
+import { createWorkflowNode } from '@/components/cylc/gscan/nodes'
 import { GSCAN_DELTAS_SUBSCRIPTION } from '@/graphql/queries'
 
 export default {
@@ -331,7 +337,7 @@ export default {
             { numeric: true, sensitivity: 'base' })
       })
         .map(workflow => {
-          return createWorkflowHierarchyFromName(workflow)
+          return createWorkflowNode(workflow, true)
         })
     }
   },

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -201,12 +201,12 @@ import uniq from 'lodash/uniq'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import TaskState from '@/model/TaskState.model'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
-import { WorkflowState, WorkflowStateOrder } from '@/model/WorkflowState.model'
+import { WorkflowState } from '@/model/WorkflowState.model'
 import Job from '@/components/cylc/Job'
 import Tree from '@/components/cylc/tree/Tree'
 import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon'
 import { addNodeToTree, createWorkflowNode } from '@/components/cylc/gscan/nodes'
-import { filterHierarchically, WORKFLOW_TYPES_ORDER } from '@/components/cylc/gscan/filters'
+import { filterHierarchically } from '@/components/cylc/gscan/filters'
 import { GSCAN_DELTAS_SUBSCRIPTION } from '@/graphql/queries'
 
 export default {
@@ -318,32 +318,6 @@ export default {
       const reducer = (acc, workflow) => addNodeToTree(createWorkflowNode(workflow, /* hierarchy */true), acc)
       return Object.values(this.workflows)
         .reduce(reducer, [])
-    },
-    /**
-     * Sort workflows by type first, showing running or paused workflows first,
-     * then stopped. Within each group, workflows are sorted alphabetically
-     * (natural sort).
-     */
-    sortedWorkflows () {
-      return [...this.filteredWorkflows].sort((left, right) => {
-        if (left.type !== right.type) {
-          return WORKFLOW_TYPES_ORDER.indexOf(left.type) - WORKFLOW_TYPES_ORDER.indexOf(right.type)
-        }
-        if (left.node.status !== right.node.status) {
-          const leftStateOrder = WorkflowStateOrder.get(left.node.status)
-          const rightStateOrder = WorkflowStateOrder.get(right.node.status)
-          // Here we compare the order of states, not the states since some states
-          // are grouped together, like RUNNING, PAUSED, and STOPPING.
-          if (leftStateOrder !== rightStateOrder) {
-            return leftStateOrder - rightStateOrder
-          }
-        }
-        return left.node.name
-          .localeCompare(
-            right.node.name,
-            undefined,
-            { numeric: true, sensitivity: 'base' })
-      })
     },
     /**
      * @return {Array<String>}

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -199,7 +199,7 @@ import { WorkflowState, WorkflowStateOrder } from '@/model/WorkflowState.model'
 import Job from '@/components/cylc/Job'
 import Tree from '@/components/cylc/tree/Tree'
 import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon'
-import { createWorkflowNode } from '@/components/cylc/gscan/nodes'
+import { createWorkflowHierarchyFromName } from '@/components/cylc/gscan/nodes'
 import { GSCAN_DELTAS_SUBSCRIPTION } from '@/graphql/queries'
 
 export default {
@@ -331,7 +331,7 @@ export default {
             { numeric: true, sensitivity: 'base' })
       })
         .map(workflow => {
-          return createWorkflowNode(workflow)
+          return createWorkflowHierarchyFromName(workflow)
         })
     }
   },

--- a/src/components/cylc/gscan/filters.js
+++ b/src/components/cylc/gscan/filters.js
@@ -23,7 +23,7 @@ import JobState from '@/model/JobState.model'
  * @returns {boolean}
  */
 export function filterByName (workflow, name) {
-  return workflow.node.name.includes(name)
+  return workflow.node.name.toLowerCase().includes(name.toLowerCase())
 }
 
 /**

--- a/src/components/cylc/gscan/filters.js
+++ b/src/components/cylc/gscan/filters.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import JobState from '@/model/JobState.model'
+
+/**
+ * @param {WorkflowGScanNode|WorkflowNamePartGScanNode} workflow
+ * @param {string} name - name filter
+ * @returns {boolean}
+ */
+export function filterByName (workflow, name) {
+  return workflow.node.name.includes(name)
+}
+
+/**
+ * @private
+ * @param stateTotals {Object} - object with the keys being states, and values the count
+ * @return {Array<String>}
+ */
+function getWorkflowStates (stateTotals) {
+  const jobStates = JobState.enumValues.map(jobState => jobState.name)
+  return !stateTotals
+    ? []
+    : Object
+      .entries(stateTotals)
+      .filter(stateTotal => {
+        // GraphQL will return all the task states possible in a workflow, but we
+        // only want the states that have an equivalent state for a job. So we filter
+        // out the states that do not exist for jobs, and that have active tasks in
+        // the workflow (no point keeping the empty states, as they are not to be
+        // displayed).
+        return jobStates.includes(stateTotal[0]) && stateTotal[1] > 0
+      })
+      .map(stateTotal => stateTotal[0])
+}
+
+/**
+ * @param {WorkflowGScanNode|WorkflowNamePartGScanNode} workflow
+ * @param {Array<String>} workflowStates
+ * @param {Array<String>} taskStates
+ * @returns {boolean}
+ */
+export function filterByState (workflow, workflowStates, taskStates) {
+  // workflow states
+  if (!workflowStates.includes(workflow.node.status)) {
+    return false
+  }
+  // task states
+  if (taskStates.length > 0) {
+    const intersection = getWorkflowStates(workflow.node.stateTotals)
+      .filter(item => taskStates.includes(item))
+    return intersection.length !== 0
+  }
+  return true
+}
+
+/**
+ * Filter a workflow using a given name (could be a part of
+ * a name) and a given list of filters.
+ *
+ * The list of filters may contain workflow states ("running", "stopped",
+ * "paused"), and/or task states ("running", "waiting", "submit-failed",
+ * etc).
+ *
+ * @param {WorkflowGScanNode|WorkflowNamePartGScanNode} workflow
+ * @param {string} name
+ * @param {Array<String>} workflowStates
+ * @param {Array<String>} taskStates
+ * @return {boolean} - true if the workflow is accepted, false otherwise
+ */
+function filterWorkflow (workflow, name, workflowStates, taskStates) {
+  let filtered = false
+  // Filter by name.
+  if (name && name !== '') {
+    filtered = filterByName(workflow, name)
+    // Stop if we know that the name was not accepted.
+    if (!filtered) {
+      return filtered
+    }
+  }
+  // Now filter using the provided list of states. We know that the name has been
+  // accepted at this point.
+  filtered = filterByState(workflow, workflowStates, taskStates)
+  return filtered
+}
+
+/**
+ * @param {Array<WorkflowGScanNode|WorkflowNamePartGScanNode>} workflows
+ * @param {String} name
+ * @param {Array<String>} workflowStates
+ * @param {Array<String>} taskStates
+ * @returns {Array<WorkflowGScanNode|WorkflowNamePartGScanNode>} - filtered workflows
+ * @see https://stackoverflow.com/questions/45289854/how-to-effectively-filter-tree-view-retaining-its-existing-structure
+ */
+export function filterHierarchically (workflows, name, workflowStates, taskStates) {
+  const filterChildren = (result, workflowNode) => {
+    if (workflowNode.type === 'workflow') {
+      if (filterWorkflow(workflowNode, name, workflowStates, taskStates)) {
+        result.push(workflowNode)
+        return result
+      }
+    } else if (workflowNode.type === 'workflow-name-part' && workflowNode.children.length) {
+      const children = workflowNode.children.reduce(filterChildren, [])
+      if (children.length) {
+        result.push({ ...workflowNode, children })
+      }
+    }
+    return result
+  }
+  return workflows.reduce(filterChildren, [])
+}
+
+export const WORKFLOW_TYPES_ORDER = ['workflow-name-part', 'workflow']

--- a/src/components/cylc/gscan/filters.js
+++ b/src/components/cylc/gscan/filters.js
@@ -123,5 +123,3 @@ export function filterHierarchically (workflows, name, workflowStates, taskState
   }
   return workflows.reduce(filterChildren, [])
 }
-
-export const WORKFLOW_TYPES_ORDER = ['workflow-name-part', 'workflow']

--- a/src/components/cylc/gscan/nodes.js
+++ b/src/components/cylc/gscan/nodes.js
@@ -23,17 +23,83 @@
  */
 
 /**
- * Create a workflow node for GScan component.
+ * Create a new Workflow Node.
  *
+ * @private
  * @param {WorkflowGraphQLData} workflow
  * @returns {{node, id, type: string}}
  */
-function createWorkflowNode (workflow) {
+function newWorkflowNode (workflow) {
   return {
     id: workflow.id,
     type: 'workflow',
     node: workflow
   }
+}
+
+/**
+ * @param {string} id
+ * @param {string} part
+ */
+function newWorkflowPartNode (id, part) {
+  return {
+    id: id,
+    type: 'workflow-name-part',
+    node: {
+      id: id,
+      name: part,
+      status: ''
+    },
+    children: []
+  }
+}
+
+/**
+ * Create a workflow node for GScan component.
+ *
+ * If the `hierarchy` parameter is `true`, then the workflow name will be split by
+ * `/`'s. For each part, a new `WorkflowNamePart` will be added in the hierarchy.
+ * With the final node being the last part of the name.
+ *
+ * The last part of a workflow name may be the workflow name (e.g. `five`), or its
+ * run ID (e.g. `run1`, if workflow name is `five/run1`).
+ *
+ * @param {WorkflowGraphQLData} workflow
+ * @param {boolean} hierarchy - whether to parse the Workflow name and create a hierarchy or not
+ * @returns {{node, id, type: string}|null}
+ */
+function createWorkflowNode (workflow, hierarchy) {
+  if (!hierarchy) {
+    return newWorkflowNode(workflow)
+  }
+  const workflowIdParts = workflow.id.split('|')
+  // The prefix contains all the ID parts, except for the workflow name.
+  let prefix = workflowIdParts.slice(0, workflowIdParts.length - 1)
+  // The name is here.
+  const workflowName = workflow.name
+  const parts = workflowName.split('/')
+  // Returned node...
+  let rootNode = null
+  // And a helper used when iterating the array...
+  let currentNode = null
+  while (parts.length > 0) {
+    const part = parts.shift()
+    // For the first part, we need to add an ID separator `|`, but for the other parts
+    // we actually want to use the name parts separator `/`.
+    prefix = prefix.includes('/') ? `${prefix}/${part}` : `${prefix}|${part}`
+    const partNode = parts.length !== 0
+      ? newWorkflowPartNode(prefix, part)
+      : newWorkflowNode(workflow)
+    partNode.node.name = part
+
+    if (rootNode === null) {
+      rootNode = currentNode = partNode
+    } else {
+      currentNode.children.push(partNode)
+      currentNode = partNode
+    }
+  }
+  return rootNode
 }
 
 export {

--- a/src/components/cylc/gscan/nodes.js
+++ b/src/components/cylc/gscan/nodes.js
@@ -61,7 +61,7 @@ function newWorkflowNode (workflow, part) {
  */
 function newWorkflowPartNode (id, part) {
   return {
-    id: id,
+    id: `workflow-name-part-${id}`,
     name: part,
     type: 'workflow-name-part',
     node: {
@@ -130,10 +130,10 @@ function createWorkflowNode (workflow, hierarchy) {
  * @return {Array<WorkflowGScanNode|WorkflowNamePartGScanNode>}
  */
 function addNodeToTree (node, nodes) {
-  // N.B.: We must compare nodes by ID, not by part-name, since we can have
-  //       research/nwp/run1 workflow, and research workflow; in this case
-  //       we do not want to confuse the research part-name with the research
-  //       workflow.
+  // N.B.: We must compare nodes by ID, not only by part-name,
+  //       since we can have research/nwp/run1 workflow, and research workflow;
+  //       in this case we do not want to confuse the research part-name with
+  //       the research workflow.
   const existingNode = nodes.find((existingNode) => existingNode.id === node.id)
   if (!existingNode) {
     // Here we calculate what is the index for this element. If we decide to have ASC and DESC,

--- a/src/components/cylc/gscan/sort.js
+++ b/src/components/cylc/gscan/sort.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
+import WorkflowState from '@/model/WorkflowState.model'
+
+export const WORKFLOW_TYPES_ORDER = ['workflow-name-part', 'workflow']
+
+/**
+ * @typedef {SortedIndexByComparator} SortTaskProxyOrFamilyProxyComparator
+ * @param {TaskProxyNode|FamilyProxyNode} leftObject
+ * @param {string} leftValue
+ * @param {TaskProxyNode|FamilyProxyNode} rightObject
+ * @param {string} rightValue
+ * @returns {boolean}
+ */
+
+/**
+ * Sort workflows by type first, showing running or paused workflows first,
+ * then stopped. Within each group, workflows are sorted alphabetically
+ * (natural sort).
+ * @param leftObject
+ * @param leftValue
+ * @param rightObject
+ * @param rightValue
+ * @returns {boolean|number}
+ */
+export function sortWorkflowNamePartNodeOrWorkflowNode (leftObject, leftValue, rightObject, rightValue) {
+  if (leftObject.node.type !== rightObject.node.type) {
+    return WORKFLOW_TYPES_ORDER.indexOf(leftObject.node.type) - WORKFLOW_TYPES_ORDER.indexOf(rightObject.node.type)
+  }
+  if (leftObject.node.status !== rightObject.node.status) {
+    const leftState = WorkflowState.enumValueOf(leftObject.node.status.toUpperCase())
+    const rightState = WorkflowState.enumValueOf(rightObject.node.status.toUpperCase())
+    // FIXME: waiting for https://github.com/cylc/cylc-ui/pull/703
+    //        which fixes another issue in GScan... Note to self,
+    //        look at the DIFF in GitHub when resolving conflicts!
+    if (!leftState || !leftState.enumOrdinal) {
+      return 1
+    }
+    if (!rightState || !rightState.enumOrdinal) {
+      return -1
+    }
+    return leftState.enumOrdinal - rightState.enumOrdinal
+  }
+  // name
+  return DEFAULT_COMPARATOR(leftValue, rightValue) > 0
+}

--- a/src/components/cylc/gscan/sort.js
+++ b/src/components/cylc/gscan/sort.js
@@ -16,7 +16,7 @@
  */
 
 import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
-import WorkflowState from '@/model/WorkflowState.model'
+import { WorkflowStateOrder } from '@/model/WorkflowState.model'
 
 export const WORKFLOW_TYPES_ORDER = ['workflow-name-part', 'workflow']
 
@@ -40,23 +40,18 @@ export const WORKFLOW_TYPES_ORDER = ['workflow-name-part', 'workflow']
  * @returns {boolean|number}
  */
 export function sortWorkflowNamePartNodeOrWorkflowNode (leftObject, leftValue, rightObject, rightValue) {
-  if (leftObject.node.type !== rightObject.node.type) {
+  if (leftObject.type !== rightObject.type) {
     return WORKFLOW_TYPES_ORDER.indexOf(leftObject.node.type) - WORKFLOW_TYPES_ORDER.indexOf(rightObject.node.type)
   }
   if (leftObject.node.status !== rightObject.node.status) {
-    const leftState = WorkflowState.enumValueOf(leftObject.node.status.toUpperCase())
-    const rightState = WorkflowState.enumValueOf(rightObject.node.status.toUpperCase())
-    // FIXME: waiting for https://github.com/cylc/cylc-ui/pull/703
-    //        which fixes another issue in GScan... Note to self,
-    //        look at the DIFF in GitHub when resolving conflicts!
-    if (!leftState || !leftState.enumOrdinal) {
-      return 1
+    const leftStateOrder = WorkflowStateOrder.get(leftObject.node.status)
+    const rightStateOrder = WorkflowStateOrder.get(rightObject.node.status)
+    // Here we compare the order of states, not the states since some states
+    // are grouped together, like RUNNING, PAUSED, and STOPPING.
+    if (leftStateOrder !== rightStateOrder) {
+      return leftStateOrder - rightStateOrder
     }
-    if (!rightState || !rightState.enumOrdinal) {
-      return -1
-    }
-    return leftState.enumOrdinal - rightState.enumOrdinal
   }
   // name
-  return DEFAULT_COMPARATOR(leftValue, rightValue) > 0
+  return DEFAULT_COMPARATOR(leftValue, rightValue)
 }

--- a/src/components/cylc/gscan/sort.js
+++ b/src/components/cylc/gscan/sort.js
@@ -41,7 +41,7 @@ export const WORKFLOW_TYPES_ORDER = ['workflow-name-part', 'workflow']
  */
 export function sortWorkflowNamePartNodeOrWorkflowNode (leftObject, leftValue, rightObject, rightValue) {
   if (leftObject.type !== rightObject.type) {
-    return WORKFLOW_TYPES_ORDER.indexOf(leftObject.node.type) - WORKFLOW_TYPES_ORDER.indexOf(rightObject.node.type)
+    return WORKFLOW_TYPES_ORDER.indexOf(leftObject.type) - WORKFLOW_TYPES_ORDER.indexOf(rightObject.type)
   }
   if (leftObject.node.status !== rightObject.node.status) {
     const leftStateOrder = WorkflowStateOrder.get(leftObject.node.status)

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -14,11 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { extractGroupState } from '@/utils/tasks'
-import { mergeWith } from 'lodash'
-import { createFamilyProxyNode, getCyclePointId } from '@/components/cylc/tree/nodes'
 import Vue from 'vue'
+import { mergeWith } from 'lodash'
+import { extractGroupState } from '@/utils/tasks'
 import { mergeWithCustomizer } from '@/components/cylc/common/merge'
+import { createFamilyProxyNode, getCyclePointId } from '@/components/cylc/tree/nodes'
 
 export const FAMILY_ROOT = 'root'
 

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -18,6 +18,8 @@ import Vue from 'vue'
 import { mergeWith } from 'lodash'
 import { extractGroupState } from '@/utils/tasks'
 import { mergeWithCustomizer } from '@/components/cylc/common/merge'
+import { sortedIndexBy } from '@/components/cylc/common/sort'
+import { sortTaskProxyOrFamilyProxy } from '@/components/cylc/tree/sort'
 import { createFamilyProxyNode, getCyclePointId } from '@/components/cylc/tree/nodes'
 
 export const FAMILY_ROOT = 'root'
@@ -59,116 +61,6 @@ function computeCyclePointsStates (cyclePointNodes) {
     // not have the .state property. So we need to ask Vue to make it reactive.
     Vue.set(cyclePointNode.node, 'state', cyclePointState)
   }
-}
-
-/**
- * The default comparator used to compare strings for cycle points, family proxies names,
- * task proxies names, and jobs.
- *
- * @param left {string}
- * @param right {string}
- * @returns {number}
- * @constructor
- */
-const DEFAULT_COMPARATOR = (left, right) => {
-  return left.toLowerCase()
-    .localeCompare(
-      right.toLowerCase(),
-      undefined,
-      {
-        numeric: true,
-        sensitivity: 'base'
-      }
-    )
-}
-
-/**
- * Declare function used in sortedIndexBy as a comparator.
- *
- * @private
- * @callback SortedIndexByComparator
- * @param {object} leftObject - left parameter object
- * @param {string} leftValue - left parameter value
- * @param {object} rightObject - right parameter object
- * @param {string} rightValue - right parameter value
- * @returns {boolean} - true if leftValue is higher than rightValue
- */
-
-/**
- * @private
- * @typedef {SortedIndexByComparator} SortTaskProxyOrFamilyProxyComparator
- * @param {TaskProxyNode|FamilyProxyNode} leftObject
- * @param {string} leftValue
- * @param {TaskProxyNode|FamilyProxyNode} rightObject
- * @param {string} rightValue
- * @returns {boolean}
- */
-function sortTaskProxyOrFamilyProxy (leftObject, leftValue, rightObject, rightValue) {
-  // sort cycle point children (family-proxies, and task-proxies)
-  // first we sort by type ascending, so 'family-proxy' types come before 'task-proxy'
-  // then we sort by node name ascending, so 'bar' comes before 'foo'
-  // node type
-  if (leftObject.type < rightObject.type) {
-    return -1
-  }
-  if (leftObject.type > rightObject.type) {
-    return 1
-  }
-  // name
-  return DEFAULT_COMPARATOR(leftValue, rightValue) > 0
-}
-
-/**
- * Declare function used in sortedIndexBy for creating the iteratee.
- *
- * @callback SortedIndexByIteratee
- * @param {Object} value - any object
- * @returns {string}
- */
-
-/**
- * Given a list of elements, and a value to be added to the list, we
- * perform a simple binary search of the list to determine the next
- * index where the value can be inserted, so that the list remains
- * sorted.
- *
- * This function uses localeCompare, which will respect the numeric
- * collation.
- *
- * This is a simplified version of lodash's function with the same
- * name, but that respects natural order for numbers, i.e. [1, 2, 10].
- * Not [1, 10, 2].
- *
- * @private
- * @param array {Array<object>} - list of string values, or of objects with string values
- * @param value {object} - a value to be inserted in the list, or an object wrapping the value (see iteratee)
- * @param iteratee {SortedIndexByIteratee=} - an optional function used to return the value of the element of the list}
- * @param comparator {SortedIndexByComparator=} - function used to compare the newValue with otherValues in the list
- */
-function sortedIndexBy (array, value, iteratee, comparator) {
-  if (array.length === 0) {
-    return 0
-  }
-  // If given a function, use it. Otherwise, simply use identity function.
-  const iterateeFunction = iteratee || ((value) => value)
-  // If given a function, use it. Otherwise, simply use locale sort with numeric enabled
-  const comparatorFunction = comparator || ((leftObject, leftValue, rightObject, rightValue) => DEFAULT_COMPARATOR(leftValue, rightValue) > 0)
-  let low = 0
-  let high = array.length
-
-  const newValue = iterateeFunction(value)
-
-  while (low < high) {
-    const mid = Math.floor((low + high) / 2)
-    const midValue = iterateeFunction(array[mid])
-    const higher = comparatorFunction(value, newValue, array[mid], midValue)
-    if (higher) {
-      low = mid + 1
-    } else {
-      high = mid
-    }
-  }
-  return high
 }
 
 /**

--- a/src/components/cylc/tree/nodes.js
+++ b/src/components/cylc/tree/nodes.js
@@ -343,11 +343,64 @@ function createJobNode (job) {
   }
 }
 
+function createWorkflowHierarchyFromName (workflow) {
+  if (workflow.name.indexOf('/') === -1) {
+    return Object.assign(
+      createWorkflowNode(workflow),
+      {
+        children: null,
+        text: workflow.name
+      })
+  }
+  const parts = workflow.name.split('/')
+  const hierarchyPart = parts.slice(0, parts.length - 1)
+  const workflowPart = parts[parts.length - 1]
+  let workflowHierarchy = null
+  /**
+   * @type {null|{
+   *   text: string,
+   *   type: string,
+   *   children: []
+   * }}
+   */
+  let lastPart = null
+  while (hierarchyPart.length > 0) {
+    const part = {
+      id: `${workflow.id}-${hierarchyPart[0]}`,
+      type: 'workflow-name-part',
+      text: hierarchyPart[0],
+      children: []
+    }
+    if (lastPart === null) {
+      // first part
+      workflowHierarchy = part
+    } else {
+      // otherwise just push down the hierarchy
+      lastPart.children.push(part)
+    }
+    lastPart = part
+    // remove head
+    hierarchyPart.splice(0, 1)
+  }
+  // finally, add the workflow to the end of the hierarchy
+  lastPart.children.push(
+    Object.assign(
+      createWorkflowNode(workflow),
+      {
+        text: workflowPart,
+        children: null
+      }
+    )
+  )
+  return workflowHierarchy
+}
+
 export {
   createWorkflowNode,
   createCyclePointNode,
   createFamilyProxyNode,
   createTaskProxyNode,
   createJobNode,
-  getCyclePointId
+  getCyclePointId,
+  createWorkflowHierarchyFromName
 }

--- a/src/components/cylc/tree/nodes.js
+++ b/src/components/cylc/tree/nodes.js
@@ -19,33 +19,6 @@ import TaskOutput from '@/model/TaskOutput.model'
 import Vue from 'vue'
 
 /**
- * A GraphQLData object represents an object from a GraphQL response as-is.
- * It is wrapped within a Tree node (i.e. a tree-node has a node), for
- * when components need the raw object data from fetched with a query
- * (e.g. the state of a task).
- *
- * The properties of this object vary depending on the query parameters,
- * and the GraphQL schema. Use GraphiQL to confirm the data if necessary.
- *
- * @typedef {Object} GraphQLData
- * @property {string} id - node ID
- */
-
-/**
- * @typedef {GraphQLData} WorkflowGraphQLData
- * @property {string} name
- * @property {string} status
- * @property {string} owner
- * @property {string} host
- * @property {string} port
- * @property {Object} stateTotals
- * @property {Array<string>} latestStateTasks
- * @property {?Array<GraphQLData>} cyclePoints
- * @property {?Array<GraphQLData>} familyProxies
- * @property {?Array<GraphQLData>} taskProxies
- */
-
-/**
  * A node of the tree, with the GraphQL data objects organized
  * hierarchically.
  *

--- a/src/components/cylc/tree/nodes.js
+++ b/src/components/cylc/tree/nodes.js
@@ -343,64 +343,11 @@ function createJobNode (job) {
   }
 }
 
-function createWorkflowHierarchyFromName (workflow) {
-  if (workflow.name.indexOf('/') === -1) {
-    return Object.assign(
-      createWorkflowNode(workflow),
-      {
-        children: null,
-        text: workflow.name
-      })
-  }
-  const parts = workflow.name.split('/')
-  const hierarchyPart = parts.slice(0, parts.length - 1)
-  const workflowPart = parts[parts.length - 1]
-  let workflowHierarchy = null
-  /**
-   * @type {null|{
-   *   text: string,
-   *   type: string,
-   *   children: []
-   * }}
-   */
-  let lastPart = null
-  while (hierarchyPart.length > 0) {
-    const part = {
-      id: `${workflow.id}-${hierarchyPart[0]}`,
-      type: 'workflow-name-part',
-      text: hierarchyPart[0],
-      children: []
-    }
-    if (lastPart === null) {
-      // first part
-      workflowHierarchy = part
-    } else {
-      // otherwise just push down the hierarchy
-      lastPart.children.push(part)
-    }
-    lastPart = part
-    // remove head
-    hierarchyPart.splice(0, 1)
-  }
-  // finally, add the workflow to the end of the hierarchy
-  lastPart.children.push(
-    Object.assign(
-      createWorkflowNode(workflow),
-      {
-        text: workflowPart,
-        children: null
-      }
-    )
-  )
-  return workflowHierarchy
-}
-
 export {
   createWorkflowNode,
   createCyclePointNode,
   createFamilyProxyNode,
   createTaskProxyNode,
   createJobNode,
-  getCyclePointId,
-  createWorkflowHierarchyFromName
+  getCyclePointId
 }

--- a/src/components/cylc/tree/sort.js
+++ b/src/components/cylc/tree/sort.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
+
+/**
+ * Sort cycle point children (family-proxies, and task-proxies) first we sort by type ascending, so 'family-proxy'
+ * types come before 'task-proxy' then we sort by node name ascending, so 'bar' comes before 'foo' node type.
+ *
+ * @param {TaskProxyNode|FamilyProxyNode} leftObject
+ * @param {string} leftValue
+ * @param {TaskProxyNode|FamilyProxyNode} rightObject
+ * @param {string} rightValue
+ * @return {number}
+ */
+export function sortTaskProxyOrFamilyProxy (leftObject, leftValue, rightObject, rightValue) {
+  if (leftObject.type < rightObject.type) {
+    return -1
+  }
+  if (leftObject.type > rightObject.type) {
+    return 1
+  }
+  // name
+  return DEFAULT_COMPARATOR(leftValue, rightValue)
+}

--- a/src/services/mock/json/GscanSubscriptionQuery.json
+++ b/src/services/mock/json/GscanSubscriptionQuery.json
@@ -1,7 +1,7 @@
 {
   "workflow": {
-    "id": "user|one",
-    "name": "one",
+    "id": "user|research/test/one/run1",
+    "name": "research/test/one/run1",
     "status": "running",
     "owner": "user",
     "host": "localhost",

--- a/src/services/mock/json/GscanSubscriptionQuery.json
+++ b/src/services/mock/json/GscanSubscriptionQuery.json
@@ -1,7 +1,7 @@
 {
   "workflow": {
-    "id": "user|research/test/one/run1",
-    "name": "research/test/one/run1",
+    "id": "user|one",
+    "name": "one",
     "status": "running",
     "owner": "user",
     "host": "localhost",

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -51,7 +51,7 @@ const state = {
    * This contains a list of workflows returned from GraphQL and is used by components
    * such as GScan, Dashboard, and WorkflowsTable.
    *
-   * @type {Array<Object>}
+   * @type {Array<WorkflowGraphQLData>}
    */
   workflows: [],
   /**

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@import '~vuetify/src/styles/styles';
+
 .c-gscan {
   .v-skeleton-loader > div:first-child {
     background: inherit;
   }
   .c-gscan-workflows {
     .c-gscan-workflow {
-      padding: 0 !important;
-      margin: 0 !important;
       a.c-workflow-stopped {
         opacity: 0.5;
       }
@@ -34,6 +34,19 @@
       .c-gscan-workflow-states {
         span.empty-state {
           opacity: 0.2;
+        }
+      }
+
+      .treeitem {
+        .node {
+          display: flex;
+          align-items: center;
+
+          .v-list-item {
+            &:hover {
+              background-color: map-get($grey, 'lighten-2');
+            }
+          }
         }
       }
     }

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -220,7 +220,13 @@ describe('GScan component', () => {
             { name: 'a/b', status: WorkflowState.RUNNING }
           ]),
           expected: ['b', 'a']
->>>>>>> Fix unit tests and fix bugs found while doing so
+        },
+        {
+          workflows: createWorkflows([
+            { name: 'a/b', status: WorkflowState.RUNNING },
+            { name: 'a', status: WorkflowState.RUNNING }
+          ]),
+          expected: ['b', 'a']
         }
       ]
       tests.forEach(test => {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -211,7 +211,7 @@ describe('GScan component', () => {
             { name: 'k', status: WorkflowState.RUNNING },
             { name: 'l', status: WorkflowState.PAUSED }
           ]),
-          expected: ['b', 'k', 'a', 'e', 'f', 'l', 'h', 'j', 'c', 'd', 'i', 'g']
+          expected: ['a', 'b', 'e', 'f', 'h', 'j', 'k', 'l', 'c', 'd', 'i', 'g']
         },
         // sorting by type too
         {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -366,6 +366,14 @@ describe('GScan component', () => {
             expected: 1
           },
           {
+            searchWorkflow: 'NEW',
+            expected: 1
+          },
+          {
+            searchWorkflow: 'neW',
+            expected: 1
+          },
+          {
             searchWorkflow: 'land',
             expected: 2
           },


### PR DESCRIPTION
Related to #139 

* Brings hierarchy into GScan, using existing Tree, TreeItem, Job, and Task components.
* Creates modules for `sort`, `filter` (will spread this pattern to other components over next PR's/days/weeks/...).
* Makes the filter workflow name field case-insensitive (i.e. searching for `RUN1` will include a workflow like `five/run1`).
* Has a known bug in sorting by status, see comment below, and pending #703 
* I think I could try some performance improvements, for instance, for every delta received it goes over the tree, finds the next insertion index, filters, etc... if you have 40 workflows, you will receive 40 workflows. We could debounce it and run this every second or every 500ms, giving time for more deltas to be applied and reduce computation in JS and DOM updates (confirmed the DOM is actually updated while the deltas are applied if not super-fast :disappointed_relieved: ). But this is for a next PR, maybe :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.

**Note for reviewers**: you may find workflows that are not sorted correctly by **status**. This is a known issue, with a fix already in review. This is what it may look like (`run4` is supposed to go up I think, as it is running, but Enumify is messing up).

![image](https://user-images.githubusercontent.com/304786/126568043-df60aa24-7be6-4f61-a459-c050f89e2591.png)


p.s.: to test calling the callback for a random delta, execute the following in the browser console

```js
var deltas = [
{
  "workflow": {
    "id": "user|research/test/one/run2",
    "name": "research/test/one/run2",
    "status": "running",
    "owner": "user",
    "host": "localhost",
    "port": 43079,
    "stateTotals": {
      "waiting": 1,
      "expired": 0,
      "preparing": 0,
      "submit-failed": 0,
      "submitted": 3,
      "running": 1,
      "failed": 0,
      "succeeded": 0
    },
    "latestStateTasks": {
      "running": [
        "running-task"
      ]
    }
  }
},
{
  "workflow": {
    "id": "user|research/test/two/run1",
    "name": "research/test/two/run1",
    "status": "running",
    "owner": "user",
    "host": "localhost",
    "port": 43079,
    "stateTotals": {
      "waiting": 1,
      "expired": 0,
      "preparing": 0,
      "submit-failed": 0,
      "submitted": 3,
      "running": 1,
      "failed": 0,
      "succeeded": 0
    },
    "latestStateTasks": {
      "running": [
        "running-task"
      ]
    }
  }
},
{
  "workflow": {
    "id": "research",
    "name": "research",
    "status": "running",
    "owner": "user",
    "host": "localhost",
    "port": 43079,
    "stateTotals": {
      "waiting": 1,
      "expired": 0,
      "preparing": 0,
      "submit-failed": 0,
      "submitted": 3,
      "running": 1,
      "failed": 0,
      "succeeded": 0
    },
    "latestStateTasks": {
      "running": [
        "running-task"
      ]
    }
  }
}
]
deltas.forEach((delta) => {
window.app.$store.dispatch('workflows/applyWorkflowsDeltas', { deltas: { added: delta } })
})
```