### PR TITLE
Make job-details a node in the tree, expand/collapse control, align tree-leaf-triangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ None or N/A.
 
 ### Enhancements
 
+[#560](https://github.com/cylc/cylc-ui/pull/560) - Make job-details a node
+in the tree, expand/collapse control, align tree-leaf-triangle. Also align
+job icons vertically in the middle of the HTML element.
+
 [#504](https://github.com/cylc/cylc-ui/pull/504) - Add mutations to the tree
 view to allow interacting with tasks, families and cycles.
 

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -73,16 +73,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </slot>
       <slot name="job" v-else-if="node.type === 'job'">
-        <div :class="getNodeDataClass()">
-          <div :class="getNodeDataClass()" @click="jobNodeClicked">
-            <job
-              v-cylc-object="node.node.id"
-              :status="node.node.state"
-            />
-            <span class="mx-1">#{{ node.node.submitNum }}</span>
-            <span class="grey--text">{{ node.node.host }}</span>
+        <div :class="getNodeDataClass()" @click="nodeClicked">
+          <job
+            v-cylc-object="node.node.id"
+            :status="node.node.state"
+          />
+          <span class="mx-1">#{{ node.node.submitNum }}</span>
+          <span class="grey--text">{{ node.node.host }}</span>
+        </div>
+      </slot>
+      <slot name="job-details" v-else-if="node.type === 'job-details'">
+        <div class="leaf">
+          <div class="arrow-up" :style="getLeafTriangleStyle()"></div>
+          <div class="leaf-data font-weight-light py-4 pl-2">
+            <div
+              v-for="(jobDetail, index) in node.node.details"
+              :key="`${node.node.id}-job-detail-${index}`"
+              class="leaf-entry"
+            >
+              <span class="px-4 leaf-entry-title">{{ jobDetail.title }}</span>
+              <span class="grey--text leaf-entry-value">{{ jobDetail.value }}</span>
+            </div>
           </div>
-          <!-- leaf node -->
         </div>
       </slot>
       <slot
@@ -96,32 +108,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </slot>
       <slot></slot>
     </div>
-    <slot name="leaf" v-if="displayLeaf && node.type === 'job'">
-      <div class="leaf">
-        <div class="arrow-up" :style="getLeafTriangleStyle()"></div>
-        <div class="leaf-data font-weight-light py-4 pl-2">
-          <div v-for="leafProperty in leafProperties" :key="leafProperty.id" class="leaf-entry">
-            <span class="px-4 leaf-entry-title">{{ leafProperty.title }}</span>
-            <span class="grey--text leaf-entry-value">{{ node.node[leafProperty.property] }}</span>
-          </div>
-        </div>
-      </div>
-    </slot>
     <span v-show="isExpanded">
       <!-- component recursion -->
       <TreeItem
-          v-for="child in sortedChildren(node.type, node.children)"
-          ref="treeitem"
-          :key="child.id"
-          :node="child"
-          :depth="depth + 1"
-          :hoverable="hoverable"
-          :initialExpanded="initialExpanded"
-          v-on:tree-item-created="$listeners['tree-item-created']"
-          v-on:tree-item-destroyed="$listeners['tree-item-destroyed']"
-          v-on:tree-item-expanded="$listeners['tree-item-expanded']"
-          v-on:tree-item-collapsed="$listeners['tree-item-collapsed']"
-          v-on:tree-item-clicked="$listeners['tree-item-clicked']"
+        v-for="child in sortedChildren(node.type, node.children)"
+        ref="treeitem"
+        :key="child.id"
+        :node="child"
+        :depth="depth + 1"
+        :hoverable="hoverable"
+        :initialExpanded="initialExpanded"
+        v-on:tree-item-created="$listeners['tree-item-created']"
+        v-on:tree-item-destroyed="$listeners['tree-item-destroyed']"
+        v-on:tree-item-expanded="$listeners['tree-item-expanded']"
+        v-on:tree-item-collapsed="$listeners['tree-item-collapsed']"
+        v-on:tree-item-clicked="$listeners['tree-item-clicked']"
       >
         <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope"><slot :name="slot" v-bind="scope"/></template>
       </TreeItem>
@@ -199,7 +200,6 @@ export default {
           property: 'latestMessage'
         }
       ],
-      displayLeaf: false,
       filtered: true
     }
   },
