### PR TITLE
Add offline mode to e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
           spec: "tests/e2e/**/*"
         env:
           CYPRESS_baseUrl: http://localhost:8080/
-          NODE_ENV: offline
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ below.
  - Alex Szabó
  - Ash Newport
  - Garrett Walker
+ - Mel Hall
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "yarn run serve",
     "lint": "vue-cli-service lint",
     "serve": "NODE_ENV=offline vue-cli-service serve",
-    "test:e2e": "vue-cli-service test:e2e",
+    "test:e2e": "NODE_ENV=offline vue-cli-service test:e2e",
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {


### PR DESCRIPTION
This is a small change with no associated Issue.

This fixes an issue whereby, running e2e tests results in error if NODE_ENV is not set to offline. 

Thanks to @kinow for the fix!


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not need tests (used only for development).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
