### PR TITLE
Sort other states, remove unnecessary Enum.toLowercase, use Enum for Workflow state filters, and add more tests for GScan

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -418,6 +418,7 @@ export default {
         this.$workflowService.unsubscribe(
           this.subscriptions[queryName]
         )
+        delete this.subscriptions[queryName]
       }
     },
 

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -263,29 +263,19 @@ export default {
       filters: [
         {
           title: 'workflow state',
-          items: [
-            {
-              text: 'running',
-              value: 'running',
-              model: true
-            },
-            {
-              text: 'held',
-              value: 'held',
-              model: true
-            },
-            {
-              text: 'stopped',
-              value: 'stopped',
+          items: WorkflowState.enumValues.map(state => {
+            return {
+              text: state.name,
+              value: state,
               model: true
             }
-          ]
+          })
         },
         {
           title: 'task state',
           items: TaskState.enumValues.map(state => {
             return {
-              text: state.name.toLowerCase(),
+              text: state.name,
               value: state,
               model: false
             }
@@ -475,12 +465,12 @@ export default {
       const workflowStates = filters[0]
         .items
         .filter(item => item.model)
-        .map(item => item.value)
+        .map(item => item.value.name)
       // get a list of the task states we are filtering
       const taskStates = new Set(filters[1]
         .items
         .filter(item => item.model)
-        .map(item => item.value.name.toLowerCase()))
+        .map(item => item.value.name))
       // filter workflows
       this.filteredWorkflows = this.filteredWorkflows.filter((workflow) => {
         // workflow states

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -301,13 +301,9 @@ export default {
     sortedWorkflows () {
       return [...this.filteredWorkflows].sort((left, right) => {
         if (left.status !== right.status) {
-          if (left.status === WorkflowState.RUNNING.name) {
-            return -1
-          }
-          if (left.status === WorkflowState.HELD.name && right.status !== WorkflowState.RUNNING.name) {
-            return -1
-          }
-          return 1
+          const leftState = WorkflowState.enumValueOf(left.status.toUpperCase())
+          const rightState = WorkflowState.enumValueOf(right.status.toUpperCase())
+          return leftState.enumOrdinal - rightState.enumOrdinal
         }
         return left.name
           .localeCompare(

--- a/src/model/WorkflowState.model.js
+++ b/src/model/WorkflowState.model.js
@@ -29,6 +29,7 @@ import {
  * Cylc valid workflow states.
  */
 class WorkflowState extends Enumify {
+  // NOTE: the order the enum values are created here is used in the UI for sorting
   static RUNNING = new WorkflowState('running', mdiPlayCircle)
   static HELD = new WorkflowState('held', mdiPauseCircle)
   static STOPPING = new WorkflowState('stopping', mdiSkipNextCircle)

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -373,6 +373,12 @@ describe('GScan component', () => {
       expect(summaries.get('user|five').get('succeeded')[1]).to.equal('foo.20130829T0000Z')
       expect(summaries.get('user|five').get('succeeded')[2]).to.equal('foo.20130829T1200Z')
     })
+    it('should return an empty map when no workflow provided', () => {
+      expect(GScan.computed.workflowsSummaries.call({
+        workflows: []
+      }).size).to.equal(0)
+      expect(GScan.computed.workflowsSummaries.call({}).size).to.equal(0)
+    })
   })
   describe('Workflow link', () => {
     it('should create an empty link for non-workflow nodes', () => {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -183,34 +183,7 @@ describe('GScan component', () => {
       expect(workflowsElements.at(4).element.textContent).to.equal('d')
     })
   })
-  describe('Workflow Summary', () => {
-    let localThis
-    beforeEach(() => {
-      localThis = {
-        workflows: simpleWorkflowGscanNodes
-      }
-    })
-    it('should correctly calculate the workflow summary', () => {
-      const summaries = GScan.computed.workflowsSummaries.call(localThis)
-      expect(summaries.size).to.equal(1)
-      expect(summaries.has('user|five')).to.equal(true)
-      expect(summaries.get('user|five').has('succeeded')).to.equal(true)
-      expect(summaries.get('user|five').get('succeeded').includes('foo.20130829T0000Z')).to.equal(true)
-      expect(summaries.get('user|five').get('succeeded').includes('bar.20130829T0000Z')).to.equal(true)
-      expect(summaries.get('user|five').get('succeeded').includes('foo.20130829T1200Z')).to.equal(true)
-      expect(summaries.get('user|five').has('running')).to.equal(true)
-      expect(summaries.get('user|five').get('running').includes('bar.20130829T1200Z')).to.equal(true)
-      expect(summaries.get('user|five').get('running').includes('foo.20130830T0000Z')).to.equal(true)
-    })
-    it('should return elements in alphabetical order', () => {
-      const summaries = GScan.computed.workflowsSummaries.call(localThis)
-      expect(summaries.get('user|five').get('succeeded').length).to.equal(3)
-      expect(summaries.get('user|five').get('succeeded')[0]).to.equal('bar.20130829T0000Z')
-      expect(summaries.get('user|five').get('succeeded')[1]).to.equal('foo.20130829T0000Z')
-      expect(summaries.get('user|five').get('succeeded')[2]).to.equal('foo.20130829T1200Z')
-    })
-  })
-  describe('filter gscan', () => {
+  describe('Filters', () => {
     const workflows = [
       {
         id: '1',
@@ -374,6 +347,33 @@ describe('GScan component', () => {
       })
     })
   })
+  describe('Workflow summary', () => {
+    let localThis
+    beforeEach(() => {
+      localThis = {
+        workflows: simpleWorkflowGscanNodes
+      }
+    })
+    it('should correctly calculate the workflow summary', () => {
+      const summaries = GScan.computed.workflowsSummaries.call(localThis)
+      expect(summaries.size).to.equal(1)
+      expect(summaries.has('user|five')).to.equal(true)
+      expect(summaries.get('user|five').has('succeeded')).to.equal(true)
+      expect(summaries.get('user|five').get('succeeded').includes('foo.20130829T0000Z')).to.equal(true)
+      expect(summaries.get('user|five').get('succeeded').includes('bar.20130829T0000Z')).to.equal(true)
+      expect(summaries.get('user|five').get('succeeded').includes('foo.20130829T1200Z')).to.equal(true)
+      expect(summaries.get('user|five').has('running')).to.equal(true)
+      expect(summaries.get('user|five').get('running').includes('bar.20130829T1200Z')).to.equal(true)
+      expect(summaries.get('user|five').get('running').includes('foo.20130830T0000Z')).to.equal(true)
+    })
+    it('should return elements in alphabetical order', () => {
+      const summaries = GScan.computed.workflowsSummaries.call(localThis)
+      expect(summaries.get('user|five').get('succeeded').length).to.equal(3)
+      expect(summaries.get('user|five').get('succeeded')[0]).to.equal('bar.20130829T0000Z')
+      expect(summaries.get('user|five').get('succeeded')[1]).to.equal('foo.20130829T0000Z')
+      expect(summaries.get('user|five').get('succeeded')[2]).to.equal('foo.20130829T1200Z')
+    })
+  })
   describe('Workflow link', () => {
     it('should create an empty link for non-workflow nodes', () => {
       const link = GScan.methods.workflowLink({})
@@ -387,6 +387,16 @@ describe('GScan component', () => {
         }
       })
       expect(link).to.equal('/workflows/name')
+    })
+  })
+  describe('Workflow icon', () => {
+    it('should return error if an invalid status is provided', () => {
+      const icon = GScan.methods.getWorkflowIcon('cylc')
+      expect(icon).to.equal(WorkflowState.ERROR.icon)
+    })
+    it('should return the right icon for a valid status', () => {
+      const icon = GScan.methods.getWorkflowIcon('running')
+      expect(icon).to.equal(WorkflowState.RUNNING.icon)
     })
   })
   describe('Toggle items values', () => {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -31,7 +31,10 @@ const localVue = createLocalVue()
 localVue.prototype.$workflowService = {
   register: function () {
   },
-  unregister: function () {
+  unregister: function (obj) {
+    // we will reset the subscriptions object so tests can confirm
+    // this function has been called
+    obj.subscriptions = {}
   },
   subscribe: function (obj, name) {
     return true
@@ -98,6 +101,16 @@ describe('GScan component', () => {
     expect(wrapper.vm.isLoading).to.equal(false)
     wrapper.vm.setActive(false)
     expect(wrapper.vm.isLoading).to.equal(true)
+  })
+  it('should unregister before being destroyed', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        workflows: []
+      }
+    })
+    expect(wrapper.vm.subscriptions.root).to.equal(true)
+    wrapper.vm.$destroy()
+    expect(wrapper.vm.subscriptions.root).to.equal(undefined)
   })
   describe('Sorting', () => {
     it('should display workflows in alphabetical order', () => {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -188,6 +188,24 @@ describe('GScan component', () => {
             { name: 'e', status: WorkflowState.HELD }
           ]),
           expected: ['b', 'a', 'e', 'c', 'd']
+        },
+        // new statuses (stopping, error)
+        {
+          workflows: createWorkflows([
+            { name: 'a', status: WorkflowState.HELD },
+            { name: 'c', status: WorkflowState.STOPPED },
+            { name: 'b', status: WorkflowState.RUNNING },
+            { name: 'd', status: WorkflowState.STOPPED },
+            { name: 'e', status: WorkflowState.HELD },
+            { name: 'f', status: WorkflowState.HELD },
+            { name: 'h', status: WorkflowState.STOPPING },
+            { name: 'g', status: WorkflowState.ERROR },
+            { name: 'j', status: WorkflowState.STOPPING },
+            { name: 'i', status: WorkflowState.STOPPED },
+            { name: 'k', status: WorkflowState.RUNNING },
+            { name: 'l', status: WorkflowState.HELD }
+          ]),
+          expected: ['b', 'k', 'a', 'e', 'f', 'l', 'h', 'j', 'c', 'd', 'i', 'g']
         }
       ]
       tests.forEach(test => {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -389,4 +389,42 @@ describe('GScan component', () => {
       expect(link).to.equal('/workflows/name')
     })
   })
+  describe('Toggle items values', () => {
+    it('should toggle items values to true', () => {
+      const items = [
+        {
+          model: false
+        },
+        {
+          model: false
+        }
+      ]
+      GScan.methods.toggleItemsValues(items)
+      expect(items.every(item => item.model))
+    })
+    it('should toggle items values to false', () => {
+      const items = [
+        {
+          model: true
+        },
+        {
+          model: true
+        }
+      ]
+      GScan.methods.toggleItemsValues(items)
+      expect(!items.every(item => item.model))
+    })
+    it('should toggle items values to false (mixed values)', () => {
+      const items = [
+        {
+          model: true
+        },
+        {
+          model: false
+        }
+      ]
+      GScan.methods.toggleItemsValues(items)
+      expect(!items.every(item => item.model))
+    })
+  })
 })


### PR DESCRIPTION
These changes close #553 

There were new states added (`STOPPING`, and `ERROR`). So now the code is using `Enumify`'s `enumOrdinal` to sort these values. They are based on the order the enum values are declared. At the moment the order is:

- RUNNING
- HELD
- STOPPING
- STOPPED
- ERROR

Also remove the now redundant `.toLowerCase` as the enums are already using the lower case string, and uses the `WorkflowState` enum to create the list of filters. We were missing stopping and another state that were included after the filters were initially written for GScan.

The unit tests should cover most of GScan. The only part covered exclusively by e2e tests, are the watchers, as that's easier to test with an e2e, rather than changing values and making sure we wait for the watcher to be triggered in an unit test (in e2e we have the browser running the event loop and handling this watcher updates).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
