### PR TITLE
Remove vuex-router-sync dependency and code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "vue-spinner": "^1.0.4",
     "vue-the-mask": "^0.11.1",
     "vuetify": "^2.3.12",
-    "vuex": "^3.5.1",
-    "vuex-router-sync": "^5.0.0"
+    "vuex": "^3.5.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.10.4",

--- a/src/main.js
+++ b/src/main.js
@@ -23,9 +23,6 @@ import Vue from 'vue'
 import './plugins'
 import vuetify from './plugins/vuetify'
 
-// Sync router with store
-import { sync } from 'vuex-router-sync'
-
 // Application imports
 import App from './App'
 import i18n from '@/i18n'
@@ -38,9 +35,6 @@ import store from '@/store'
  */
 import SubscriptionWorkflowService from 'workflow-service'
 import { createGraphQLUrls, createSubscriptionClient } from '@/utils/graphql'
-
-// Sync store with router
-sync(store, router)
 
 // WorkflowService singleton available application-wide
 // On the offline mode, we do not have a WebSocket link, so we must create a null SubscriptionClient to use an empty link

--- a/yarn.lock
+++ b/yarn.lock
@@ -13483,11 +13483,6 @@ vuetify@^2.3.12:
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.3.12.tgz#799410de0878d8aae10cfae14e40549b9a88ca87"
   integrity sha512-FSt1pzpf0/Lh0xuctAPB7RiLbUl7bzVc7ejbXLLhfmgm7zD7yabuhVYuyVda/SzokjZMGS3j1lNu2lLfdrz0oQ==
 
-vuex-router-sync@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/vuex-router-sync/-/vuex-router-sync-5.0.0.tgz#1a225c17a1dd9e2f74af0a1b2c62072e9492b305"
-  integrity sha512-Mry2sO4kiAG64714X1CFpTA/shUH1DmkZ26DFDtwoM/yyx6OtMrc+MxrU+7vvbNLO9LSpgwkiJ8W+rlmRtsM+w==
-
 vuex@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.5.1.tgz#f1b8dcea649bc25254cf4f4358081dbf5da18b3d"


### PR DESCRIPTION
This is a small change with no associated Issue.

Found this while working on the JupyterLab tests yesterday. While reviewing our dependencies, to see what JupyterLab would need, I spotted this one that I didn't remember why we needed it.

Some `git-log`'ing later, I remembered it came with the Tim Creative theme that we used for the first versions of Cylc UI.

https://github.com/vuejs/vuex-router-sync

The `vuex-router-sync` library adds a `store.state.route` attribute to the Vuex store's state. This `route` attribute represents the current route. We haven't had to use this yet, so safe to remove IMO.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? removing dependency).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
