### PR TITLE
Update list of browsers fixing warning

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3614,9 +3614,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001111:
-  version "1.0.30001116"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001116.tgz#f3a3dea347f9294a3bdc4292309039cc84117fb8"
-  integrity sha512-f2lcYnmAI5Mst9+g0nkMIznFGsArRmZ0qU+dnq8l91hymdc2J3SFbiPhOJEeDqC1vtE8nc1qNQyklzB8veJefQ==
+  version "1.0.30001180"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz"
+  integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This is a small change with no associated Issue.

Small issue. I noticed this one yesterday while running tests. The console has the following warning:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```
I executed the command above, which reported:

```
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 84
+ and_chr 88
- and_ff 68
+ and_ff 83
- chrome 84
- chrome 83
+ chrome 88
+ chrome 87
+ chrome 86
- edge 84
- edge 83
+ edge 88
+ edge 87
- firefox 79
- firefox 78
+ firefox 84
+ firefox 83
- ios_saf 13.4-13.5
- ios_saf 13.3
+ ios_saf 14.0-14.3
+ ios_saf 13.4-13.7
- op_mob 46
+ op_mob 59
- opera 69
- opera 68
+ opera 72
+ opera 71
- safari 13
+ safari 14
- samsung 11.1-11.2
+ samsung 13.0

```

Created this PR as apparently it changed the `yarn.lock` file too. Running tests after this change, there is no more warning. One review should be enough.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
