### PR TITLE
Add slots to the Tree and Tree item components, and then use Tree component in GScan

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -310,12 +310,13 @@ export default {
     sortedWorkflows () {
       return [...this.filteredWorkflows].sort((left, right) => {
         if (left.status !== right.status) {
-          if (left.status === WorkflowState.STOPPED.name) {
-            return 1
-          }
-          if (right.status === WorkflowState.STOPPED.name) {
+          if (left.status === WorkflowState.RUNNING.name) {
             return -1
           }
+          if (left.status === WorkflowState.HELD.name) {
+            return -1
+          }
+          return 1
         }
         return left.name
           .localeCompare(

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -314,7 +314,7 @@ export default {
           if (left.status === WorkflowState.RUNNING.name) {
             return -1
           }
-          if (left.status === WorkflowState.HELD.name) {
+          if (left.status === WorkflowState.HELD.name && right.status !== WorkflowState.RUNNING.name) {
             return -1
           }
           return 1

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -181,6 +181,7 @@ import { mdiFilter } from '@mdi/js'
 import Job from '@/components/cylc/Job'
 import Tree from '@/components/cylc/tree/Tree'
 import { createWorkflowNode } from '@/components/cylc/tree/index'
+import TaskState from '@/model/TaskState.model'
 
 const QUERIES = {
   root: GSCAN_QUERY

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <v-container>
     <v-row
+      v-if="filterable"
       class="mb-1"
     >
       <v-col
@@ -96,6 +97,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       v-on:tree-item-collapsed="onTreeItemCollapsed"
       v-on:tree-item-clicked="onTreeItemClicked"
     >
+      <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope"><slot :name="slot" v-bind="scope"/></template>
     </tree-item>
   </v-container>
 </template>
@@ -120,7 +122,11 @@ export default {
     },
     hoverable: Boolean,
     activable: Boolean,
-    multipleActive: Boolean
+    multipleActive: Boolean,
+    filterable: {
+      type: Boolean,
+      default: true
+    }
   },
   components: {
     Task,

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </v-row>
     <!-- each workflow is a tree root -->
     <tree-item
-      v-for="workflow of sortedChildren('workflow', workflows)"
+      v-for="workflow of workflows"
       :key="workflow.id"
       :node="workflow"
       :hoverable="hoverable"

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -281,8 +281,7 @@ export default {
       return {
         node: true,
         'node--hoverable': this.hoverable,
-        'node--active': this.active,
-        'ml-3': true
+        'node--active': this.active
       }
     },
     getNodeDataClass () {

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -21,6 +21,8 @@
   }
   .c-gscan-workflows {
     .c-gscan-workflow {
+      padding: 0 !important;
+      margin: 0 !important;
       a.c-workflow-stopped {
         opacity: 0.5;
       }

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -161,11 +161,11 @@ describe('GScan component', () => {
       const wrapper = mountFunction({
         propsData: {
           workflows: [
-            { id: 'user|e', name: 'e', status: 'held' },
             { id: 'user|a', name: 'a', status: 'held' },
             { id: 'user|c', name: 'c', status: 'stopped' },
             { id: 'user|b', name: 'b', status: 'running' },
-            { id: 'user|d', name: 'd', status: 'stopped' }
+            { id: 'user|d', name: 'd', status: 'stopped' },
+            { id: 'user|e', name: 'e', status: 'held' }
           ]
         },
         data () {
@@ -372,6 +372,21 @@ describe('GScan component', () => {
         })
         expect(wrapper.vm.filteredWorkflows.length).to.equal(0)
       })
+    })
+  })
+  describe('Workflow link', () => {
+    it('should create an empty link for non-workflow nodes', () => {
+      const link = GScan.methods.workflowLink({})
+      expect(link).to.equal('')
+    })
+    it('should create a link for a workflow node', () => {
+      const link = GScan.methods.workflowLink({
+        type: 'workflow',
+        node: {
+          name: 'name'
+        }
+      })
+      expect(link).to.equal('/workflows/name')
     })
   })
 })

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -20,6 +20,7 @@ import { expect } from 'chai'
 // import vuetify here so that we do not have warnings in the console output
 // eslint-disable-next-line no-unused-vars
 import GScan from '@/components/cylc/gscan/GScan'
+import TreeItem from '@/components/cylc/tree/TreeItem'
 import { simpleWorkflowGscanNodes } from './gscan.data'
 import WorkflowState from '@/model/WorkflowState.model'
 import TaskState from '@/model/TaskState.model'
@@ -85,11 +86,11 @@ describe('GScan component', () => {
       const wrapper = mountFunction({
         propsData: {
           workflows: [
-            { id: '1', name: 'a', status: 'running' },
-            { id: '5', name: 'e', status: 'running' },
-            { id: '3', name: 'c', status: 'running' },
-            { id: '2', name: 'b', status: 'running' },
-            { id: '4', name: 'd', status: 'running' }
+            { id: 'user|a', name: 'a', status: 'running' },
+            { id: 'user|e', name: 'e', status: 'running' },
+            { id: 'user|c', name: 'c', status: 'running' },
+            { id: 'user|b', name: 'b', status: 'running' },
+            { id: 'user|d', name: 'd', status: 'running' }
           ]
         },
         data () {
@@ -98,7 +99,7 @@ describe('GScan component', () => {
           }
         }
       })
-      const workflowsElements = wrapper.findAll('.c-gscan-workflow')
+      const workflowsElements = wrapper.findAllComponents(TreeItem)
       expect(workflowsElements.length).to.equal(5)
       expect(workflowsElements.at(0).element.textContent).to.equal('a')
       expect(workflowsElements.at(1).element.textContent).to.equal('b')
@@ -110,11 +111,11 @@ describe('GScan component', () => {
       const wrapper = mountFunction({
         propsData: {
           workflows: [
-            { id: '1', name: 'a', status: 'held' },
-            { id: '5', name: 'e', status: 'running' },
-            { id: '3', name: 'c', status: 'stopped' },
-            { id: '2', name: 'b', status: 'stopped' },
-            { id: '4', name: 'd', status: 'stopped' }
+            { id: 'user|e', name: 'e', status: 'held' },
+            { id: 'user|a', name: 'a', status: 'running' },
+            { id: 'user|c', name: 'c', status: 'stopped' },
+            { id: 'user|b', name: 'b', status: 'stopped' },
+            { id: 'user|d', name: 'd', status: 'stopped' }
           ]
         },
         data () {
@@ -123,7 +124,7 @@ describe('GScan component', () => {
           }
         }
       })
-      const workflowsElements = wrapper.findAll('.c-gscan-workflow')
+      const workflowsElements = wrapper.findAllComponents(TreeItem)
       expect(workflowsElements.length).to.equal(5)
       expect(workflowsElements.at(0).element.textContent).to.equal('a')
       expect(workflowsElements.at(1).element.textContent).to.equal('e')
@@ -135,11 +136,11 @@ describe('GScan component', () => {
       const wrapper = mountFunction({
         propsData: {
           workflows: [
-            { id: '5', name: 'e', status: 'held' },
-            { id: '1', name: 'a', status: 'held' },
-            { id: '3', name: 'c', status: 'stopped' },
-            { id: '2', name: 'b', status: 'running' },
-            { id: '4', name: 'd', status: 'stopped' }
+            { id: 'user|e', name: 'e', status: 'held' },
+            { id: 'user|a', name: 'a', status: 'held' },
+            { id: 'user|c', name: 'c', status: 'stopped' },
+            { id: 'user|b', name: 'b', status: 'running' },
+            { id: 'user|d', name: 'd', status: 'stopped' }
           ]
         },
         data () {
@@ -148,10 +149,10 @@ describe('GScan component', () => {
           }
         }
       })
-      const workflowsElements = wrapper.findAll('.c-gscan-workflow')
+      const workflowsElements = wrapper.findAllComponents(TreeItem)
       expect(workflowsElements.length).to.equal(5)
-      expect(workflowsElements.at(0).element.textContent).to.equal('a')
-      expect(workflowsElements.at(1).element.textContent).to.equal('b')
+      expect(workflowsElements.at(0).element.textContent).to.equal('b')
+      expect(workflowsElements.at(1).element.textContent).to.equal('a')
       expect(workflowsElements.at(2).element.textContent).to.equal('e')
       expect(workflowsElements.at(3).element.textContent).to.equal('c')
       expect(workflowsElements.at(4).element.textContent).to.equal('d')
@@ -160,11 +161,11 @@ describe('GScan component', () => {
       const wrapper = mountFunction({
         propsData: {
           workflows: [
-            { id: '5', name: 'e', status: 'held' },
-            { id: '1', name: 'a', status: 'held' },
-            { id: '3', name: 'c', status: 'stopped' },
-            { id: '2', name: 'b', status: 'running' },
-            { id: '4', name: 'd', status: 'stopped' }
+            { id: 'user|e', name: 'e', status: 'held' },
+            { id: 'user|a', name: 'a', status: 'held' },
+            { id: 'user|c', name: 'c', status: 'stopped' },
+            { id: 'user|b', name: 'b', status: 'running' },
+            { id: 'user|d', name: 'd', status: 'stopped' }
           ]
         },
         data () {
@@ -173,10 +174,10 @@ describe('GScan component', () => {
           }
         }
       })
-      const workflowsElements = wrapper.findAll('.c-gscan-workflow')
+      const workflowsElements = wrapper.findAllComponents(TreeItem)
       expect(workflowsElements.length).to.equal(5)
-      expect(workflowsElements.at(0).element.textContent).to.equal('a')
-      expect(workflowsElements.at(1).element.textContent).to.equal('b')
+      expect(workflowsElements.at(0).element.textContent).to.equal('b')
+      expect(workflowsElements.at(1).element.textContent).to.equal('a')
       expect(workflowsElements.at(2).element.textContent).to.equal('e')
       expect(workflowsElements.at(3).element.textContent).to.equal('c')
       expect(workflowsElements.at(4).element.textContent).to.equal('d')
@@ -192,21 +193,21 @@ describe('GScan component', () => {
     it('should correctly calculate the workflow summary', () => {
       const summaries = GScan.computed.workflowsSummaries.call(localThis)
       expect(summaries.size).to.equal(1)
-      expect(summaries.has('five')).to.equal(true)
-      expect(summaries.get('five').has('succeeded')).to.equal(true)
-      expect(summaries.get('five').get('succeeded').includes('foo.20130829T0000Z')).to.equal(true)
-      expect(summaries.get('five').get('succeeded').includes('bar.20130829T0000Z')).to.equal(true)
-      expect(summaries.get('five').get('succeeded').includes('foo.20130829T1200Z')).to.equal(true)
-      expect(summaries.get('five').has('running')).to.equal(true)
-      expect(summaries.get('five').get('running').includes('bar.20130829T1200Z')).to.equal(true)
-      expect(summaries.get('five').get('running').includes('foo.20130830T0000Z')).to.equal(true)
+      expect(summaries.has('user|five')).to.equal(true)
+      expect(summaries.get('user|five').has('succeeded')).to.equal(true)
+      expect(summaries.get('user|five').get('succeeded').includes('foo.20130829T0000Z')).to.equal(true)
+      expect(summaries.get('user|five').get('succeeded').includes('bar.20130829T0000Z')).to.equal(true)
+      expect(summaries.get('user|five').get('succeeded').includes('foo.20130829T1200Z')).to.equal(true)
+      expect(summaries.get('user|five').has('running')).to.equal(true)
+      expect(summaries.get('user|five').get('running').includes('bar.20130829T1200Z')).to.equal(true)
+      expect(summaries.get('user|five').get('running').includes('foo.20130830T0000Z')).to.equal(true)
     })
     it('should return elements in alphabetical order', () => {
       const summaries = GScan.computed.workflowsSummaries.call(localThis)
-      expect(summaries.get('five').get('succeeded').length).to.equal(3)
-      expect(summaries.get('five').get('succeeded')[0]).to.equal('bar.20130829T0000Z')
-      expect(summaries.get('five').get('succeeded')[1]).to.equal('foo.20130829T0000Z')
-      expect(summaries.get('five').get('succeeded')[2]).to.equal('foo.20130829T1200Z')
+      expect(summaries.get('user|five').get('succeeded').length).to.equal(3)
+      expect(summaries.get('user|five').get('succeeded')[0]).to.equal('bar.20130829T0000Z')
+      expect(summaries.get('user|five').get('succeeded')[1]).to.equal('foo.20130829T0000Z')
+      expect(summaries.get('user|five').get('succeeded')[2]).to.equal('foo.20130829T1200Z')
     })
   })
   describe('filter gscan', () => {


### PR DESCRIPTION
These changes partially address #502 

For the hierarchy in GScan, we don't need/want to re-create a tree/treeitem components pair. Instead, we should be able to use Vue's [components slots](https://vuejs.org/v2/guide/components-slots.html).

This PR was part of the hierarchy PR for GScan. That PR, however, will take a bit longer to be ready to be merged. And other PR's pending review will also modify the GScan component. So having this simpler PR will make it easier, I think, to merge this change and simplify the hierarchy PR to GScan.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
