### PR TITLE
Display message triggers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ None or N/A.
 
 ### Enhancements
 
+[#530](https://github.com/cylc/cylc-ui/pull/530) - Display message triggers.
+
 [#544](https://github.com/cylc/cylc-ui/pull/544) - Enable editing
 mutation inputs and support broadcasts in the UI.
 

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -89,13 +89,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             v-if="node.node.customOutputs.length > 0"
           >
             <v-tooltip
-              v-for="customOutput of node.node.customOutputs.slice(0, 5)"
-              :key="customOutput.id"
+              v-for="customOutput of [...node.node.customOutputs].slice(0, 5)"
+              :key="`${customOutput.id}-chip`"
               bottom
             >
               <template v-slot:activator="{ on, attrs }">
                 <v-chip
-                  :key="`${customOutput.id}-chip`"
                   v-bind="attrs"
                   v-on="on"
                   color="grey"
@@ -140,7 +139,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
               <div
                 v-for="customOutput of node.node.customOutputs"
-                :key="customOutput.id"
+                :key="`${customOutput.id}-leaf`"
                 class="leaf-entry"
               >
                 <span class="px-4 leaf-entry-title">{{ customOutput.label }}</span>

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -88,15 +88,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="grey--text d-flex flex-nowrap flex-row align-center"
             v-if="node.node.customOutputs.length > 0"
           >
-            <v-chip
-              v-if="node.node.customOutputs.length > 5"
-              color="grey"
-              text-color="grey lighten-5"
-              class="ml-2"
-              small
-              link
-              @click="typeClicked"
-            >+{{ node.node.customOutputs.length - 5 }}</v-chip>
             <v-tooltip
               v-for="customOutput of node.node.customOutputs.slice(0, 5)"
               :key="customOutput.id"
@@ -115,6 +106,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </template>
               <span>{{ customOutput.message }}</span>
             </v-tooltip>
+            <v-chip
+              v-if="node.node.customOutputs.length > 5"
+              color="grey"
+              text-color="grey lighten-5"
+              class="ml-2"
+              small
+              link
+              @click="typeClicked"
+            >+{{ node.node.customOutputs.length - 5 }}</v-chip>
           </span>
         </div>
       </slot>

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -81,24 +81,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <span class="mx-1">#{{ node.node.submitNum }}</span>
           <span class="grey--text">{{ node.node.host }}</span>
           <span
-            class="grey--text d-flex flex-nowrap flex-row"
-            v-if="node.node.customMessages.length > 0"
+            class="grey--text d-flex flex-nowrap flex-row align-center"
+            v-if="node.node.customOutputs.length > 0"
           >
             <v-chip
-              v-if="node.node.customMessages.length > 5"
+              v-if="node.node.customOutputs.length > 5"
               color="grey"
               text-color="grey lighten-5"
               class="ml-2"
               small
               link
               @click="typeClicked"
-            >{{ node.node.customMessages.length }}+</v-chip>
-            <!-- eslint-disable-next-line vue/no-unused-vars -->
+            >{{ node.node.customOutputs.length }}+</v-chip>
             <v-tooltip
-              v-for="(customMessage, index) of
-                    node.node.customMessages
-                      .filter(message => message.satisfied)
-                      .slice(0, 5)"
+              v-for="(customOutput, index) of node.node.customOutputs.slice(0, 5)"
               :key="index"
               bottom
             >
@@ -110,9 +106,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   text-color="grey lighten-5"
                   class="ml-2"
                   small
-                >{{ customMessage.label }}</v-chip>
+                >{{ customOutput.label }}</v-chip>
               </template>
-              <span>{{ customMessage.message }}</span>
+              <span>{{ customOutput.message }}</span>
             </v-tooltip>
           </span>
         </div>
@@ -133,14 +129,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="leaf-entry">
               <span class="px-4 leaf-entry-title grey--text text--darken-1">outputs</span>
             </div>
-            <div v-if="node.node.customMessages.length > 0">
+            <div v-if="node.node.customOutputs && node.node.customOutputs.length > 0">
               <div
-                v-for="(customMessage, index) of node.node.customMessages"
+                v-for="(customOutput, index) of node.node.customOutputs"
                 :key="`${node.node.id}-job-custom-message-${index}`"
                 class="leaf-entry"
               >
-                <span class="px-4 leaf-entry-title">{{ customMessage.label }}</span>
-                <span class="grey--text leaf-entry-value">{{ customMessage.message }}</span>
+                <span class="px-4 leaf-entry-title">{{ customOutput.label }}</span>
+                <span class="grey--text leaf-entry-value">{{ customOutput.message }}</span>
               </div>
             </div>
             <div v-else class="leaf-entry">

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -88,6 +88,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="grey--text d-flex flex-nowrap flex-row align-center"
             v-if="node.node.customOutputs.length > 0"
           >
+            <!--
+              We had a tricky bug in #530 due to the :key here. In summary, the list
+              that is backing this component changes. It contains zero or more entries,
+              up to N (5 at the time of writing).
+              Initially we used `:key=customOutput.id` here. But Vue tried to avoid
+              changing the DOM elements, which caused some elements to be out of order
+              in the final rendered UI (as Vue was trying to optimize and keep the
+              DOM elements in-place whenever possible).
+              That behaviour is not deterministic, so sometimes you would have the list
+              in order. The fix was to use a key that combines a string with the list
+              iteration `index` (the `:key` value must be unique, so we used output-chip
+              prefix).
+              @see https://github.com/cylc/cylc-ui/pull/530#issuecomment-781076619
+            -->
             <v-tooltip
               v-for="(customOutput, index) of [...node.node.customOutputs].slice(0, 5)"
               :key="`output-chip-${index}`"

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -92,7 +92,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               small
               link
               @click="typeClicked"
-            >{{ node.node.customOutputs.length }}+</v-chip>
+            >{{ node.node.customOutputs.length - 5 }}+</v-chip>
             <v-tooltip
               v-for="(customOutput, index) of node.node.customOutputs.slice(0, 5)"
               :key="index"

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -80,6 +80,41 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           />
           <span class="mx-1">#{{ node.node.submitNum }}</span>
           <span class="grey--text">{{ node.node.host }}</span>
+          <span
+            class="grey--text d-flex flex-nowrap flex-row"
+            v-if="node.node.customMessages.length > 0"
+          >
+            <v-chip
+              v-if="node.node.customMessages.length > 5"
+              color="grey"
+              text-color="grey lighten-5"
+              class="ml-2"
+              small
+              link
+              @click="typeClicked"
+            >{{ node.node.customMessages.length }}+</v-chip>
+            <!-- eslint-disable-next-line vue/no-unused-vars -->
+            <v-tooltip
+              v-for="(customMessage, index) of
+                    node.node.customMessages
+                      .filter(message => message.satisfied)
+                      .slice(0, 5)"
+              :key="index"
+              bottom
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <v-chip
+                  v-bind="attrs"
+                  v-on="on"
+                  color="grey"
+                  text-color="grey lighten-5"
+                  class="ml-2"
+                  small
+                >{{ customMessage.label }}</v-chip>
+              </template>
+              <span>{{ customMessage.message }}</span>
+            </v-tooltip>
+          </span>
         </div>
       </slot>
       <slot name="job-details" v-else-if="node.type === 'job-details'">
@@ -93,6 +128,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
               <span class="px-4 leaf-entry-title">{{ jobDetail.title }}</span>
               <span class="grey--text leaf-entry-value">{{ jobDetail.value }}</span>
+            </div>
+            <v-divider class="ml-3 mr-5" />
+            <div class="leaf-entry">
+              <span class="px-4 leaf-entry-title grey--text text--darken-1">outputs</span>
+            </div>
+            <div v-if="node.node.customMessages.length > 0">
+              <div
+                v-for="(customMessage, index) of node.node.customMessages"
+                :key="`${node.node.id}-job-custom-message-${index}`"
+                class="leaf-entry"
+              >
+                <span class="px-4 leaf-entry-title">{{ customMessage.label }}</span>
+                <span class="grey--text leaf-entry-value">{{ customMessage.message }}</span>
+              </div>
+            </div>
+            <div v-else class="leaf-entry">
+              <span class="px-4 leaf-entry-title grey--text text--darken-1">No custom messages</span>
             </div>
           </div>
         </div>

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -89,8 +89,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             v-if="node.node.customOutputs.length > 0"
           >
             <v-tooltip
-              v-for="customOutput of [...node.node.customOutputs].slice(0, 5)"
-              :key="`${customOutput.id}-chip`"
+              v-for="(customOutput, index) of [...node.node.customOutputs].slice(0, 5)"
+              :key="`output-chip-${index}`"
               bottom
             >
               <template v-slot:activator="{ on, attrs }">

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -35,6 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div :class="getNodeDataClass()" @click="nodeClicked">
           <task
             v-cylc-object="node.node.id"
+            :key="node.node.id"
             :status="node.node.state"
             :isHeld="node.node.isHeld"
             :progress=0
@@ -46,6 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div :class="getNodeDataClass()" @click="nodeClicked">
           <task
             v-cylc-object="node.node.id"
+            :key="node.node.id"
             :status="node.node.state"
             :isHeld="node.node.isHeld"
             :progress="node.node.progress"
@@ -57,6 +59,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div :class="getNodeDataClass()" @click="nodeClicked">
           <task
             v-cylc-object="node.node.id"
+            :key="node.node.id"
             :status="node.node.state"
             :isHeld="node.node.isHeld"
             :progress="node.node.progress"
@@ -76,6 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div :class="getNodeDataClass()" @click="nodeClicked">
           <job
             v-cylc-object="node.node.id"
+            :key="node.node.id"
             :status="node.node.state"
           />
           <span class="mx-1">#{{ node.node.submitNum }}</span>
@@ -152,7 +156,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         v-else
       >
         <div :class="getNodeDataClass()">
-          <span @click="nodeClicked" class="mx-1" v-if="node && node.node">{{ node.node.name }}</span>
+          <span
+            v-if="node && node.node"
+            @click="nodeClicked"
+            :key="node.node.id"
+            class="mx-1">{{ node.node.name }}</span>
         </div>
       </slot>
       <slot></slot>

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -96,7 +96,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               small
               link
               @click="typeClicked"
-            >{{ node.node.customOutputs.length - 5 }}+</v-chip>
+            >+{{ node.node.customOutputs.length - 5 }}</v-chip>
             <v-tooltip
               v-for="customOutput of node.node.customOutputs.slice(0, 5)"
               :key="customOutput.id"

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -134,7 +134,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="leaf-entry">
               <span class="px-4 leaf-entry-title grey--text text--darken-1">outputs</span>
             </div>
-            <div v-if="node.node.customOutputs && node.node.customOutputs.length > 0">
+            <div
+              v-if="node.node.customOutputs && node.node.customOutputs.length > 0"
+              class="leaf-outputs-entry"
+            >
               <div
                 v-for="customOutput of node.node.customOutputs"
                 :key="customOutput.id"

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -94,12 +94,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               @click="typeClicked"
             >{{ node.node.customOutputs.length - 5 }}+</v-chip>
             <v-tooltip
-              v-for="(customOutput, index) of node.node.customOutputs.slice(0, 5)"
-              :key="index"
+              v-for="customOutput of node.node.customOutputs.slice(0, 5)"
+              :key="customOutput.id"
               bottom
             >
               <template v-slot:activator="{ on, attrs }">
                 <v-chip
+                  :key="`${customOutput.id}-chip`"
                   v-bind="attrs"
                   v-on="on"
                   color="grey"
@@ -118,8 +119,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <div class="arrow-up" :style="getLeafTriangleStyle()"></div>
           <div class="leaf-data font-weight-light py-4 pl-2">
             <div
-              v-for="(jobDetail, index) in node.node.details"
-              :key="`${node.node.id}-job-detail-${index}`"
+              v-for="jobDetail in node.node.details"
+              :key="jobDetail.id"
               class="leaf-entry"
             >
               <span class="px-4 leaf-entry-title">{{ jobDetail.title }}</span>
@@ -131,8 +132,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             <div v-if="node.node.customOutputs && node.node.customOutputs.length > 0">
               <div
-                v-for="(customOutput, index) of node.node.customOutputs"
-                :key="`${node.node.id}-job-custom-message-${index}`"
+                v-for="customOutput of node.node.customOutputs"
+                :key="customOutput.id"
                 class="leaf-entry"
               >
                 <span class="px-4 leaf-entry-title">{{ customOutput.label }}</span>

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -36,19 +36,19 @@ export const FAMILY_ROOT = 'root'
  * @param {*} source - the source object
  */
 function mergeWithCustomizer (objValue, srcValue, key, object, source) {
-  // 1. object[key], or objValue, is undefined
-  //    meaning the destination object does not have the property
-  //    so let's add it with reactivity!
-  if (objValue === undefined) {
-    Vue.set(object, `${key}`, srcValue)
-    return object[key]
-  }
-  // 2. object[key], or objValue, is defined but without reactivity
-  //    this means somehow the object got a new property that is not reactive
-  //    so let's now make it reactive with the new value!
-  if (object && object[key] && !object[key].__ob__) {
-    Vue.set(object, `${key}`, srcValue)
-    return object[key]
+  if (srcValue !== undefined) {
+    // 1. object[key], or objValue, is undefined
+    //    meaning the destination object does not have the property
+    //    so let's add it with reactivity!
+    if (objValue === undefined) {
+      Vue.set(object, `${key}`, srcValue)
+    }
+    // 2. object[key], or objValue, is defined but without reactivity
+    //    this means somehow the object got a new property that is not reactive
+    //    so let's now make it reactive with the new value!
+    if (object[key] && !object[key].__ob__) {
+      Vue.set(object, `${key}`, srcValue)
+    }
   }
 }
 

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -15,11 +15,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { extractGroupState } from '@/utils/tasks'
-import { merge, sortedIndex } from 'lodash'
+import { mergeWith, sortedIndex } from 'lodash'
 import { createFamilyProxyNode, getCyclePointId } from '@/components/cylc/tree/index'
 import TaskState from '@/model/TaskState.model'
+import Vue from 'vue'
 
 export const FAMILY_ROOT = 'root'
+
+/**
+ * Only effectively used if we return something. Otherwise Lodash will use its default merge
+ * function. We use it here not to mutate objects, but to check that we are not losing
+ * reactivity in Vue by adding a non-reactive property into an existing object (which should
+ * be reactive and used in the node tree component).
+ *
+ * @see https://docs-lodash.com/v4/merge-with/
+ * @param {*} objValue - destination value in the existing object (same as object[key])
+ * @param {*} srcValue - source value from the object with new values to be merged
+ * @param {string} key - name of the property being merged (used to access object[key])
+ * @param {*} object - the object being mutated (original, destination, the value is retrieved with object[key])
+ * @param {*} source - the source object
+ */
+function mergeWithCustomizer (objValue, srcValue, key, object, source) {
+  // 1. object[key], or objValue, is undefined
+  //    meaning the destination object does not have the property
+  //    so let's add it with reactivity!
+  if (objValue === undefined) {
+    Vue.set(object, `${key}`, srcValue)
+    return object[key]
+  }
+  // 2. object[key], or objValue, is defined but without reactivity
+  //    this means somehow the object got a new property that is not reactive
+  //    so let's now make it reactive with the new value!
+  if (object && object[key] && !object[key].__ob__) {
+    Vue.set(object, `${key}`, srcValue)
+    return object[key]
+  }
+}
 
 /**
  * Compute percent progress.
@@ -301,7 +332,7 @@ class CylcTree {
   updateCyclePoint (cyclePoint) {
     const node = this.lookup.get(cyclePoint.id)
     if (node) {
-      merge(node, cyclePoint)
+      mergeWith(node, cyclePoint, mergeWithCustomizer)
     }
   }
 
@@ -348,7 +379,7 @@ class CylcTree {
       // family proxy. In that case, we create an orphan node in the lookup table.
       // The second time will be node with more information, such as .firstParent {}. When this happens,
       // we must remember to merge the objects.
-      merge(existingFamilyProxy, familyProxy)
+      mergeWith(existingFamilyProxy, familyProxy, mergeWithCustomizer)
       this.lookup.set(existingFamilyProxy.id, existingFamilyProxy)
       // NOTE: important, replace the version so that we use the existing one
       // when linking with the parent node in the tree, not the new GraphQL data
@@ -397,7 +428,7 @@ class CylcTree {
   updateFamilyProxy (familyProxy) {
     const node = this.lookup.get(familyProxy.id)
     if (node) {
-      merge(node, familyProxy)
+      mergeWith(node, familyProxy, mergeWithCustomizer)
       if (!node.node.state) {
         node.node.state = ''
       }
@@ -478,6 +509,14 @@ class CylcTree {
     if (!this.lookup.has(taskProxy.id)) {
       // progress starts at 0
       taskProxy.node.progress = 0
+      // A TaskProxy could be a ghost node, which doesn't have a state/status yet.
+      // Note that we cannot have this if-check in `createTaskProxyNode`, as an
+      // update-delta might not have a state, and we don't want to merge
+      // { state: "" } with an object that contains { state: "running" }, for
+      // example.
+      if (!taskProxy.node.state) {
+        taskProxy.node.state = ''
+      }
       this.lookup.set(taskProxy.id, taskProxy)
       if (taskProxy.node.firstParent) {
         const parent = this.findTaskProxyParent(taskProxy)
@@ -503,7 +542,7 @@ class CylcTree {
     const node = this.lookup.get(taskProxy.id)
     if (node) {
       computeTaskProgress(taskProxy)
-      merge(node, taskProxy)
+      mergeWith(node, taskProxy, mergeWithCustomizer)
     }
   }
 
@@ -554,7 +593,7 @@ class CylcTree {
   updateJob (job) {
     const node = this.lookup.get(job.id)
     if (node) {
-      merge(node, job)
+      mergeWith(node, job, mergeWithCustomizer)
       if (job.node.firstParent) {
         const parent = this.lookup.get(job.node.firstParent.id)
         // re-calculate the job's task progress

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -18,6 +18,7 @@
 // eslint-disable-next-line no-unused-vars
 import CylcTree from '@/components/cylc/tree/cylc-tree'
 import TaskOutput from '@/model/TaskOutput'
+import Vue from 'vue'
 
 /**
  * Create a workflow node. Uses the same properties (by reference) as the given workflow,
@@ -215,7 +216,7 @@ function createCustomOutputs (job) {
 // TODO: add job-leaf (details) in the hierarchy later for infinite-tree
 function createJobNode (job) {
   const jobDetailsNode = createJobDetailsNode(job)
-  job.customOutputs = createCustomOutputs(job)
+  Vue.set(job, 'customOutputs', createCustomOutputs(job))
   return {
     id: job.id,
     type: 'job',

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -115,10 +115,6 @@ function createFamilyProxyNode (familyProxy) {
  */
 // TODO: move expanded state to data later for infinite-tree
 function createTaskProxyNode (taskProxy) {
-  // A TaskProxy could be a ghost node, which doesn't have a state/status yet
-  if (!taskProxy.state) {
-    taskProxy.state = ''
-  }
   return {
     id: taskProxy.id,
     type: 'task-proxy',
@@ -155,6 +151,7 @@ function createJobDetailsNode (job) {
       value: job.finishedTime
     }
   ]
+
   // NOTE: `node.node.customOutputs` is not from the GraphQL query, but added
   //       in createJobNode in this module.
   return {
@@ -174,6 +171,7 @@ function createJobDetailsNode (job) {
  * If no outputs or no custom outputs are provided, then we return an empty list.
  *
  * @param {{
+ *   id: string,
  *   taskProxy: {
  *     outputs: [
  *       {
@@ -197,6 +195,11 @@ function createCustomOutputs (job) {
     .taskProxy
     .outputs
     .filter(output => !TaskOutput.enumValues.map(taskOutput => taskOutput.name).includes(output.label))
+    .map(output => {
+      return Object.assign({}, output, {
+        id: `${job.id}-output-${output.label}`
+      })
+    })
   return customOutputs || []
 }
 

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -192,6 +192,10 @@ function createJobDetailsNode (job) {
 function createCustomOutputs (job) {
   // NOTE: the query has the filter satisfied:true already, no need to filter for that here
   //       but we want only custom outputs, so we will filter removing the standard outputs
+  if (!job || !job.taskProxy || !job.taskProxy.outputs) {
+    return []
+  }
+
   const customOutputs = job
     .taskProxy
     .outputs

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -159,7 +159,7 @@ function createJobDetailsNode (job) {
     id: `${job.id}-details`,
     type: 'job-details',
     node: {
-      customOutputs: createCustomOutputs(job),
+      customOutputs: job.customOutputs,
       details
     }
   }
@@ -215,8 +215,8 @@ function createCustomOutputs (job) {
 // TODO: re-work the latest message, as this is the task latest message, not the job's...
 // TODO: add job-leaf (details) in the hierarchy later for infinite-tree
 function createJobNode (job) {
-  const jobDetailsNode = createJobDetailsNode(job)
   Vue.set(job, 'customOutputs', createCustomOutputs(job))
+  const jobDetailsNode = createJobDetailsNode(job)
   return {
     id: job.id,
     type: 'job',

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -158,7 +158,8 @@ function createJobDetailsNode (job) {
     id: `${job.id}-details`,
     type: 'job-details',
     node: {
-      details
+      details,
+      customMessages: job.customMessages
     }
   }
 }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -160,6 +160,12 @@ fragment JobData on Job {
   finishedTime
   state
   submitNum
+  taskProxy {
+    outputs (satisfied: true, sort: { keys: ["time"], reverse: true}) {
+      label
+      message
+    }
+  }
 }
 
 # WORKFLOW DATA END

--- a/src/model/TaskOutput.js
+++ b/src/model/TaskOutput.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Enumify } from 'enumify'
+
+class TaskOutput extends Enumify {
+  // @see: https://cylc.github.io/cylc-admin/proposal-state-names.html#outputs
+  // @see: https://github.com/cylc/cylc-flow/blob/bb79a6e03437927ecf97deb6a34fa8f1e7ab0835/cylc/flow/task_outputs.py
+  static EXPIRED = new TaskOutput('expired')
+  static SUBMITTED = new TaskOutput('submitted')
+  static SUBMIT_FAILED = new TaskOutput('submit-failed')
+  static STARTED = new TaskOutput('started')
+  static SUCCEEDED = new TaskOutput('succeeded')
+  static FAILED = new TaskOutput('failed')
+  static _ = this.closeEnum()
+
+  /**
+   * Constructor.
+   * @param {String} name
+   */
+  constructor (name) {
+    super()
+    this.name = name
+  }
+}
+
+export default TaskOutput

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -95,8 +95,8 @@ fragment JobData on Job {
   finishedTime
   state
   submitNum
-  taskProxy (stripNull: false) {
-    outputs (satisfied: true, sort: { keys: ["timestamp"], reverse: true}) {
+  taskProxy {
+    outputs (satisfied: true, sort: { keys: ["time"], reverse: true}) {
       label
       message
     }

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -95,6 +95,12 @@ fragment JobData on Job {
   finishedTime
   state
   submitNum
+  taskProxy (stripNull: false) {
+    outputs (satisfied: true, sort: { keys: ["timestamp"], reverse: true}) {
+      label
+      message
+    }
+  }
 }
 '''
 

--- a/src/services/mock/workflow.service.mock.js
+++ b/src/services/mock/workflow.service.mock.js
@@ -127,9 +127,10 @@ class MockWorkflowService extends GQuery {
     let baseTimestamp = new Date().getTime()
     // TODO: remove if the checkpoint workflow adds message triggers, as this is used
     //       only for testing in the offline mode.
-    // NOTE: in the query for GraphQL, use a sort on the timestamp value, to make sure
+    // NOTE: In the query for GraphQL, use a sort on the timestamp value, to make sure
     //       the elements returned are in order, showing the most recent ones first!
-    const messages = [...Array(15).keys()]
+    //       We also have satisfied:true in the query, that's why we have the .filter below.
+    const outputs = [...Array(15).keys()]
       .map(i => {
         const label = `msg-label-${i}`
         const message = `This is the message of the label ${i}`
@@ -141,10 +142,13 @@ class MockWorkflowService extends GQuery {
           satisfied: i % 2 === 0
         }
       })
+      .filter(output => output.satisfied)
       .sort((a, b) => b.timestamp - a.timestamp)
     one.taskProxies.forEach(taskProxy => {
       taskProxy.jobs.forEach(job => {
-        job.customMessages = messages
+        job.taskProxy = {
+          outputs: outputs
+        }
       })
     })
     store.dispatch('workflows/set', workflows).then(() => {})

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -18,6 +18,18 @@
 @import '../../../node_modules/vuetify/src/styles/styles';
 
 $active-color: #BDD5F7;
+/**
+ * Height of each line/row in the tree. Same as saying “each node in the tree has
+ * $line-height height”.
+ */
+$line-height: 1.8em;
+/**
+ * The number of visible outputs in the job info box, under the “outputs” header.
+ * This value is used with $line-height to calculate the maximum height of the
+ * outputs container. Change this value to 10, and you will have 10 visible outputs
+ * in the job info, the remaining outputs being accessible through a scroll.
+ */
+$visible-outputs: 5;
 
 @mixin active-state() {
   background-color: $active-color;
@@ -36,7 +48,7 @@ $active-color: #BDD5F7;
   display: block;
   width: 100%;
   .node {
-    line-height: 1.8em;
+    line-height: $line-height;
     display: block;
 
     .node-expand-collapse-button {
@@ -105,6 +117,13 @@ $active-color: #BDD5F7;
         .leaf-entry-value {
           white-space: nowrap;
         }
+      }
+      .leaf-outputs-entry {
+        // 5 outputs, plus a buffer of 1.0em that appears to give the scroll just the
+        // right space to show the N items in the scroll (without the buffer the last
+        // item is partially hidden).
+        max-height: calc(#{$line-height} * #{$visible-outputs} + 1.0em);
+        overflow-y: scroll;
       }
     }
   }

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -164,7 +164,7 @@ describe('Tree component', () => {
       lastChild
         .children()
         .first()
-        .should('have.text', '8+')
+        .should('have.text', '3+')
     }
     // Finally, let's verify that expanding the job, will show the custom messages
     // in the job details...

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -163,7 +163,7 @@ describe('Tree component', () => {
       const lastChild = failedJob.children().last()
       lastChild
         .children()
-        .first()
+        .last()
         .should('have.text', '+3')
     }
     // Finally, let's verify that expanding the job, will show the custom messages
@@ -174,7 +174,7 @@ describe('Tree component', () => {
       failedJob
         .parent()
         .children()
-        .first()
+        .last()
         .click({ force: true })
       cy
         .get('.leaf-entry-title')

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -164,7 +164,7 @@ describe('Tree component', () => {
       lastChild
         .children()
         .first()
-        .should('have.text', '3+')
+        .should('have.text', '+3')
     }
     // Finally, let's verify that expanding the job, will show the custom messages
     // in the job details...

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -134,6 +134,54 @@ describe('Tree component', () => {
         })
       })
   })
+  it('Should display message triggers', () => {
+    // TODO: The message triggers are programmatically added in the mocked workflow service.
+    //       If/when the one checkpoint workflow is updated and includes data with custom
+    //       message triggers, we need to update this test accordingly.
+    cy.visit('/#/tree/one')
+    // The "failed" task contains custom messages, so let's expand it first
+    const failedTaskProxy = cy
+      .get('.mx-1')
+      .contains('failed')
+      .parent()
+    const failedTaskProxyTreeNode = failedTaskProxy
+      .parent()
+    failedTaskProxyTreeNode
+      .find('.node-expand-collapse-button')
+      .click({ force: true })
+    // Here the job "#1" of the task-proxy "failed" should be visible,
+    // let's confirm it's showing the "N+" chip...
+    const failedJob = cy
+      .get('.mx-1')
+      .contains('#1')
+      .parent()
+    // eslint-disable-next-line no-lone-blocks
+    {
+      failedJob
+        .should('be.visible')
+      // Let's confirm it shows the "N+" chip (i.e. this task has more N messages)
+      const lastChild = failedJob.children().last()
+      lastChild
+        .children()
+        .first()
+        .should('have.text', '8+')
+    }
+    // Finally, let's verify that expanding the job, will show the custom messages
+    // in the job details...
+    // eslint-disable-next-line no-lone-blocks
+    {
+      // expand the job
+      failedJob
+        .parent()
+        .children()
+        .first()
+        .click({ force: true })
+      cy
+        .get('.leaf-entry-title')
+        .contains('msg-label-14')
+        .should('be.visible')
+    }
+  })
   describe('filters', () => {
     it('Should not filter by default', () => {
       cy.visit('/#/tree/one')

--- a/tests/unit/components/cylc/tree/index.spec.js
+++ b/tests/unit/components/cylc/tree/index.spec.js
@@ -16,6 +16,7 @@
  */
 
 import {
+  createJobNode,
   createTaskProxyNode,
   getCyclePointId,
   populateTreeFromGraphQLData
@@ -201,5 +202,17 @@ describe('Tree component functions', () => {
         expect(getCyclePointId(test.node)).to.equal(test.expected)
       }
     })
+  })
+  it('should create custom outputs', () => {
+    const job = sampleWorkflow1.taskProxies[0].jobs[0]
+    const jobNode = createJobNode(job)
+    // The outputs in the GraphQL returned data (and in our test data) contains
+    // 4 outputs, submitted, started, succeeded, and the out1 custom output.
+    // Here we are verifying that `createJobNode` did its work well, removing
+    // the standard outputs, leaving only 1 custom output as below (eql = deep equal).
+    expect(jobNode.node.customOutputs).to.eql([{
+      label: 'out1',
+      message: 'Aliquam a lectus euismod, vehicula leo vel, ultricies odio.'
+    }])
   })
 })

--- a/tests/unit/components/cylc/tree/index.spec.js
+++ b/tests/unit/components/cylc/tree/index.spec.js
@@ -17,7 +17,6 @@
 
 import {
   createJobNode,
-  createTaskProxyNode,
   getCyclePointId,
   populateTreeFromGraphQLData
 } from '@/components/cylc/tree/index'
@@ -125,12 +124,6 @@ describe('Tree component functions', () => {
     // remove the mock
     stub.restore()
   })
-  it('should initialize the task proxy state if undefined', () => {
-    const taskProxy = sampleWorkflow1.taskProxies[0]
-    delete taskProxy.state
-    const taskProxyNode = createTaskProxyNode(taskProxy)
-    expect(taskProxyNode.node.state).to.equal('')
-  })
   it('should not throw an error when the workflow to be populated is invalid', () => {
     const tree = {}
     const workflow = {}
@@ -211,6 +204,7 @@ describe('Tree component functions', () => {
     // Here we are verifying that `createJobNode` did its work well, removing
     // the standard outputs, leaving only 1 custom output as below (eql = deep equal).
     expect(jobNode.node.customOutputs).to.eql([{
+      id: 'cylc|one|20000101T0000Z|eventually_succeeded|4-output-out1',
       label: 'out1',
       message: 'Aliquam a lectus euismod, vehicula leo vel, ultricies odio.'
     }])

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -44,7 +44,8 @@ const simpleWorkflowTree4Nodes = [
             node: {
               __typename: 'TaskProxy',
               name: 'foo',
-              state: 'failed'
+              state: 'failed',
+              prerequisites: []
             },
             expanded: false,
             children: [
@@ -56,7 +57,8 @@ const simpleWorkflowTree4Nodes = [
                   name: '1',
                   startedTime: '2019-08-19T22:44:42Z',
                   state: 'failed',
-                  submitNum: 1
+                  submitNum: 1,
+                  customMessages: []
                 }
               }
             ]

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -44,8 +44,7 @@ const simpleWorkflowTree4Nodes = [
             node: {
               __typename: 'TaskProxy',
               name: 'foo',
-              state: 'failed',
-              prerequisites: []
+              state: 'failed'
             },
             expanded: false,
             children: [

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -58,7 +58,12 @@ const simpleWorkflowTree4Nodes = [
                   startedTime: '2019-08-19T22:44:42Z',
                   state: 'failed',
                   submitNum: 1,
-                  customMessages: []
+                  customOutputs: [
+                    {
+                      label: 'out1',
+                      message: 'Aliquam a lectus euismod, vehicula leo vel, ultricies odio.'
+                    }
+                  ]
                 }
               }
             ]
@@ -123,7 +128,27 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:50Z',
           finishedTime: '2019-10-23T07:02:51Z',
           state: 'succeeded',
-          submitNum: 4
+          submitNum: 4,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              },
+              {
+                label: 'out1',
+                message: 'Aliquam a lectus euismod, vehicula leo vel, ultricies odio.'
+              }
+            ]
+          }
         },
         {
           id: 'cylc|one|20000101T0000Z|eventually_succeeded|3',
@@ -139,7 +164,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:46Z',
           finishedTime: '2019-10-23T07:02:47Z',
           state: 'failed',
-          submitNum: 3
+          submitNum: 3,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         },
         {
           id: 'cylc|one|20000101T0000Z|eventually_succeeded|2',
@@ -155,7 +196,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:42Z',
           finishedTime: '2019-10-23T07:02:43Z',
           state: 'failed',
-          submitNum: 2
+          submitNum: 2,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         },
         {
           id: 'cylc|one|20000101T0000Z|eventually_succeeded|1',
@@ -171,7 +228,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:38Z',
           finishedTime: '2019-10-23T07:02:39Z',
           state: 'failed',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     },
@@ -207,7 +280,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:05Z',
           finishedTime: '2019-10-23T07:03:06Z',
           state: 'succeeded',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         }
       ]
     },
@@ -244,7 +333,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:38Z',
           finishedTime: '2019-10-23T07:02:39Z',
           state: 'succeeded',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         }
       ]
     },
@@ -281,7 +386,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:38Z',
           finishedTime: '2019-10-23T07:02:39Z',
           state: 'failed',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     },
@@ -318,7 +439,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:56Z',
           finishedTime: '2019-10-23T07:03:03Z',
           state: 'succeeded',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         }
       ]
     },
@@ -355,7 +492,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:02:53Z',
           finishedTime: '2019-10-23T07:02:54Z',
           state: 'failed',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     },
@@ -392,7 +545,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:05Z',
           finishedTime: '2019-10-23T07:03:06Z',
           state: 'succeeded',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         }
       ]
     },
@@ -449,7 +618,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:09Z',
           finishedTime: '2019-10-23T07:03:10Z',
           state: 'succeeded',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         }
       ]
     },
@@ -486,7 +671,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:24Z',
           finishedTime: '2019-10-23T07:03:25Z',
           state: 'failed',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     },
@@ -543,7 +744,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:27Z',
           finishedTime: '',
           state: 'running',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     },
@@ -580,7 +797,19 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:27Z',
           finishedTime: '',
           state: 'running',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              }
+            ]
+          }
         }
       ]
     },
@@ -617,7 +846,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:21Z',
           finishedTime: '2019-10-23T07:03:22Z',
           state: 'succeeded',
-          submitNum: 4
+          submitNum: 4,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'succeeded',
+                message: 'succeeded'
+              }
+            ]
+          }
         },
         {
           id: 'cylc|one|20000102T0000Z|eventually_succeeded|3',
@@ -633,7 +878,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:17Z',
           finishedTime: '2019-10-23T07:03:18Z',
           state: 'failed',
-          submitNum: 3
+          submitNum: 3,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         },
         {
           id: 'cylc|one|20000102T0000Z|eventually_succeeded|2',
@@ -649,7 +910,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:13Z',
           finishedTime: '2019-10-23T07:03:14Z',
           state: 'failed',
-          submitNum: 2
+          submitNum: 2,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         },
         {
           id: 'cylc|one|20000102T0000Z|eventually_succeeded|1',
@@ -665,7 +942,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:09Z',
           finishedTime: '2019-10-23T07:03:10Z',
           state: 'failed',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     },
@@ -702,7 +995,23 @@ const sampleWorkflow1 = {
           submittedTime: '2019-10-23T07:03:09Z',
           finishedTime: '2019-10-23T07:03:10Z',
           state: 'failed',
-          submitNum: 1
+          submitNum: 1,
+          taskProxy: {
+            outputs: [
+              {
+                label: 'submitted',
+                message: 'submitted'
+              },
+              {
+                label: 'started',
+                message: 'started'
+              },
+              {
+                label: 'failed',
+                message: 'failed'
+              }
+            ]
+          }
         }
       ]
     }

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -501,6 +501,26 @@ describe('CylcTree', () => {
       cylcTree.updateTaskProxy(taskProxy)
       expect(cylcTree.root.children[0].children[0].children[0].node.state).to.equal(TaskState.WAITING.name)
     })
+    it('Should not change the state of an existing task proxy when updating it', () => {
+      const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
+      const taskProxyState = TaskState.RUNNING.name
+      const taskProxy = createTaskProxyNode({
+        id: taskProxyId,
+        firstParent: {
+          id: familyProxy.id
+        },
+        state: taskProxyState
+      })
+      cylcTree.addTaskProxy(taskProxy)
+      expect(cylcTree.root.children[0].children[0].children[0].node.state).to.equal(TaskState.RUNNING.name)
+
+      // state="running", now a delta without state should NOT change the existing state
+      const updateTaskProxy = createTaskProxyNode({
+        id: taskProxyId
+      })
+      cylcTree.updateTaskProxy(updateTaskProxy)
+      expect(cylcTree.root.children[0].children[0].children[0].node.state).to.equal(TaskState.RUNNING.name)
+    })
     it('Should not update an task proxy if it is not in the tree', () => {
       const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
       const taskProxyState = TaskState.RUNNING.name

--- a/tests/unit/components/cylc/tree/tree.vue.spec.js
+++ b/tests/unit/components/cylc/tree/tree.vue.spec.js
@@ -90,7 +90,8 @@ describe('Tree component', () => {
     it('should not activate by default', () => {
       const wrapper = mountFunction({
         propsData: {
-          workflows: simpleWorkflowTree4Nodes[0].children
+          workflows: simpleWorkflowTree4Nodes[0].children,
+          filterable: false
         }
       })
       const treeItems = wrapper.findAllComponents({ name: 'TreeItem' })


### PR DESCRIPTION
These changes close #402 

- [x] display `v-chip`'s with the message "labels"
- [x] display the message text as a tooltip of the `v-chip`
- [x] hide the message if its flag (`satisfied`, `received`, etc) is not `true`
- [x] limit number of `v-chip`'s to 5 most recent (remember to check the backend model for a timestamp...)
- [x] when more than 5 `v-chip`'s, display an icon showing that we have more; when pressed, open job details
- [x] also include all the "label" & "message" in the job details (leaf-node)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
