### PR TITLE
Use cycle point ID in the tree view structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,10 @@ and the development libraries.
 [#483](https://github.com/cylc/cylc-ui/pull/458) - Filter tree item
 by tasks name and tasks states.
 
+[#505](https://github.com/cylc/cylc-ui/pull/505) - Use cycle point ID
+in the tree view structure.
+
+
 ### Fixes
 
 None.

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -38,17 +38,48 @@ function createWorkflowNode (workflow) {
 }
 
 /**
+ * Create a cycle point node ID. Uses the node property `id`.
+ *
+ * It will split the node ID using the separator. And if the number
+ * of tokens is at least three, it will return the three first tokens
+ * joined by the separator too.
+ *
+ * Otherwise returns the node ID.
+ *
+ * For example, given a node with the following ID's:
+ *
+ * - 'a|b|c|d'    results in a cycle point node ID 'a|b|c'
+ * - 'a|b|c|d|e'  results in a cycle point node ID 'a|b|c'
+ * - 'a|b|c'      results in a cycle point node ID 'a|b|c'
+ * - 'a|b'        results in a cycle point node ID 'a|b'
+ * - ''           results in a cycle point node ID ''
+ *
+ * @param node {{
+ *   id: string
+ * }} a tree node
+ * @return {string}
+ */
+function getCyclePointId (node) {
+  const tokens = node.id.split('|')
+  if (tokens.length >= 3) {
+    return tokens.splice(0, 3).join('|')
+  }
+  return node.id
+}
+
+/**
  * Create a cycle point node. Uses the family proxy property `cyclePoint`.
  *
  * @param familyProxy {Object} family proxy
  * @return {{id: string, type: string, node: Object, children: []}}
  */
 function createCyclePointNode (familyProxy) {
+  const id = getCyclePointId(familyProxy)
   return {
-    id: familyProxy.cyclePoint,
+    id: id,
     type: 'cyclepoint',
     node: {
-      id: familyProxy.cyclePoint,
+      id: id,
       name: familyProxy.cyclePoint
     },
     children: []
@@ -168,5 +199,6 @@ export {
   createTaskProxyNode,
   createJobNode,
   containsTreeData,
-  populateTreeFromGraphQLData
+  populateTreeFromGraphQLData,
+  getCyclePointId
 }

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -64,7 +64,8 @@ function getCyclePointId (node) {
   if (tokens.length >= 3) {
     return tokens.splice(0, 3).join('|')
   }
-  return node.id
+  const nodeId = node.id ? node.id : 'undefined'
+  throw new Error(`Error extracting cycle point ID from node ID ${nodeId}`)
 }
 
 /**

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -54,7 +54,7 @@ fragment WorkflowTreeAddedData on Added {
   workflow {
     ...WorkflowData
     cyclePoints: familyProxies (ids: ["root"], ghosts: true) {
-      cyclePoint
+      ...CyclePointData
     }
     taskProxies (sort: { keys: ["name"], reverse: false }, ghosts: true) {
       ...TaskProxyData
@@ -67,7 +67,7 @@ fragment WorkflowTreeAddedData on Added {
     }
   }
   cyclePoints: familyProxies (ids: ["root"], ghosts: true) {
-    cyclePoint
+    ...CyclePointData
   }
   familyProxies (exids: ["root"], sort: { keys: ["name"] }, ghosts: true) {
     ...FamilyProxyData
@@ -109,6 +109,11 @@ fragment WorkflowData on Workflow {
   owner
   host
   port
+}
+
+fragment CyclePointData on FamilyProxy {
+  id
+  cyclePoint
 }
 
 fragment FamilyProxyData on FamilyProxy {

--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -24,296 +24,14 @@ const checkpoint = {
             "status": "running",
             "owner": "user",
             "host": "localhost",
-            "port": 43007,
+            "port": 43015,
             "cyclePoints": [
                 {
+                    "id": "user|one|20000102T0000Z|root",
                     "cyclePoint": "20000102T0000Z"
-                },
-                {
-                    "cyclePoint": "20000101T0000Z"
                 }
             ],
             "taskProxies": [
-                {
-                    "id": "user|one|20000101T0000Z|sleepy",
-                    "name": "sleepy",
-                    "state": "succeeded",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|sleepy|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|sleepy"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17254",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:35Z",
-                            "submittedTime": "2020-05-01T03:41:34Z",
-                            "finishedTime": "2020-05-01T03:41:36Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "user|one|20000101T0000Z|eventually_succeeded",
-                    "name": "eventually_succeeded",
-                    "state": "succeeded",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 0.5,
-                        "name": "eventually_succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|eventually_succeeded|4",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17123",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:17Z",
-                            "submittedTime": "2020-05-01T03:41:16Z",
-                            "finishedTime": "2020-05-01T03:41:18Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "user|one|20000101T0000Z|eventually_succeeded|3",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17088",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:12Z",
-                            "submittedTime": "2020-05-01T03:41:12Z",
-                            "finishedTime": "2020-05-01T03:41:13Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "user|one|20000101T0000Z|eventually_succeeded|2",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17053",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:08Z",
-                            "submittedTime": "2020-05-01T03:41:07Z",
-                            "finishedTime": "2020-05-01T03:41:09Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "user|one|20000101T0000Z|eventually_succeeded|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "16951",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:04Z",
-                            "submittedTime": "2020-05-01T03:41:03Z",
-                            "finishedTime": "2020-05-01T03:41:04Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "user|one|20000101T0000Z|retrying",
-                    "name": "retrying",
-                    "state": "succeeded",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2020-05-01T03:46:04Z)",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|BAD",
-                        "name": "BAD",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "retrying"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|retrying|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|retrying"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "16952",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:04Z",
-                            "submittedTime": "2020-05-01T03:41:03Z",
-                            "finishedTime": "2020-05-01T03:41:04Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "user|one|20000101T0000Z|checkpoint",
-                    "name": "checkpoint",
-                    "state": "succeeded",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 7.0,
-                        "name": "checkpoint"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|checkpoint|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|checkpoint"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17194",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:24Z",
-                            "submittedTime": "2020-05-01T03:41:23Z",
-                            "finishedTime": "2020-05-01T03:41:31Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "user|one|20000101T0000Z|waiting",
-                    "name": "waiting",
-                    "state": "succeeded",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "waiting"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|waiting|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|waiting"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17255",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:35Z",
-                            "submittedTime": "2020-05-01T03:41:34Z",
-                            "finishedTime": "2020-05-01T03:41:36Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "user|one|20000101T0000Z|succeeded",
-                    "name": "succeeded",
-                    "state": "succeeded",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "succeeded",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    },
-                    "task": {
-                        "meanElapsedTime": 0.5,
-                        "name": "succeeded"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|succeeded|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "16955",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:04Z",
-                            "submittedTime": "2020-05-01T03:41:03Z",
-                            "finishedTime": "2020-05-01T03:41:04Z",
-                            "state": "succeeded",
-                            "submitNum": 1
-                        }
-                    ]
-                },
-                {
-                    "id": "user|one|20000101T0000Z|failed",
-                    "name": "failed",
-                    "state": "failed",
-                    "isHeld": false,
-                    "cyclePoint": "20000101T0000Z",
-                    "latestMessage": "failed/EXIT",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|BAD",
-                        "name": "BAD",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 0.0,
-                        "name": "failed"
-                    },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000101T0000Z|failed|1",
-                            "firstParent": {
-                                "id": "user|one|20000101T0000Z|failed"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17159",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:21Z",
-                            "submittedTime": "2020-05-01T03:41:20Z",
-                            "finishedTime": "2020-05-01T03:41:21Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
-                },
                 {
                     "id": "user|one|20000102T0000Z|checkpoint",
                     "name": "checkpoint",
@@ -325,7 +43,7 @@ const checkpoint = {
                         "id": "user|one|20000102T0000Z|root",
                         "name": "root",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "retrying"
                     },
                     "task": {
                         "meanElapsedTime": 7.0,
@@ -338,10 +56,10 @@ const checkpoint = {
                                 "id": "user|one|20000102T0000Z|checkpoint"
                             },
                             "batchSysName": "background",
-                            "batchSysJobId": "17569",
+                            "batchSysJobId": "32528",
                             "host": "localhost",
-                            "startedTime": "2020-05-01T03:42:00Z",
-                            "submittedTime": "2020-05-01T03:41:59Z",
+                            "startedTime": "2020-09-28T01:22:35Z",
+                            "submittedTime": "2020-09-28T01:22:34Z",
                             "finishedTime": "",
                             "state": "running",
                             "submitNum": 1
@@ -349,17 +67,93 @@ const checkpoint = {
                     ]
                 },
                 {
-                    "id": "user|one|20000102T0000Z|failed",
-                    "name": "failed",
-                    "state": "failed",
+                    "id": "user|one|20000102T0000Z|eventually_succeeded",
+                    "name": "eventually_succeeded",
+                    "state": "submitted",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed/EXIT",
+                    "latestMessage": "submitted",
+                    "firstParent": {
+                        "id": "user|one|20000102T0000Z|SUCCEEDED",
+                        "name": "SUCCEEDED",
+                        "cyclePoint": "20000102T0000Z",
+                        "state": "running"
+                    },
+                    "task": {
+                        "meanElapsedTime": 1.0,
+                        "name": "eventually_succeeded"
+                    },
+                    "jobs": [
+                        {
+                            "id": "user|one|20000102T0000Z|eventually_succeeded|4",
+                            "firstParent": {
+                                "id": "user|one|20000102T0000Z|eventually_succeeded"
+                            },
+                            "batchSysName": "background",
+                            "batchSysJobId": "32464",
+                            "host": "localhost",
+                            "startedTime": "2020-09-28T01:22:28Z",
+                            "submittedTime": "2020-09-28T01:22:27Z",
+                            "finishedTime": "2020-09-28T01:22:28Z",
+                            "state": "succeeded",
+                            "submitNum": 4
+                        },
+                        {
+                            "id": "user|one|20000102T0000Z|eventually_succeeded|3",
+                            "firstParent": {
+                                "id": "user|one|20000102T0000Z|eventually_succeeded"
+                            },
+                            "batchSysName": "background",
+                            "batchSysJobId": "32432",
+                            "host": "localhost",
+                            "startedTime": "2020-09-28T01:22:23Z",
+                            "submittedTime": "2020-09-28T01:22:22Z",
+                            "finishedTime": "2020-09-28T01:22:24Z",
+                            "state": "failed",
+                            "submitNum": 3
+                        },
+                        {
+                            "id": "user|one|20000102T0000Z|eventually_succeeded|2",
+                            "firstParent": {
+                                "id": "user|one|20000102T0000Z|eventually_succeeded"
+                            },
+                            "batchSysName": "background",
+                            "batchSysJobId": "32398",
+                            "host": "localhost",
+                            "startedTime": "2020-09-28T01:22:20Z",
+                            "submittedTime": "2020-09-28T01:22:19Z",
+                            "finishedTime": "2020-09-28T01:22:20Z",
+                            "state": "failed",
+                            "submitNum": 2
+                        },
+                        {
+                            "id": "user|one|20000102T0000Z|eventually_succeeded|1",
+                            "firstParent": {
+                                "id": "user|one|20000102T0000Z|eventually_succeeded"
+                            },
+                            "batchSysName": "background",
+                            "batchSysJobId": "32307",
+                            "host": "localhost",
+                            "startedTime": "2020-09-28T01:22:14Z",
+                            "submittedTime": "2020-09-28T01:22:14Z",
+                            "finishedTime": "2020-09-28T01:22:15Z",
+                            "state": "failed",
+                            "submitNum": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "user|one|20000102T0000Z|failed",
+                    "name": "failed",
+                    "state": "submitted",
+                    "isHeld": false,
+                    "cyclePoint": "20000102T0000Z",
+                    "latestMessage": "submitted",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|BAD",
                         "name": "BAD",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "retrying"
                     },
                     "task": {
                         "meanElapsedTime": 0.0,
@@ -372,34 +166,15 @@ const checkpoint = {
                                 "id": "user|one|20000102T0000Z|failed"
                             },
                             "batchSysName": "background",
-                            "batchSysJobId": "17534",
+                            "batchSysJobId": "32497",
                             "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:56Z",
-                            "submittedTime": "2020-05-01T03:41:55Z",
-                            "finishedTime": "2020-05-01T03:41:57Z",
+                            "startedTime": "2020-09-28T01:22:31Z",
+                            "submittedTime": "2020-09-28T01:22:31Z",
+                            "finishedTime": "2020-09-28T01:22:32Z",
                             "state": "failed",
                             "submitNum": 1
                         }
                     ]
-                },
-                {
-                    "id": "user|one|20000102T0000Z|sleepy",
-                    "name": "sleepy",
-                    "state": "waiting",
-                    "isHeld": true,
-                    "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
-                    "firstParent": {
-                        "id": "user|one|20000102T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
-                    },
-                    "task": {
-                        "meanElapsedTime": 1.0,
-                        "name": "sleepy"
-                    },
-                    "jobs": []
                 },
                 {
                     "id": "user|one|20000102T0000Z|retrying",
@@ -407,12 +182,12 @@ const checkpoint = {
                     "state": "retrying",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2020-05-01T03:46:40Z)",
+                    "latestMessage": "failed, retrying in PT5M (after 2020-09-28T01:27:16Z)",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|BAD",
                         "name": "BAD",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "retrying"
                     },
                     "task": {
                         "meanElapsedTime": 0.0,
@@ -425,107 +200,50 @@ const checkpoint = {
                                 "id": "user|one|20000102T0000Z|retrying"
                             },
                             "batchSysName": "background",
-                            "batchSysJobId": "17325",
+                            "batchSysJobId": "32308",
                             "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:39Z",
-                            "submittedTime": "2020-05-01T03:41:38Z",
-                            "finishedTime": "2020-05-01T03:41:40Z",
+                            "startedTime": "2020-09-28T01:22:14Z",
+                            "submittedTime": "2020-09-28T01:22:14Z",
+                            "finishedTime": "2020-09-28T01:22:15Z",
                             "state": "failed",
                             "submitNum": 1
                         }
                     ]
                 },
                 {
-                    "id": "user|one|20000102T0000Z|eventually_succeeded",
-                    "name": "eventually_succeeded",
-                    "state": "succeeded",
+                    "id": "user|one|20000102T0000Z|sleepy",
+                    "name": "sleepy",
+                    "state": "",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "succeeded",
+                    "latestMessage": "",
                     "firstParent": {
-                        "id": "user|one|20000102T0000Z|SUCCEEDED",
-                        "name": "SUCCEEDED",
+                        "id": "user|one|20000102T0000Z|root",
+                        "name": "root",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "succeeded"
+                        "state": "retrying"
                     },
                     "task": {
-                        "meanElapsedTime": 0.5,
-                        "name": "eventually_succeeded"
+                        "meanElapsedTime": 0.0,
+                        "name": "sleepy"
                     },
-                    "jobs": [
-                        {
-                            "id": "user|one|20000102T0000Z|eventually_succeeded|4",
-                            "firstParent": {
-                                "id": "user|one|20000102T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17495",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:53Z",
-                            "submittedTime": "2020-05-01T03:41:52Z",
-                            "finishedTime": "2020-05-01T03:41:53Z",
-                            "state": "succeeded",
-                            "submitNum": 4
-                        },
-                        {
-                            "id": "user|one|20000102T0000Z|eventually_succeeded|3",
-                            "firstParent": {
-                                "id": "user|one|20000102T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17460",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:48Z",
-                            "submittedTime": "2020-05-01T03:41:47Z",
-                            "finishedTime": "2020-05-01T03:41:49Z",
-                            "state": "failed",
-                            "submitNum": 3
-                        },
-                        {
-                            "id": "user|one|20000102T0000Z|eventually_succeeded|2",
-                            "firstParent": {
-                                "id": "user|one|20000102T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17425",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:44Z",
-                            "submittedTime": "2020-05-01T03:41:43Z",
-                            "finishedTime": "2020-05-01T03:41:44Z",
-                            "state": "failed",
-                            "submitNum": 2
-                        },
-                        {
-                            "id": "user|one|20000102T0000Z|eventually_succeeded|1",
-                            "firstParent": {
-                                "id": "user|one|20000102T0000Z|eventually_succeeded"
-                            },
-                            "batchSysName": "background",
-                            "batchSysJobId": "17324",
-                            "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:39Z",
-                            "submittedTime": "2020-05-01T03:41:38Z",
-                            "finishedTime": "2020-05-01T03:41:40Z",
-                            "state": "failed",
-                            "submitNum": 1
-                        }
-                    ]
+                    "jobs": []
                 },
                 {
                     "id": "user|one|20000102T0000Z|succeeded",
                     "name": "succeeded",
-                    "state": "succeeded",
+                    "state": "running",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "succeeded",
+                    "latestMessage": "started",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|SUCCEEDED",
                         "name": "SUCCEEDED",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "succeeded"
+                        "state": "running"
                     },
                     "task": {
-                        "meanElapsedTime": 0.5,
+                        "meanElapsedTime": 0.0,
                         "name": "succeeded"
                     },
                     "jobs": [
@@ -535,11 +253,11 @@ const checkpoint = {
                                 "id": "user|one|20000102T0000Z|succeeded"
                             },
                             "batchSysName": "background",
-                            "batchSysJobId": "17328",
+                            "batchSysJobId": "32311",
                             "host": "localhost",
-                            "startedTime": "2020-05-01T03:41:39Z",
-                            "submittedTime": "2020-05-01T03:41:38Z",
-                            "finishedTime": "2020-05-01T03:41:40Z",
+                            "startedTime": "2020-09-28T01:22:14Z",
+                            "submittedTime": "2020-09-28T01:22:14Z",
+                            "finishedTime": "2020-09-28T01:22:15Z",
                             "state": "succeeded",
                             "submitNum": 1
                         }
@@ -548,7 +266,7 @@ const checkpoint = {
                 {
                     "id": "user|one|20000102T0000Z|waiting",
                     "name": "waiting",
-                    "state": "waiting",
+                    "state": "",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
                     "latestMessage": "",
@@ -556,10 +274,10 @@ const checkpoint = {
                         "id": "user|one|20000102T0000Z|root",
                         "name": "root",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "retrying"
                     },
                     "task": {
-                        "meanElapsedTime": 1.0,
+                        "meanElapsedTime": 0.0,
                         "name": "waiting"
                     },
                     "jobs": []
@@ -567,75 +285,39 @@ const checkpoint = {
             ],
             "familyProxies": [
                 {
-                    "id": "user|one|20000101T0000Z|SUCCEEDED",
-                    "name": "SUCCEEDED",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|GOOD",
-                        "name": "GOOD",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "succeeded"
-                    }
-                },
-                {
-                    "id": "user|one|20000101T0000Z|GOOD",
-                    "name": "GOOD",
-                    "state": "succeeded",
-                    "cyclePoint": "20000101T0000Z",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    }
-                },
-                {
-                    "id": "user|one|20000101T0000Z|BAD",
+                    "id": "user|one|20000102T0000Z|BAD",
                     "name": "BAD",
-                    "state": "failed",
-                    "cyclePoint": "20000101T0000Z",
-                    "firstParent": {
-                        "id": "user|one|20000101T0000Z|root",
-                        "name": "root",
-                        "cyclePoint": "20000101T0000Z",
-                        "state": "failed"
-                    }
-                },
-                {
-                    "id": "user|one|20000102T0000Z|SUCCEEDED",
-                    "name": "SUCCEEDED",
-                    "state": "succeeded",
+                    "state": "retrying",
                     "cyclePoint": "20000102T0000Z",
                     "firstParent": {
-                        "id": "user|one|20000102T0000Z|GOOD",
-                        "name": "GOOD",
+                        "id": "user|one|20000102T0000Z|root",
+                        "name": "root",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "succeeded"
+                        "state": "retrying"
                     }
                 },
                 {
                     "id": "user|one|20000102T0000Z|GOOD",
                     "name": "GOOD",
-                    "state": "succeeded",
+                    "state": "running",
                     "cyclePoint": "20000102T0000Z",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|root",
                         "name": "root",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "retrying"
                     }
                 },
                 {
-                    "id": "user|one|20000102T0000Z|BAD",
-                    "name": "BAD",
-                    "state": "failed",
+                    "id": "user|one|20000102T0000Z|SUCCEEDED",
+                    "name": "SUCCEEDED",
+                    "state": "running",
                     "cyclePoint": "20000102T0000Z",
                     "firstParent": {
-                        "id": "user|one|20000102T0000Z|root",
-                        "name": "root",
+                        "id": "user|one|20000102T0000Z|GOOD",
+                        "name": "GOOD",
                         "cyclePoint": "20000102T0000Z",
-                        "state": "failed"
+                        "state": "running"
                     }
                 }
             ]

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -20,7 +20,7 @@ import re
 graphql_module_path = Path(f'{dirname(__file__)}/../../../graphql/')
 queries_file = graphql_module_path / 'queries.js'
 
-workflows_query_variable = 'WORKFLOW_TREE_QUERY'
+workflows_query_variable = 'WORKFLOW_TREE_DELTAS_SUBSCRIPTION'
 
 query = ''
 
@@ -28,7 +28,7 @@ query = ''
 # for js multiline variable
 with queries_file.open() as f:
     query = re.search(
-        rf'const\s+{workflows_query_variable}\s*=\s*`([^`]+)`',
+        rf'const\s+{workflows_query_variable}\s*=\s*gql`([^`]+)`',
         f.read(),
         re.MULTILINE).group(1).strip()
     # replace the placeholder for the workflow ID
@@ -38,7 +38,10 @@ with queries_file.open() as f:
 
 
 wrapper = {
-    'request_string': query
+    'request_string': query,
+    'variables': {
+        'workflowId': 'one'
+    }
 }
 
 import json

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -13,34 +13,95 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from os.path import dirname
-from pathlib import Path
-import re
+# NOTE: The deltas-subscription for the tree view cannot be used here as
+#       cylc-client wouldn't give us a single response payload; but we
+#       can re-use the fragments. If the query for the tree view changes,
+#       just copy the new fragment below, or tweak the query as fit.
+query = '''
+query ($workflowID: ID) {
+  workflows (ids: [$workflowID]) {
+    ...WorkflowData
+    cyclePoints: familyProxies (ids: ["root"], ghosts: true) {
+      ...CyclePointData
+    }
+    taskProxies (sort: { keys: ["name"], reverse: false }, ghosts: true) {
+      ...TaskProxyData
+      jobs(sort: { keys: ["submit_num"], reverse:true }) {
+        ...JobData
+      }
+    }
+    familyProxies (exids: ["root"], sort: { keys: ["name"] }, ghosts: true) {
+      ...FamilyProxyData
+    }
+  }
+}
 
-graphql_module_path = Path(f'{dirname(__file__)}/../../../graphql/')
-queries_file = graphql_module_path / 'queries.js'
+fragment WorkflowData on Workflow {
+  id
+  name
+  status
+  owner
+  host
+  port
+}
 
-workflows_query_variable = 'WORKFLOW_TREE_DELTAS_SUBSCRIPTION'
+fragment CyclePointData on FamilyProxy {
+  id
+  cyclePoint
+}
 
-query = ''
+fragment FamilyProxyData on FamilyProxy {
+  id
+  name
+  state
+  cyclePoint
+  firstParent {
+    id
+    name
+    cyclePoint
+    state
+  }
+}
 
-# use a regex to match anything after the variable name and within ``
-# for js multiline variable
-with queries_file.open() as f:
-    query = re.search(
-        rf'const\s+{workflows_query_variable}\s*=\s*gql`([^`]+)`',
-        f.read(),
-        re.MULTILINE).group(1).strip()
-    # replace the placeholder for the workflow ID
-    query = query.replace('(ids: ["WORKFLOW_ID"])', '', 1)
-    if query.startswith('subscription'):
-        query = query.replace('subscription', '', 1)
+fragment TaskProxyData on TaskProxy {
+  id
+  name
+  state
+  isHeld
+  cyclePoint
+  latestMessage
+  firstParent {
+    id
+    name
+    cyclePoint
+    state
+  }
+  task {
+    meanElapsedTime
+    name
+  }
+}
 
+fragment JobData on Job {
+  id
+  firstParent: taskProxy {
+    id
+  }
+  batchSysName
+  batchSysJobId
+  host
+  startedTime
+  submittedTime
+  finishedTime
+  state
+  submitNum
+}
+'''
 
 wrapper = {
     'request_string': query,
     'variables': {
-        'workflowId': 'one'
+        'workflowID': 'one'
     }
 }
 

--- a/src/services/mock/one/flow.cylc
+++ b/src/services/mock/one/flow.cylc
@@ -100,7 +100,4 @@
             # reset stuff
             cylc unhold \
                 "${CYLC_SUITE_NAME}" "sleepy.${CYLC_TASK_CYCLE_POINT}"
-            cylc reset \
-                "${CYLC_SUITE_NAME}" "retrying.${CYLC_TASK_CYCLE_POINT}" \
-                -s 'succeeded'
         """

--- a/src/services/mock/one/flow.cylc
+++ b/src/services/mock/one/flow.cylc
@@ -100,4 +100,6 @@
             # reset stuff
             cylc unhold \
                 "${CYLC_SUITE_NAME}" "sleepy.${CYLC_TASK_CYCLE_POINT}"
+            cylc set-outputs \
+		"${CYLC_SUITE_NAME}" "retrying.${CYLC_TASK_CYCLE_POINT}"
         """

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -16,15 +16,13 @@
  */
 
 describe('Tree component', () => {
-  it('Should display two cycle points for the mocked workflow', () => {
+  it('Should display cycle points for the mocked workflow', () => {
     cy.visit('/#/workflows/one')
     cy
       .get('.node-data-cyclepoint', { timeout: 10000 })
       .should(($div) => {
         // by default, in our expected viewport size for tests, both cycle points exist and are visible
-        expect($div).to.have.length(2)
         expect($div.get(0)).to.contain('20000102T0000Z')
-        expect($div.get(1)).to.contain('20000101T0000Z')
       })
     cy
       .get('.node-data-cyclepoint')
@@ -137,9 +135,6 @@ describe('Tree component', () => {
     it('Should not filter by default', () => {
       cy.visit('/#/tree/one')
       cy
-        .get('.node-data-task-proxy:visible')
-        .should('have.length', 14)
-      cy
         .get('.node-data-task-proxy')
         .contains('sleepy')
         .should('be.visible')
@@ -150,9 +145,6 @@ describe('Tree component', () => {
     })
     it('Should filter by task name', () => {
       cy.visit('/#/tree/one')
-      cy
-        .get('.node-data-task-proxy:visible')
-        .should('have.length', 14)
       cy
         .get('.node-data-task-proxy')
         .contains('sleepy')
@@ -168,9 +160,6 @@ describe('Tree component', () => {
       cy
         .get('#c-tree-filter-btn')
         .click()
-      cy
-        .get('.node-data-task-proxy:visible')
-        .should('have.length', 2)
       cy
         .get('.node-data-task-proxy')
         .contains('sleepy')
@@ -192,18 +181,19 @@ describe('Tree component', () => {
       // click on succeeded and waiting
       cy
         .get('.v-list-item')
-        .contains('succeeded')
-        .click({ force: true })
-      cy
-        .get('.v-list-item')
-        .contains('waiting')
+        .contains('submitted')
         .click({ force: true })
       cy
         .get('#c-tree-filter-btn')
         .click()
       cy
-        .get('.node-data-task-proxy:visible')
-        .should('have.length', 10)
+        .get('.node-data-task-proxy')
+        .contains('sleepy')
+        .should('be.not.visible')
+      cy
+        .get('.node-data-task-proxy')
+        .contains('failed')
+        .should('be.visible')
     })
     it('Should filter by task name and states', () => {
       cy.visit('/#/tree/one')
@@ -214,14 +204,14 @@ describe('Tree component', () => {
       // eep should filter sleepy
       cy
         .get('#c-tree-filter-task-name')
-        .type('eep')
+        .type('fail')
       cy
         .get('#c-tree-filter-task-states')
         .click({ force: true })
       // click on waiting, the other sleepy is succeeded, but we don't want to see it
       cy
         .get('.v-list-item')
-        .contains('waiting')
+        .contains('submitted')
         .click({ force: true })
       cy
         .get('#c-tree-filter-btn')

--- a/tests/unit/components/cylc/tree/deltas.spec.js
+++ b/tests/unit/components/cylc/tree/deltas.spec.js
@@ -143,7 +143,8 @@ describe('Deltas', () => {
         added: {
           cyclePoints: [
             {
-              cyclePoint: cyclePointId
+              id: cyclePointId,
+              cyclePoint: '1'
             }
           ]
         }
@@ -163,15 +164,16 @@ describe('Deltas', () => {
         id: WORKFLOW_ID
       }))
       cyclePoint = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint)
       familyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|FAM`,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|FAM`,
         state: TaskState.RUNNING.name.toLowerCase(),
-        cyclePoint: cyclePoint.id,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         }
       })
@@ -205,15 +207,16 @@ describe('Deltas', () => {
         id: WORKFLOW_ID
       }))
       cyclePoint = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint)
       familyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|FAM`,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|FAM`,
         state: TaskState.RUNNING.name.toLowerCase(),
-        cyclePoint: cyclePoint.id,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         }
       })

--- a/tests/unit/components/cylc/tree/index.spec.js
+++ b/tests/unit/components/cylc/tree/index.spec.js
@@ -17,6 +17,7 @@
 
 import {
   createTaskProxyNode,
+  getCyclePointId,
   populateTreeFromGraphQLData
 } from '@/components/cylc/tree/index'
 import { expect } from 'chai'
@@ -126,5 +127,66 @@ describe('Tree component functions', () => {
     expect(populateTreeFromGraphQLData, null, workflow).to.not.throw(Error)
     expect(populateTreeFromGraphQLData, tree, null).to.not.throw(Error)
     expect(populateTreeFromGraphQLData, tree, workflow).to.not.throw(Error)
+  })
+  it('should extract the cycle point ID', () => {
+    const tests = [
+      {
+        node: {
+          id: ''
+        },
+        expected: Error
+      },
+      {
+        node: {
+          id: null
+        },
+        expected: Error
+      },
+      {
+        node: {
+          id: 'a'
+        },
+        expected: Error
+      },
+      {
+        node: {
+          id: 'a|b'
+        },
+        expected: Error
+      },
+      {
+        node: {
+          id: 'a|b|c'
+        },
+        expected: 'a|b|c'
+      },
+      {
+        node: {
+          id: 'a|b|c|d'
+        },
+        expected: 'a|b|c'
+      },
+      {
+        node: {
+          id: 'a|b|c|d|e'
+        },
+        expected: 'a|b|c'
+      },
+      {
+        node: {
+          id: '|||'
+        },
+        expected: '||'
+      }
+    ]
+    tests.forEach(test => {
+      it('should extract cycle point node ID', () => {
+        if (test.expected === Error) {
+          expect(getCyclePointId(test.args)).to.throw(test.expected)
+        } else {
+          expect(getCyclePointId(test.args)).to.equal(test.expected)
+        }
+      })
+    })
   })
 })

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -78,10 +78,12 @@ const sampleWorkflow1 = {
   cyclePoints: [
     {
       __typename: 'FamilyProxy',
+      id: 'cylc|one|20000101T0000Z|root',
       cyclePoint: '20000101T0000Z'
     },
     {
       __typename: 'FamilyProxy',
+      id: 'cylc|one|20000102T0000Z|root',
       cyclePoint: '20000102T0000Z'
     }
   ],

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -81,21 +81,24 @@ describe('CylcTree', () => {
     })
     it('Should add cycle points', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       const cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
         cyclePoint: '2'
       })
       cylcTree.addCyclePoint(cyclePoint1)
       expect(cylcTree.root.children.length).to.equal(1)
-      expect(cylcTree.root.children[0].id).to.equal('1')
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
 
       cylcTree.addCyclePoint(cyclePoint2)
       expect(cylcTree.root.children.length).to.equal(2)
-      expect(cylcTree.root.children[1].id).to.equal('2')
+      expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|2`)
     })
     it('Should not add a cycle point twice', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint1)
@@ -104,22 +107,24 @@ describe('CylcTree', () => {
     })
     it('Should update cycle points', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint1)
       expect(cylcTree.root.children.length).to.equal(1)
-      expect(cylcTree.root.children[0].id).to.equal('1')
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
       expect(cylcTree.root.children[0].children.length).to.equal(0)
       cyclePoint1.children.push({
         id: 10
       })
       cylcTree.updateCyclePoint(cyclePoint1)
       expect(cylcTree.root.children.length).to.equal(1)
-      expect(cylcTree.root.children[0].id).to.equal('1')
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
       expect(cylcTree.root.children[0].children.length).to.equal(1)
     })
     it('Should not update a cycle point if not already in the tree', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.updateCyclePoint(cyclePoint1)
@@ -127,10 +132,12 @@ describe('CylcTree', () => {
     })
     it('Should remove cycle points', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint1)
       const cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
         cyclePoint: '2'
       })
       cylcTree.addCyclePoint(cyclePoint1)
@@ -140,10 +147,12 @@ describe('CylcTree', () => {
     })
     it('Should remove cycle points', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint1)
       const cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
         cyclePoint: '2'
       })
       cylcTree.addCyclePoint(cyclePoint1)
@@ -153,6 +162,7 @@ describe('CylcTree', () => {
     })
     it('Should ignore if the cycle point to remove is not in the tree', () => {
       const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.removeCyclePoint(cyclePoint1.id)
@@ -170,9 +180,11 @@ describe('CylcTree', () => {
       })
       cylcTree = new CylcTree(workflow)
       cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
         cyclePoint: '2'
       })
       cylcTree.addCyclePoint(cyclePoint1)
@@ -182,7 +194,7 @@ describe('CylcTree', () => {
       // This is because we may have a family proxy found in a task proxy first parent, or in another
       // family proxy first parent, that is not in the tree yet.
       const familyProxy1 = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint1.id}|fam`
+        id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam`
       })
       cylcTree.addFamilyProxy(familyProxy1)
       expect(cylcTree.root.children[0].children.length).to.equal(0)
@@ -194,8 +206,8 @@ describe('CylcTree', () => {
       // then the next time we add it, it is because we found it in the family proxy part of the
       // graphql response. When that happens, we must actually add-update it, merging with the
       // extra data found in graphql family proxies entry.
-      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.id}|fam1`
-      const familyProxyId2 = `${WORKFLOW_ID}|${cyclePoint1.id}|fam2`
+      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam1`
+      const familyProxyId2 = `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam2`
       const familyProxy1 = createFamilyProxyNode({
         id: familyProxyId1,
         firstParent: {
@@ -216,12 +228,12 @@ describe('CylcTree', () => {
       expect(cylcTree.lookup.get(familyProxy1.id).node.state).to.equal(TaskState.WAITING.name.toLowerCase())
     })
     it('Should add family proxies under the cycle point when first parent is root', () => {
-      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.id}|fam1`
+      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam1`
       const familyProxy1 = createFamilyProxyNode({
         id: familyProxyId1,
-        cyclePoint: cyclePoint1.id,
+        cyclePoint: cyclePoint1.node.name,
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint1.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         }
       })
@@ -229,13 +241,13 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[0].children[0].id).to.equal(familyProxyId1)
     })
     it('Should add family proxies under another family proxy successfully', () => {
-      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.id}|fam1`
-      const familyProxyId2 = `${WORKFLOW_ID}|${cyclePoint1.id}|fam2`
+      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam1`
+      const familyProxyId2 = `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam2`
       const familyProxy1 = createFamilyProxyNode({
         id: familyProxyId1,
-        cyclePoint: cyclePoint1.id,
+        cyclePoint: cyclePoint1.node.name,
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint1.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         }
       })
@@ -253,8 +265,8 @@ describe('CylcTree', () => {
     it('Should add family proxies under another family proxy successfully (even if the parent family proxy does not exist in the tree yet!)', () => {
       // We may have a child family proxy, before the parent family proxy is created. In this case, we have to create the
       // parent family proxy, add to the tree, and link parent-child family proxies.
-      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint2.id}|fam1`
-      const familyProxyId2 = `${WORKFLOW_ID}|${cyclePoint2.id}|fam1`
+      const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam1`
+      const familyProxyId2 = `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam1`
       const familyProxy2 = createFamilyProxyNode({
         id: familyProxyId2,
         firstParent: {
@@ -267,10 +279,10 @@ describe('CylcTree', () => {
     })
     it('Should not add a family proxy twice to lookup, nor to its parent', () => {
       const familyProxy1 = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|fam1`,
-        cyclePoint: cyclePoint2.id,
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam1`,
+        cyclePoint: cyclePoint2.node.name,
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint1.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         }
       })
@@ -280,7 +292,7 @@ describe('CylcTree', () => {
     })
     it('Should update family proxies', () => {
       const familyProxy1 = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|fam1`
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam1`
       })
       cylcTree.addFamilyProxy(familyProxy1)
       expect(cylcTree.lookup.get(familyProxy1.id).state).to.equal(undefined)
@@ -290,14 +302,14 @@ describe('CylcTree', () => {
     })
     it('Should not update a family proxy if it is not in the tree', () => {
       const familyProxy1 = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|fam1`
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam1`
       })
       cylcTree.updateFamilyProxy(familyProxy1)
       expect(cylcTree.lookup.get(familyProxy1.id)).to.equal(undefined)
     })
     it('Should remove family proxies', () => {
       const rootFamilyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|${FAMILY_ROOT}`,
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|${FAMILY_ROOT}`,
         name: FAMILY_ROOT,
         cyclePoint: cyclePoint2.id,
         firstParent: {
@@ -310,7 +322,7 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[1].children.length).to.equal(0)
 
       const childFamilyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|fam2`,
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam2`,
         cyclePoint: cyclePoint2.id,
         firstParent: {
           id: rootFamilyProxy.id,
@@ -324,7 +336,7 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[1].children[0].children.length).to.equal(0)
 
       const grandChildFamilyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|fam3`,
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|fam3`,
         cyclePoint: cyclePoint2.id,
         firstParent: {
           id: childFamilyProxy.id
@@ -358,21 +370,22 @@ describe('CylcTree', () => {
       })
       cylcTree = new CylcTree(workflow)
       cyclePoint = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint)
       rootFamilyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|${FAMILY_ROOT}`,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|${FAMILY_ROOT}`,
         name: FAMILY_ROOT,
-        cyclePoint: cyclePoint.id,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: cyclePoint.id
         }
       })
       cylcTree.addFamilyProxy(rootFamilyProxy)
       familyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|FAM1`,
-        cyclePoint: cyclePoint.id,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|FAM1`,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: rootFamilyProxy.id,
           name: rootFamilyProxy.node.name
@@ -411,14 +424,14 @@ describe('CylcTree', () => {
       expect(family.children.length).to.equal(1)
     })
     it('Should add task proxies under root family', () => {
-      const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
+      const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.node.name}|foo`
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
         firstParent: {
           id: rootFamilyProxy.id,
           name: rootFamilyProxy.node.name
         },
-        cyclePoint: cyclePoint.id,
+        cyclePoint: cyclePoint.node.name,
         state: TaskState.RUNNING.name.toLowerCase()
       })
       cylcTree.addTaskProxy(taskProxy)
@@ -529,7 +542,7 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[0].children[0].children.length).to.equal(0)
     })
     it('Should remove task proxies if added to the root family', () => {
-      const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
+      const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.node.name}|foo`
       const taskProxyState = TaskState.RUNNING.name.toLowerCase()
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
@@ -583,21 +596,22 @@ describe('CylcTree', () => {
       })
       cylcTree = new CylcTree(workflow)
       cyclePoint = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint)
       rootFamilyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|${FAMILY_ROOT}`,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|${FAMILY_ROOT}`,
         name: FAMILY_ROOT,
-        cyclePoint: cyclePoint.id,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: cyclePoint.id
         }
       })
       cylcTree.addFamilyProxy(rootFamilyProxy)
       familyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|FAM1`,
-        cyclePoint: cyclePoint.id,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|FAM1`,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: rootFamilyProxy.id,
           name: rootFamilyProxy.node.name
@@ -605,7 +619,7 @@ describe('CylcTree', () => {
       })
       cylcTree.addFamilyProxy(familyProxy)
       taskProxy = createTaskProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}|foo`,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|foo`,
         firstParent: {
           id: familyProxy.id
         },
@@ -764,21 +778,22 @@ describe('CylcTree', () => {
       })
       cylcTree = new CylcTree(workflow)
       cyclePoint = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint)
       rootFamilyProxy = createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint.id}|${FAMILY_ROOT}`,
         name: FAMILY_ROOT,
-        cyclePoint: cyclePoint.id,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: cyclePoint.id
         }
       })
       cylcTree.addFamilyProxy(rootFamilyProxy)
       familyProxy = createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}||FAM1`,
-        cyclePoint: cyclePoint.id,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}||FAM1`,
+        cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: rootFamilyProxy.id,
           name: rootFamilyProxy.node.name
@@ -786,7 +801,7 @@ describe('CylcTree', () => {
       })
       cylcTree.addFamilyProxy(familyProxy)
       taskProxy = createTaskProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint.id}||foo`,
+        id: `${WORKFLOW_ID}|${cyclePoint.node.name}|foo`,
         firstParent: {
           id: familyProxy.id
         },
@@ -827,45 +842,47 @@ describe('CylcTree', () => {
       })
       cylcTree = new CylcTree(workflow)
       cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
       })
       cylcTree.addCyclePoint(cyclePoint1)
       cylcTree.addFamilyProxy(createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint1.id}|FAM1`,
+        id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|FAM1`,
         state: TaskState.RUNNING.name.toLowerCase(),
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint1.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         },
         cyclePoint: cyclePoint1.id
       }))
       cylcTree.addFamilyProxy(createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint1.id}|FAM2`,
+        id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|FAM2`,
         state: TaskState.SUBMIT_RETRYING.name.toLowerCase(),
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint1.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         },
         cyclePoint: cyclePoint1.id
       }))
       cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
         cyclePoint: '2'
       })
       cylcTree.addCyclePoint(cyclePoint2)
       cylcTree.addFamilyProxy(createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|FAM1`,
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|FAM1`,
         state: TaskState.SUBMIT_RETRYING.name.toLowerCase(),
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint2.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         },
         cyclePoint: cyclePoint2.id
       }))
       cylcTree.addFamilyProxy(createFamilyProxyNode({
-        id: `${WORKFLOW_ID}|${cyclePoint2.id}|FAM2`,
+        id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|FAM2`,
         state: TaskState.RUNNING.name.toLowerCase(),
         firstParent: {
-          id: `${WORKFLOW_ID}|${cyclePoint2.id}|${FAMILY_ROOT}`,
+          id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
         },
         cyclePoint: cyclePoint2.id


### PR DESCRIPTION
These changes are related to #504 #339 

At the moment every node in the tree has an ID like `kinow|five|1|foo`, except the cycle points, which use just `1` (integer-type).

I implemented that way as it was the simplest approach, and because our cycle points are built from family proxies in the GraphQL query (cycle points are not types in the schema I think). @oliver-sanders found out that we didn't have the ID's while working on the mutations & api-on-the-fly integration.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
