### PR TITLE
Add more tests for Vuex store, and remove unused code

### DIFF
--- a/src/mixins/toolbar.js
+++ b/src/mixins/toolbar.js
@@ -39,7 +39,7 @@ export default {
   },
 
   methods: {
-    ...mapMutations('app', ['setDrawer', 'toggleDrawer']),
+    ...mapMutations('app', ['setDrawer']),
     onClickBtn () {
       this.setDrawer(!this.$store.state.app.drawer)
     },

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -17,16 +17,12 @@
 
 const state = {
   drawer: null,
-  color: 'success',
   title: null
 }
 
 const mutations = {
   setDrawer (state, drawer) {
     state.drawer = drawer
-  },
-  setColor (state, color) {
-    state.color = color
   },
   setTitle (state, title) {
     state.title = title

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -28,9 +28,6 @@ const mutations = {
   setColor (state, color) {
     state.color = color
   },
-  toggleDrawer (state) {
-    state.drawer = !state.drawer
-  },
   setTitle (state, title) {
     state.title = title
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -59,6 +59,7 @@ const state = {
   packageJson: JSON.parse(unescape(process.env.PACKAGE_JSON || '%7B%7D')),
   /**
    * Number of references that have set the loading state.
+   * TODO: we can probably remove it and use a different approach for alerts (see bootstrap toast).
    */
   refCount: 0
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -33,13 +33,34 @@ import { user } from './user.module'
 
 // State
 const state = {
-  packageJson: JSON.parse(unescape(process.env.PACKAGE_JSON || '%7B%7D')),
-  environment: process.env.NODE_ENV.toUpperCase(),
-  isLoading: false,
-  refCount: 0,
+  /**
+   * Application alert.
+   */
   alert: null,
+  /**
+   * Application base URL (set by the backend).
+   */
+  baseUrl: '/',
+  /**
+   * Application environmnet (e.g. offline, development, production), retrieved from NODE_ENV.
+   */
+  environment: process.env.NODE_ENV.toUpperCase(),
+  /**
+   * Whether the application is loading or not.
+   */
+  isLoading: false,
+  /**
+   * Whether the application is offline or not.
+   */
   offline: false,
-  baseUrl: '/'
+  /**
+   * Contents of package.json.
+   */
+  packageJson: JSON.parse(unescape(process.env.PACKAGE_JSON || '%7B%7D')),
+  /**
+   * Number of references that have set the loading state.
+   */
+  refCount: 0
 }
 
 // Actions

--- a/tests/unit/store/app.spec.js
+++ b/tests/unit/store/app.spec.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai'
+import store from '@/store'
+
+/**
+ * Tests for the store/app module.
+ */
+describe('app', () => {
+  /**
+   * Tests for store.app.drawer.
+   */
+  describe('drawer', () => {
+    const resetState = () => {
+      store.state.app.drawer = null
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
+    it('should start with no drawer', () => {
+      expect(store.state.app.drawer).to.equal(null)
+    })
+    it('should set drawer', () => {
+      const drawer = true
+      store.commit('app/setDrawer', drawer)
+      expect(store.state.app.drawer).to.equal(drawer)
+    })
+  })
+  /**
+   * Tests for store.app.title.
+   */
+  describe('title', () => {
+    const resetState = () => {
+      store.state.app.title = null
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
+    it('should start with no title', () => {
+      expect(store.state.app.title).to.equal(null)
+    })
+    it('should set title', () => {
+      const title = 'Cylc'
+      store.commit('app/setTitle', title)
+      expect(store.state.app.title).to.equal(title)
+    })
+  })
+})

--- a/tests/unit/store/index.spec.js
+++ b/tests/unit/store/index.spec.js
@@ -20,16 +20,26 @@ import store from '@/store'
 import Alert from '@/model/Alert.model'
 import sinon from 'sinon'
 
-describe('store', () => {
+/**
+ * Tests for the store/index module.
+ */
+describe('index', () => {
+  // using sinon to capture console.log
   beforeEach(() => {
-    store.dispatch('setAlert', null)
-    store.state.offline = false
     sinon.stub(console, 'log')
   })
   afterEach(() => {
     sinon.restore()
   })
-  describe('alerts', () => {
+  /**
+   * Tests for store.alert.
+   */
+  describe('alert', () => {
+    const resetState = () => {
+      store.state.alert = null
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
     it('should start with no alert', () => {
       expect(store.state.alert).to.equal(null)
     })
@@ -47,7 +57,33 @@ describe('store', () => {
       expect(store.state.alert).to.equal(null)
     })
   })
-  describe('loading', () => {
+  /**
+   * Tests for store.baseUrl
+   */
+  describe('baseUrl', () => {
+    const resetState = () => {
+      store.state.baseUrl = '/'
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
+    it('should initialize with correct base URL', () => {
+      expect(store.state.baseUrl).to.equal('/')
+    })
+    it('should set a new base URL', () => {
+      const newBaseUrl = 'new-base-url'
+      store.dispatch('setBaseUrl', newBaseUrl)
+      expect(store.state.baseUrl).to.equal(newBaseUrl)
+    })
+  })
+  /**
+   * Tests for store.isLoading.
+   */
+  describe('isLoading', () => {
+    const resetState = () => {
+      store.state.isLoading = false
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
     it('should start with loading false', () => {
       expect(store.state.isLoading).to.equal(false)
       expect(store.state.refCount).to.equal(0)
@@ -65,7 +101,15 @@ describe('store', () => {
       expect(store.state.refCount).to.equal(0)
     })
   })
+  /**
+   * Tests for store.offline.
+   */
   describe('offline', () => {
+    const resetState = () => {
+      store.state.offline = false
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
     it('should start online so that the component is not rendered for a few seconds', () => {
       expect(store.state.offline).to.equal(false)
     })

--- a/tests/unit/store/user.spec.js
+++ b/tests/unit/store/user.spec.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai'
+import store from '@/store'
+
+/**
+ * Tests for the store/user module.
+ */
+describe('user', () => {
+  /**
+   * Tests for store.user.
+   */
+  describe('user', () => {
+    const resetState = () => {
+      store.state.user.user = null
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
+    it('should start with no user', () => {
+      expect(store.state.user.user).to.equal(null)
+    })
+    it('should set user', () => {
+      const user = {
+        id: 1,
+        username: 'cylc'
+      }
+      store.dispatch('user/setUser', user)
+      expect(store.state.user.user).to.deep.equal(user)
+    })
+  })
+})

--- a/tests/unit/store/workflows.spec.js
+++ b/tests/unit/store/workflows.spec.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai'
+import store from '@/store'
+
+/**
+ * Tests for the store/workflows module.
+ */
+describe('workflows', () => {
+  /**
+   * Tests for store.workflows.
+   */
+  describe('workflows', () => {
+    const resetState = () => {
+      store.state.workflows.workflows = []
+      store.state.workflows.workflowName = null
+    }
+    beforeEach(resetState)
+    afterEach(resetState)
+    it('should start with no workflows and no workflow name', () => {
+      expect(store.state.workflows.workflows).to.deep.equal([])
+      expect(store.state.workflows.workflowName).to.equal(null)
+    })
+    it('should set workflows', () => {
+      const workflows = [
+        {
+          id: 'cylc|cylc',
+          name: 'cylc'
+        }
+      ]
+      store.dispatch('workflows/set', workflows)
+      expect(store.state.workflows.workflows).to.deep.equal(workflows)
+    })
+    it('should set workflow name', () => {
+      const workflowName = 'cylc'
+      store.commit('workflows/SET_WORKFLOW_NAME', { workflowName })
+      expect(store.state.workflows.workflowName).to.equal(workflowName)
+    })
+    it('should get the current workflow', () => {
+      expect(store.getters['workflows/currentWorkflow']).to.equal(null)
+      const workflows = [
+        {
+          id: 'cylc|cylc',
+          name: 'cylc'
+        }
+      ]
+      store.dispatch('workflows/set', workflows)
+      store.commit('workflows/SET_WORKFLOW_NAME', {
+        workflowName: workflows[0].name
+      })
+      expect(store.getters['workflows/currentWorkflow']).to.deep.equal(workflows[0])
+    })
+  })
+})


### PR DESCRIPTION
This is a small change with no associated Issue.

Trying to increase our code coverage a bit more. There are pieces of code from the theme we downloaded for the very first version of Cylc UI that are not used and can now be removed.

In our tests, we also have a very bad pattern, where the Vuex store is imported and modified during tests. This means that one unit test may modify states in the store that are used by other tests. Making it difficult to run anything in parallel, as well as to add and update tests. I will try to fix that so that we don't end up with flaky tests :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