@@ -251,16 +251,9 @@ export default {
     nodeClicked (e) {
       this.$emit('tree-item-clicked', this)
     },
-    /**
-     * Handler for when a job node was clicked.
-     * @param {event} e event
-     */
-    jobNodeClicked (e) {
-      this.displayLeaf = !this.displayLeaf
-    },
     getNodeStyle () {
       return {
-        'padding-left': `${this.depth * NODE_DEPTH_OFFSET}px`
+        'padding-left': `${this.node.type === 'job-details' ? 0 : this.depth * NODE_DEPTH_OFFSET}px`
       }
     },
     /**
@@ -274,7 +267,7 @@ export default {
       return {
         // we add half the depth offset to compensate and move the arrow under the job icon, the another 2px
         // just to center-align it
-        'margin-left': `${(NODE_DEPTH_OFFSET / 2) + 2 + (this.depth * NODE_DEPTH_OFFSET)}px`
+        'margin-left': `${(this.depth * NODE_DEPTH_OFFSET) - 4 - (NODE_DEPTH_OFFSET / 2)}px`
       }
     },
     getNodeClass () {

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -139,7 +139,7 @@ import { treeitem } from '@/mixins/treeitem'
  * Offset used to move nodes to the right or left, to represent the nodes hierarchy.
  * @type {number} integer
  */
-const NODE_DEPTH_OFFSET = 30
+const NODE_DEPTH_OFFSET = 1.5 // em
 
 export default {
   name: 'TreeItem',
@@ -253,7 +253,7 @@ export default {
     },
     getNodeStyle () {
       return {
-        'padding-left': `${this.node.type === 'job-details' ? 0 : this.depth * NODE_DEPTH_OFFSET}px`
+        'padding-left': `${this.node.type === 'job-details' ? 0 : this.depth * NODE_DEPTH_OFFSET}em`
       }
     },
     /**
@@ -265,9 +265,8 @@ export default {
      */
     getLeafTriangleStyle () {
       return {
-        // we add half the depth offset to compensate and move the arrow under the job icon, the another 2px
-        // just to center-align it
-        'margin-left': `${(this.depth * NODE_DEPTH_OFFSET) - 4 - (NODE_DEPTH_OFFSET / 2)}px`
+        // subtract half of the width of the job component
+        'margin-left': `${(this.depth * NODE_DEPTH_OFFSET) - 0.5}em`
       }
     },
     getNodeClass () {

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -127,6 +127,46 @@ function createTaskProxyNode (taskProxy) {
   }
 }
 
+function createJobDetailsNode (job) {
+  const details = [
+    {
+      title: 'host id',
+      value: job.host
+    },
+    {
+      title: 'job id',
+      value: job.batchSysJobId
+    },
+    {
+      title: 'batch sys',
+      value: job.batchSysName
+    },
+    {
+      title: 'submit time',
+      value: job.submittedTime
+    },
+    {
+      title: 'start time',
+      value: job.startedTime
+    },
+    {
+      title: 'finish time',
+      value: job.finishedTime
+    },
+    {
+      title: 'latest message',
+      property: job.latestMessage
+    }
+  ]
+  return {
+    id: `${job.id}-details`,
+    type: 'job-details',
+    node: {
+      details
+    }
+  }
+}
+
 /**
  * Create a job node. Contains the same properties (by reference) as the given job,
  * only adding new properties such as type, name, etc.
@@ -134,16 +174,19 @@ function createTaskProxyNode (taskProxy) {
  * @param job {Object} job
  * @param [latestMessage] {string} latest message of the job's task, defaults to an empty string
  * @return {{node: Object, latestMessage: string}}
- * @return {{id: string, type: string, node: Object, latestMessage: string}}
+ * @return {{id: string, type: string, expanded: boolean, latestMessage: string, node: Object, children: []}}
  */
 // TODO: re-work the latest message, as this is the task latest message, not the job's...
 // TODO: add job-leaf (details) in the hierarchy later for infinite-tree
 function createJobNode (job, latestMessage = '') {
+  const jobDetailsNode = createJobDetailsNode(job)
   return {
     id: job.id,
     type: 'job',
+    expanded: false,
     node: job,
-    latestMessage: latestMessage
+    latestMessage: latestMessage,
+    children: [jobDetailsNode]
   }
 }
 

--- a/src/styles/cylc/_job.scss
+++ b/src/styles/cylc/_job.scss
@@ -27,6 +27,7 @@ $cjob: ".c-job svg.job rect";
 
 .c-job {
     svg.job {
+        vertical-align: middle;
         /* scale the icon to the font-size */
         width: 1em;
         height: 1em;

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -72,6 +72,7 @@ $active-color: #BDD5F7;
     display: flex;
     flex-wrap: nowrap;
     flex-direction: column;
+    flex-grow: 1;
     .arrow-up {
       width: 0;
       height: 0;

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -68,6 +68,7 @@ describe('Tree component', () => {
     // but clicking on a visible job should display its leaf node
     cy
       .get('.node-data-job:first')
+      .prev()
       .click()
     cy
       .get('.leaf:first')


### PR DESCRIPTION
This is a small change with no associated Issue.

In #530 , I moved the job-details out of the template, into the JavaScript code and as a node in the tree.

This way, we control whether it is expanded by clicking on the expand/collapse icon, as with other icons.

Yesterday while I was testing #543, making sure I didn't forget @oliver-sanders ' mutations work when fixing conflicts, I realized clicking on the Job icon would

1. expand the node
2. display the pop up with the mutations context menu

By using the expand/collapse icon, we avoid expanding nodes or displaying the context menu unnecessarily.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
