### PR TITLE
Fix icons in the Dashboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,7 +55,7 @@ in the tree view structure.
 
 ### Fixes
 
-None.
+[#554](https://github.com/cylc/cylc-ui/pull/554) - Fix icons in the Dashboard.
 
 ### Documentation
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -76,7 +76,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-list three-line>
           <v-list-item to="/workflows">
             <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon medium>{{ svgPaths.table }}</v-icon>
+              <v-icon large>{{ svgPaths.table }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
@@ -89,7 +89,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list-item>
           <v-list-item to="/user-profile">
             <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon medium>{{ svgPaths.settings }}</v-icon>
+              <v-icon large>{{ svgPaths.settings }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
@@ -102,7 +102,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list-item>
           <v-list-item :href=hubUrl>
             <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon medium>{{ svgPaths.hub }}</v-icon>
+              <v-icon large>{{ svgPaths.hub }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
@@ -119,7 +119,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-list three-line>
           <v-list-item href="#">
             <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon medium>{{ svgPaths.quickstart }}</v-icon>
+              <v-icon large>{{ svgPaths.quickstart }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
@@ -132,7 +132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list-item>
           <v-list-item href="https://cylc.github.io/doc/built-sphinx/suite-design-guide/suite-design-guide-master.html">
             <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon medium>{{ svgPaths.suite }}</v-icon>
+              <v-icon large>{{ svgPaths.suite }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
@@ -145,7 +145,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list-item>
           <v-list-item href="https://cylc.github.io/documentation">
             <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon medium>{{ svgPaths.documentation }}</v-icon>
+              <v-icon large>{{ svgPaths.documentation }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -24,5 +24,12 @@ describe('Dashboard', () => {
       .parent()
       .should('have.class', 'v-list-item--active')
   })
+  it('Should display the icons', () => {
+    cy.visit('/#/')
+    cy
+      .get('.c-dashboard .v-icon:first')
+      .find('svg')
+      .should('be.visible')
+  })
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
 })


### PR DESCRIPTION
This is a small change with no associated Issue.

Fixing issue reported by @hjoliver on Element, where he would get the icons in the dashboard with a really large width/height. I reproduced the issue, but instead of large icons, my dashboard had no icons at all.

From what I could tell, something might have changed in Vuetify, where the parent element VList or VListItem stopped giving the right dimensions, and instead returned large or invalid values, causing the icon—which inherits the height and widget—to be either very large or hidden.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
