### PR TITLE
Fix e2e coverage

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -15,7 +15,7 @@
   "extension": [".js", ".vue"],
   "reporter": ["html", "lcov", "text-summary"],
   "cache": false,
-  "all": true,
+  "all": false,
   "check-coverage": false,
   "instrument": true,
   "sourceMap": true

--- a/babel.config.js
+++ b/babel.config.js
@@ -20,6 +20,7 @@ module.exports = {
     '@vue/app'
   ],
   plugins: [
-    ['@babel/plugin-proposal-class-properties', { loose: true }]
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
+    ['babel-plugin-istanbul', { extension: ['.js', '.vue'] }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:watch": "vue-cli-service build --watch --mode development",
     "checkpoint": "./src/services/mock/generate",
     "coverage:unit": "nyc vue-cli-service test:unit",
-    "coverage:e2e": "nyc vue-cli-service test:e2e",
+    "coverage:e2e": "NODE_ENV=offline nyc vue-cli-service test:e2e",
     "dev": "yarn run serve",
     "lint": "vue-cli-service lint",
     "serve": "NODE_ENV=offline vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@vue/cli-service": "^4.5.6",
     "@vue/test-utils": "^1.1.0",
     "babel-eslint": "^10.1.0",
+    "babel-plugin-istanbul": "^6.0.0",
     "bufferutil": "^4.0.1",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -19,7 +19,7 @@ const webpack = require('@cypress/webpack-preprocessor')
 
 module.exports = (on, config) => {
   // For test coverage
-  on('task', require('@cypress/code-coverage/task'))
+  require('@cypress/code-coverage/task')(on, config)
   const webpackOptions = require('@vue/cli-service/webpack.config')
   // NOTE: if we do not remove the webpack optimizations, Cypress seems
   //       to get confused when our JS code imports scss, failing

--- a/tests/e2e/specs/userprofile.js
+++ b/tests/e2e/specs/userprofile.js
@@ -41,7 +41,7 @@ describe('User Profile', () => {
     // NOTE: had to use Promises in order to locate right element with Cypress
     cy.get('button#font-size-increase-button').then(($button) => {
       for (let i = 0; i < clicks; i++) {
-        $button.click()
+        $button.trigger('click')
       }
       const currentFontSize = getCurrentFontSize()
       const expectedNewSize = expectedFontSize(true, clicks)
@@ -58,7 +58,7 @@ describe('User Profile', () => {
     const clicks = 3
     cy.get('button#font-size-decrease-button').then(($button) => {
       for (let i = 0; i < clicks; i++) {
-        $button.click()
+        $button.trigger('click')
       }
       const currentFontSize = getCurrentFontSize()
       const expectedNewSize = expectedFontSize(false, clicks)
@@ -75,10 +75,10 @@ describe('User Profile', () => {
     const clicks = 3
     cy.get('button#font-size-decrease-button').then(($button) => {
       for (let i = 0; i < clicks; i++) {
-        $button.click()
+        $button.trigger('click')
       }
       cy.get('button#font-size-reset-button').then(($resetButton) => {
-        $resetButton.click()
+        $resetButton.trigger('click')
         const currentFontSize = getCurrentFontSize()
         const expectedNewSize = parseFloat(INITIAL_FONT_SIZE)
         expect(Math.round(expectedNewSize)).to.be.equal(Math.round(currentFontSize))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,6 +2745,17 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-istanbul@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
+  integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^4.0.0"
+    test-exclude "^6.0.0"
+
 babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13912,11 +13912,6 @@ yargs@^15.0.0, yargs@^15.0.2:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yarn@^1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
-
 yauzl@2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
This is a small change with no associated Issue.

Thought it was strange that my last PR's the coverage wasn't increasing as much as I expected. Something happened some commits ago, and looks like the e2e reports are empty. We are still not too bad, with about 70% for unit tests coverage :partying_face: 

Let's hope this PR fixes e2e coverage, and that the reported number is good as.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
