### PR TITLE
gscan: add icons for stopping and stopped flows

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -97,7 +97,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import Job from '@/components/cylc/Job'
 import { getWorkflowSummary } from '@/components/cylc/gscan/index'
 import { GSCAN_QUERY } from '@/graphql/queries'
-import { mdiPlayCircle, mdiPauseOctagon, mdiHelpCircle } from '@mdi/js'
 import WorkflowState from '@/model/WorkflowState.model'
 
 const QUERIES = {
@@ -124,12 +123,7 @@ export default {
       viewID: '',
       subscriptions: {},
       isLoading: true,
-      maximumTasksDisplayed: 5,
-      svgPaths: {
-        running: mdiPlayCircle,
-        held: mdiPauseOctagon,
-        unknown: mdiHelpCircle
-      }
+      maximumTasksDisplayed: 5
     }
   },
   computed: {
@@ -141,16 +135,16 @@ export default {
     sortedWorkflows () {
       return [...this.workflows].sort((left, right) => {
         if (left.status !== right.status) {
-          if (left.status === WorkflowState.STOPPED.name.toLowerCase()) {
+          if (left.status === WorkflowState.STOPPED.name) {
             return 1
           }
-          if (right.status === WorkflowState.STOPPED.name.toLowerCase()) {
+          if (right.status === WorkflowState.STOPPED.name) {
             return -1
           }
         }
-        return left.name.toLowerCase()
+        return left.name
           .localeCompare(
-            right.name.toLowerCase(),
+            right.name,
             undefined,
             { numeric: true, sensitivity: 'base' })
       })
@@ -219,20 +213,16 @@ export default {
     },
 
     getWorkflowIcon (status) {
-      switch (status) {
-      case WorkflowState.RUNNING.name.toLowerCase():
-        return this.svgPaths.running
-      case WorkflowState.HELD.name.toLowerCase():
-        return this.svgPaths.held
-      default:
-        return this.svgPaths.unknown
+      let wstatus = WorkflowState.enumValueOf(status.toUpperCase())
+      if (!wstatus) {
+        wstatus = WorkflowState.ERROR
       }
+      return wstatus.icon
     },
 
     getWorkflowClass (status) {
       return {
-        // TODO: replace by constant or enum later (not TaskState as that doesn't have stopped, maybe WorkflowState?)
-        'c-workflow-stopped': status === WorkflowState.STOPPED.name.toLowerCase()
+        'c-workflow-stopped': status === WorkflowState.STOPPED.name
       }
     }
   }

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -37,7 +37,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :class="getWorkflowClass(workflow.status)"
           >
             <v-list-item-action>
-              <v-icon>{{ getWorkflowIcon(workflow.status) }}</v-icon>
+              <v-tooltip right>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon
+                    v-bind="attrs"
+                    v-on="on"
+                  >
+                    {{ getWorkflowIcon(workflow.status) }}
+                  </v-icon>
+                </template>
+                <span>{{ workflow.status }}</span>
+              </v-tooltip>
             </v-list-item-action>
             <v-list-item-title>
               <v-layout align-center align-content-center nowrap>

--- a/src/model/WorkflowState.model.js
+++ b/src/model/WorkflowState.model.js
@@ -17,24 +17,33 @@
 
 import { Enumify } from 'enumify'
 
+import {
+  mdiHelpCircle,
+  mdiPauseCircle,
+  mdiPlayCircle,
+  mdiSkipNextCircle,
+  mdiStopCircle
+} from '@mdi/js'
+
 /**
  * Cylc valid workflow states.
  */
 class WorkflowState extends Enumify {
-  static RUNNING = new WorkflowState('running')
-  static HELD = new WorkflowState('held')
-  static STOPPING = new WorkflowState('stopping')
-  static STOPPED = new WorkflowState('stopped')
-  static ERROR = new WorkflowState('error')
+  static RUNNING = new WorkflowState('running', mdiPlayCircle)
+  static HELD = new WorkflowState('held', mdiPauseCircle)
+  static STOPPING = new WorkflowState('stopping', mdiSkipNextCircle)
+  static STOPPED = new WorkflowState('stopped', mdiStopCircle)
+  static ERROR = new WorkflowState('error', mdiHelpCircle)
   static _ = this.closeEnum()
 
   /**
    * Constructor.
    * @param {String} name
    */
-  constructor (name) {
+  constructor (name, icon) {
     super()
     this.name = name
+    this.icon = icon
   }
 }
 


### PR DESCRIPTION
* Switch octagon pause icon for circular equivalent.
* Add stopped and stopping icons.
* Learn how to use enumify, nice, will make more use of this.
* Add icons to the WorkflowState enumeration.
* Remove surplus `toLowerCase()` calls.
* Add tooltip for workflow state (in-case the icons are not clear enough).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No documentation update required.
