### PR TITLE
Tweak CSS flex/overflow values for GScan workflow names, to avoid word-break, and hidden job statuses

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -36,9 +36,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <v-icon>{{ getWorkflowIcon(workflow.status) }}</v-icon>
           </v-list-item-action>
           <v-list-item-title>
-            <v-layout align-center align-content-center wrap>
-              <v-flex grow>{{ workflow.name }}</v-flex>
-              <v-flex shrink ml-4>
+            <v-layout align-center align-content-center nowrap>
+              <v-flex class="c-gscan-workflow-name">{{ workflow.name }}</v-flex>
+              <v-flex shrink>
                 <!-- task summary tooltips -->
                 <span
                   v-for="[state, tasks] in workflowsSummaries.get(workflow.name).entries()"

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -21,6 +21,11 @@
       a.c-workflow-stopped {
         opacity: 0.5;
       }
+      .c-gscan-workflow-name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 }

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -50,7 +50,7 @@ describe('GScan component', () => {
     })
     expect(wrapper.props().workflows[0].name).to.equal('five')
     expect(wrapper.find('div')).to.not.equal(null)
-    expect(wrapper.html()).to.contain('<div class="flex grow">five</div>')
+    expect(wrapper.html()).to.contain('five')
   })
   describe('Sorting', () => {
     it('should display workflows in alphabetical order', () => {


### PR DESCRIPTION
These changes close #529 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? cosmetic change, and testing that two elements have some `x`/are aligned, is quite hard ).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
