### PR TITLE
Fix task states.

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -331,7 +331,7 @@ export default {
     if (context.props.isHeld) {
       taskIconSvgCssClasses.push('held')
     }
-    if (['waiting', 'preparing', 'expired', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed'].includes(context.props.status)) {
+    if (['waiting', 'preparing', 'expired', 'submitted', 'running', 'succeeded', 'failed', 'submit-failed', 'queued'].includes(context.props.status)) {
       taskIconSvgCssClasses.push(context.props.status)
     } else {
       taskIconSvgCssClasses.push('unknown')

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -442,7 +442,7 @@ export default {
      * a name) and a given list of filters.
      *
      * The list of filters may contain workflow states ("running", "stopped",
-     * "held"), and/or task states ("running", "waiting", "submit_failed", etc).
+     * "held"), and/or task states ("running", "waiting", "submit-failed", etc).
      *
      * Does not return any value, but modifies the data variable
      * filteredWorkflows, used in the template.

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -53,12 +53,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-model="tasksFilter.states"
         >
           <template v-slot:item="slotProps">
-            <Task :status="slotProps.item.value.toLowerCase()" :progress=0 />
-            <span class="ml-2">{{ slotProps.item.value.toLowerCase() }}</span>
+            <Task :status="slotProps.item.value" :progress=0 />
+            <span class="ml-2">{{ slotProps.item.value }}</span>
           </template>
           <template v-slot:selection="slotProps">
             <div class="mr-2" v-if="slotProps.index >= 0 && slotProps.index < maximumTasks">
-              <Task :status="slotProps.item.value.toLowerCase()" :progress=0 />
+              <Task :status="slotProps.item.value" :progress=0 />
             </div>
             <span
               v-if="slotProps.index === maximumTasks"
@@ -161,7 +161,7 @@ export default {
     },
     tasksFilterStates: function () {
       return this.activeFilters.states.map(selectedTaskState => {
-        return selectedTaskState.toLowerCase()
+        return selectedTaskState
       })
     }
   },

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -116,7 +116,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import { mapGetters, mapState } from 'vuex'
 import toolbar from '@/mixins/toolbar'
-import TaskState from '@/model/TaskState.model'
+import WorkflowState from '@/model/WorkflowState.model'
 import {
   mdiViewList,
   mdiPlay,
@@ -153,7 +153,7 @@ export default {
     ...mapState('app', ['title']),
     ...mapGetters('workflows', ['currentWorkflow']),
     isHeld: function () {
-      return this.currentWorkflow.status === TaskState.HELD.name
+      return this.currentWorkflow.status === WorkflowState.HELD.name
     }
   },
 

--- a/src/model/TaskState.model.js
+++ b/src/model/TaskState.model.js
@@ -23,7 +23,7 @@ import { Enumify } from 'enumify'
 class TaskState extends Enumify {
   // NOTE: the order of the enum values is important to calculate the group states in the UI. Items at
   // the top of the list have preference over the items below in the algorithm.
-  static SUBMIT_FAILED = new TaskState('submit_failed')
+  static SUBMIT_FAILED = new TaskState('submit-failed')
   static FAILED = new TaskState('failed')
   static EXPIRED = new TaskState('expired')
   static RUNNING = new TaskState('running')
@@ -31,7 +31,6 @@ class TaskState extends Enumify {
   static PREPARING = new TaskState('preparing')
   static QUEUED = new TaskState('queued')
   static WAITING = new TaskState('waiting')
-  static HELD = new TaskState('held')
   static SUCCEEDED = new TaskState('succeeded')
   static _ = this.closeEnum()
 

--- a/src/utils/tasks.js
+++ b/src/utils/tasks.js
@@ -30,8 +30,7 @@ const isStoppedOrderedStates = [
   TaskState.PREPARING,
   TaskState.SUCCEEDED,
   TaskState.QUEUED,
-  TaskState.WAITING,
-  TaskState.HELD
+  TaskState.WAITING
 ]
 
 /**

--- a/src/utils/tasks.js
+++ b/src/utils/tasks.js
@@ -44,7 +44,7 @@ function extractGroupState (childStates, isStopped = false) {
   const states = isStopped ? isStoppedOrderedStates : TaskState.enumValues
   for (const state of states) {
     if (childStates.includes(state.name)) {
-      return state.name.toLowerCase()
+      return state.name
     }
   }
   return ''

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -233,7 +233,7 @@ describe('Tree component', () => {
       TaskState.enumValues.forEach(state => {
         cy
           .get('.v-list-item')
-          .contains(state.name.toLowerCase())
+          .contains(state.name)
           .click({ force: true })
       })
       cy

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -234,7 +234,7 @@ describe('GScan component', () => {
         name: 'new zealand',
         status: WorkflowState.HELD.name,
         stateTotals: {
-          [WorkflowState.HELD.name]: 1
+          [TaskState.QUEUED.name]: 1
         }
       },
       {
@@ -393,7 +393,7 @@ describe('GScan component', () => {
           },
           // enable only the ones we have in our test data set
           {
-            workflowTaskStates: [TaskState.RUNNING, TaskState.HELD],
+            workflowTaskStates: [TaskState.RUNNING, TaskState.QUEUED],
             expected: 2
           },
           // enable just one of the values we have in our test data set

--- a/tests/unit/components/cylc/toolbar.vue.spec.js
+++ b/tests/unit/components/cylc/toolbar.vue.spec.js
@@ -58,7 +58,7 @@ describe('Toolbar component', () => {
       {
         id: 'user/id',
         name: 'test',
-        status: TaskState.RUNNING.name.toLowerCase()
+        status: TaskState.RUNNING.name
       }
     ]
     store.state.workflows.workflowName = 'test'

--- a/tests/unit/components/cylc/tree/deltas.spec.js
+++ b/tests/unit/components/cylc/tree/deltas.spec.js
@@ -191,7 +191,7 @@ describe('Deltas', () => {
       cylcTree.addCyclePoint(cyclePoint)
       familyProxy = createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint.node.name}|FAM`,
-        state: TaskState.RUNNING.name.toLowerCase(),
+        state: TaskState.RUNNING.name,
         cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: `${WORKFLOW_ID}|${cyclePoint.node.name}|${FAMILY_ROOT}`,
@@ -208,14 +208,14 @@ describe('Deltas', () => {
           familyProxies: [
             {
               id: familyProxy.id,
-              state: TaskState.FAILED.name.toLowerCase()
+              state: TaskState.FAILED.name
             }
           ]
         }
       }
       const fakeTree = sinon.spy(cylcTree)
       applyDeltas(deltasUpdated, fakeTree)
-      expect(cylcTree.root.children[0].children[0].node.state).to.equal(TaskState.FAILED.name.toLowerCase())
+      expect(cylcTree.root.children[0].children[0].node.state).to.equal(TaskState.FAILED.name)
       expect(fakeTree.tallyCyclePointStates.called).to.equal(true)
     })
   })
@@ -234,7 +234,7 @@ describe('Deltas', () => {
       cylcTree.addCyclePoint(cyclePoint)
       familyProxy = createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint.node.name}|FAM`,
-        state: TaskState.RUNNING.name.toLowerCase(),
+        state: TaskState.RUNNING.name,
         cyclePoint: cyclePoint.node.name,
         firstParent: {
           id: `${WORKFLOW_ID}|${cyclePoint.node.name}|${FAMILY_ROOT}`,

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -219,13 +219,13 @@ describe('CylcTree', () => {
       expect(cylcTree.lookup.get(familyProxy1.id).node.state).to.equal('')
       const familyProxy1Again = createFamilyProxyNode({
         id: familyProxyId1,
-        state: TaskState.WAITING.name.toLowerCase()
+        state: TaskState.WAITING.name
       })
       cylcTree.addFamilyProxy(familyProxy1Again)
       expect(cylcTree.root.children[0].children.length).to.equal(0)
       expect(cylcTree.root.children[1].children.length).to.equal(0)
       expect(cylcTree.lookup.get(familyProxy1.id).id).to.not.equal(null)
-      expect(cylcTree.lookup.get(familyProxy1.id).node.state).to.equal(TaskState.WAITING.name.toLowerCase())
+      expect(cylcTree.lookup.get(familyProxy1.id).node.state).to.equal(TaskState.WAITING.name)
     })
     it('Should add family proxies under the cycle point when first parent is root', () => {
       const familyProxyId1 = `${WORKFLOW_ID}|${cyclePoint1.node.name}|fam1`
@@ -296,9 +296,9 @@ describe('CylcTree', () => {
       })
       cylcTree.addFamilyProxy(familyProxy1)
       expect(cylcTree.lookup.get(familyProxy1.id).state).to.equal(undefined)
-      familyProxy1.state = TaskState.WAITING.name.toLowerCase()
+      familyProxy1.state = TaskState.WAITING.name
       cylcTree.updateFamilyProxy(familyProxy1)
-      expect(cylcTree.lookup.get(familyProxy1.id).state).to.equal(TaskState.WAITING.name.toLowerCase())
+      expect(cylcTree.lookup.get(familyProxy1.id).state).to.equal(TaskState.WAITING.name)
     })
     it('Should not update a family proxy if it is not in the tree', () => {
       const familyProxy1 = createFamilyProxyNode({
@@ -400,7 +400,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: familyProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addTaskProxy(taskProxy)
       const cyclepoint = cylcTree.root.children[0]
@@ -415,7 +415,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: familyProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addTaskProxy(taskProxy)
       cylcTree.addTaskProxy(taskProxy)
@@ -432,7 +432,7 @@ describe('CylcTree', () => {
           name: rootFamilyProxy.node.name
         },
         cyclePoint: cyclePoint.node.name,
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addTaskProxy(taskProxy)
       const cyclepoint = cylcTree.root.children[0]
@@ -453,7 +453,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: familyProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addTaskProxy(taskProxy)
       const cyclepoint = cylcTree.root.children[0]
@@ -469,7 +469,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: '-1'
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       const sandbox = sinon.createSandbox()
       sandbox.stub(console, 'error')
@@ -481,7 +481,7 @@ describe('CylcTree', () => {
     })
     it('Should update task proxies', () => {
       const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
-      const taskProxyState = TaskState.RUNNING.name.toLowerCase()
+      const taskProxyState = TaskState.RUNNING.name
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
         firstParent: {
@@ -494,13 +494,13 @@ describe('CylcTree', () => {
       const family = cyclepoint.children[0]
       const task = family.children[0]
       expect(task.node.state).to.equal(taskProxyState)
-      taskProxy.node.state = TaskState.WAITING.name.toLowerCase()
+      taskProxy.node.state = TaskState.WAITING.name
       cylcTree.updateTaskProxy(taskProxy)
-      expect(cylcTree.root.children[0].children[0].children[0].node.state).to.equal(TaskState.WAITING.name.toLowerCase())
+      expect(cylcTree.root.children[0].children[0].children[0].node.state).to.equal(TaskState.WAITING.name)
     })
     it('Should not update an task proxy if it is not in the tree', () => {
       const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
-      const taskProxyState = TaskState.RUNNING.name.toLowerCase()
+      const taskProxyState = TaskState.RUNNING.name
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
         firstParent: {
@@ -525,7 +525,7 @@ describe('CylcTree', () => {
     })
     it('Should remove task proxies', () => {
       const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
-      const taskProxyState = TaskState.RUNNING.name.toLowerCase()
+      const taskProxyState = TaskState.RUNNING.name
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
         firstParent: {
@@ -543,7 +543,7 @@ describe('CylcTree', () => {
     })
     it('Should remove task proxies if added to the root family', () => {
       const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.node.name}|foo`
-      const taskProxyState = TaskState.RUNNING.name.toLowerCase()
+      const taskProxyState = TaskState.RUNNING.name
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
         firstParent: {
@@ -566,7 +566,7 @@ describe('CylcTree', () => {
     })
     it('Should not remove task proxies if not added to the tree', () => {
       const taskProxyId = `${WORKFLOW_ID}|${cyclePoint.id}|foo`
-      const taskProxyState = TaskState.RUNNING.name.toLowerCase()
+      const taskProxyState = TaskState.RUNNING.name
       const taskProxy = createTaskProxyNode({
         id: taskProxyId,
         firstParent: {
@@ -626,7 +626,7 @@ describe('CylcTree', () => {
         task: {
           meanElapsedTime: 3.0
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addTaskProxy(taskProxy)
     })
@@ -641,7 +641,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.FAILED.name.toLowerCase(),
+        state: TaskState.FAILED.name,
         startedTime
       })
       const sandbox = sinon.createSandbox()
@@ -663,7 +663,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addJob(job)
       cylcTree.addJob(job)
@@ -676,7 +676,7 @@ describe('CylcTree', () => {
     })
     it('Should update jobs', () => {
       const jobId = `${taskProxy.id}|1`
-      const state = TaskState.RUNNING.name.toLowerCase()
+      const state = TaskState.RUNNING.name
       const job = createJobNode({
         id: jobId,
         firstParent: {
@@ -690,13 +690,13 @@ describe('CylcTree', () => {
       const task = family.children[0]
       const createdJob = task.children[0]
       expect(createdJob.node.state).to.equal(state)
-      job.node.state = TaskState.WAITING.name.toLowerCase()
+      job.node.state = TaskState.WAITING.name
       cylcTree.updateJob(job)
-      expect(task.children[0].node.state).equal(TaskState.WAITING.name.toLowerCase())
+      expect(task.children[0].node.state).equal(TaskState.WAITING.name)
     })
     it('Should not update a job if it is not in the tree', () => {
       const jobId = `${taskProxy.id}|1`
-      const state = TaskState.RUNNING.name.toLowerCase()
+      const state = TaskState.RUNNING.name
       const job = createJobNode({
         id: jobId,
         firstParent: {
@@ -718,7 +718,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addJob(job)
       const cyclepoint = cylcTree.root.children[0]
@@ -736,7 +736,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addJob(job)
       const cyclepoint = cylcTree.root.children[0]
@@ -754,7 +754,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addJob(job)
       const cyclepoint = cylcTree.root.children[0]
@@ -778,7 +778,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.FAILED.name.toLowerCase(),
+        state: TaskState.FAILED.name,
         startedTime
       })
       const sandbox = sinon.createSandbox()
@@ -833,7 +833,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: familyProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addTaskProxy(taskProxy)
     })
@@ -844,7 +844,7 @@ describe('CylcTree', () => {
         firstParent: {
           id: taskProxy.id
         },
-        state: TaskState.RUNNING.name.toLowerCase()
+        state: TaskState.RUNNING.name
       })
       cylcTree.addJob(job)
       const cyclepoint = cylcTree.root.children[0]
@@ -876,7 +876,7 @@ describe('CylcTree', () => {
       cylcTree.addCyclePoint(cyclePoint1)
       cylcTree.addFamilyProxy(createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|FAM1`,
-        state: TaskState.RUNNING.name.toLowerCase(),
+        state: TaskState.RUNNING.name,
         firstParent: {
           id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
@@ -885,7 +885,7 @@ describe('CylcTree', () => {
       }))
       cylcTree.addFamilyProxy(createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|FAM2`,
-        state: TaskState.WAITING.name.toLowerCase(),
+        state: TaskState.WAITING.name,
         firstParent: {
           id: `${WORKFLOW_ID}|${cyclePoint1.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
@@ -899,7 +899,7 @@ describe('CylcTree', () => {
       cylcTree.addCyclePoint(cyclePoint2)
       cylcTree.addFamilyProxy(createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|FAM1`,
-        state: TaskState.WAITING.name.toLowerCase(),
+        state: TaskState.WAITING.name,
         firstParent: {
           id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
@@ -908,7 +908,7 @@ describe('CylcTree', () => {
       }))
       cylcTree.addFamilyProxy(createFamilyProxyNode({
         id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|FAM2`,
-        state: TaskState.RUNNING.name.toLowerCase(),
+        state: TaskState.RUNNING.name,
         firstParent: {
           id: `${WORKFLOW_ID}|${cyclePoint2.node.name}|${FAMILY_ROOT}`,
           name: FAMILY_ROOT
@@ -921,8 +921,8 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[0].state).to.equal(undefined)
       expect(cylcTree.root.children[1].state).to.equal(undefined)
       cylcTree.tallyCyclePointStates()
-      expect(cylcTree.root.children[0].node.state).to.equal(TaskState.RUNNING.name.toLowerCase())
-      expect(cylcTree.root.children[1].node.state).to.equal(TaskState.RUNNING.name.toLowerCase())
+      expect(cylcTree.root.children[0].node.state).to.equal(TaskState.RUNNING.name)
+      expect(cylcTree.root.children[1].node.state).to.equal(TaskState.RUNNING.name)
     })
   })
 })

--- a/tests/unit/components/cylc/workflow/toolbar.vue.spec.js
+++ b/tests/unit/components/cylc/workflow/toolbar.vue.spec.js
@@ -25,20 +25,20 @@ import Vuetify from 'vuetify/lib'
 const mockedWorkflowService = {
   releaseWorkflow: function () {
     return new Promise((resolve) => {
-      if (store.state.workflows.workflows[0].status === WorkflowState.HELD.name.toLowerCase()) {
-        store.state.workflows.workflows[0].status = WorkflowState.RUNNING.name.toLowerCase()
+      if (store.state.workflows.workflows[0].status === WorkflowState.HELD.name) {
+        store.state.workflows.workflows[0].status = WorkflowState.RUNNING.name
       } else {
-        store.state.workflows.workflows[0].status = WorkflowState.HELD.name.toLowerCase()
+        store.state.workflows.workflows[0].status = WorkflowState.HELD.name
       }
       return resolve(true)
     })
   },
   holdWorkflow: function () {
     return new Promise((resolve) => {
-      if (store.state.workflows.workflows[0].status === WorkflowState.HELD.name.toLowerCase()) {
-        store.state.workflows.workflows[0].status = WorkflowState.RUNNING.name.toLowerCase()
+      if (store.state.workflows.workflows[0].status === WorkflowState.HELD.name) {
+        store.state.workflows.workflows[0].status = WorkflowState.RUNNING.name
       } else {
-        store.state.workflows.workflows[0].status = WorkflowState.HELD.name.toLowerCase()
+        store.state.workflows.workflows[0].status = WorkflowState.HELD.name
       }
       return resolve(true)
     })
@@ -85,7 +85,7 @@ describe('Workflow Toolbar component', () => {
       {
         id: 'user/id',
         name: 'test',
-        status: WorkflowState.RUNNING.name.toLowerCase()
+        status: WorkflowState.RUNNING.name
       }
     ]
     store.state.workflows.workflowName = 'test'

--- a/tests/unit/components/cylc/workflow/toolbar.vue.spec.js
+++ b/tests/unit/components/cylc/workflow/toolbar.vue.spec.js
@@ -18,27 +18,27 @@
 import { shallowMount, mount, createLocalVue } from '@vue/test-utils'
 import { expect } from 'chai'
 import Toolbar from '@/components/cylc/workflow/Toolbar'
-import TaskState from '@/model/TaskState.model'
+import WorkflowState from '@/model/WorkflowState.model'
 import store from '@/store/index'
 import Vuetify from 'vuetify/lib'
 
 const mockedWorkflowService = {
   releaseWorkflow: function () {
     return new Promise((resolve) => {
-      if (store.state.workflows.workflows[0].status === TaskState.HELD.name.toLowerCase()) {
-        store.state.workflows.workflows[0].status = TaskState.RUNNING.name.toLowerCase()
+      if (store.state.workflows.workflows[0].status === WorkflowState.HELD.name.toLowerCase()) {
+        store.state.workflows.workflows[0].status = WorkflowState.RUNNING.name.toLowerCase()
       } else {
-        store.state.workflows.workflows[0].status = TaskState.HELD.name.toLowerCase()
+        store.state.workflows.workflows[0].status = WorkflowState.HELD.name.toLowerCase()
       }
       return resolve(true)
     })
   },
   holdWorkflow: function () {
     return new Promise((resolve) => {
-      if (store.state.workflows.workflows[0].status === TaskState.HELD.name.toLowerCase()) {
-        store.state.workflows.workflows[0].status = TaskState.RUNNING.name.toLowerCase()
+      if (store.state.workflows.workflows[0].status === WorkflowState.HELD.name.toLowerCase()) {
+        store.state.workflows.workflows[0].status = WorkflowState.RUNNING.name.toLowerCase()
       } else {
-        store.state.workflows.workflows[0].status = TaskState.HELD.name.toLowerCase()
+        store.state.workflows.workflows[0].status = WorkflowState.HELD.name.toLowerCase()
       }
       return resolve(true)
     })
@@ -85,7 +85,7 @@ describe('Workflow Toolbar component', () => {
       {
         id: 'user/id',
         name: 'test',
-        status: TaskState.RUNNING.name.toLowerCase()
+        status: WorkflowState.RUNNING.name.toLowerCase()
       }
     ]
     store.state.workflows.workflowName = 'test'

--- a/tests/unit/utils/tasks.spec.js
+++ b/tests/unit/utils/tasks.spec.js
@@ -24,14 +24,14 @@ describe('tasks', () => {
     it('should return the correct state for the node groups when not stopped', () => {
       [
         [
-          TaskState.FAILED.name.toLowerCase(), // expected
-          [TaskState.WAITING, TaskState.FAILED].map((state) => state.name.toLowerCase())], // childStates
+          TaskState.FAILED.name, // expected
+          [TaskState.WAITING, TaskState.FAILED].map((state) => state.name)], // childStates
         [
-          TaskState.WAITING.name.toLowerCase(),
-          [TaskState.WAITING].map((state) => state.name.toLowerCase())],
+          TaskState.WAITING.name,
+          [TaskState.WAITING].map((state) => state.name)],
         [
-          TaskState.RUNNING.name.toLowerCase(),
-          [TaskState.SUBMITTED, TaskState.RUNNING].map((state) => state.name.toLowerCase())]
+          TaskState.RUNNING.name,
+          [TaskState.SUBMITTED, TaskState.RUNNING].map((state) => state.name)]
       ].forEach((val) => {
         const groupState = extractGroupState(val[1], false)
         expect(groupState).to.equal(val[0])
@@ -40,14 +40,14 @@ describe('tasks', () => {
     it('should return the correct state for the node groups when stopped', () => {
       [
         [
-          TaskState.RUNNING.name.toLowerCase(), // expected
-          [TaskState.WAITING, TaskState.SUBMITTED, TaskState.RUNNING].map((state) => state.name.toLowerCase())], // childStates
+          TaskState.RUNNING.name, // expected
+          [TaskState.WAITING, TaskState.SUBMITTED, TaskState.RUNNING].map((state) => state.name)], // childStates
         [
-          TaskState.SUCCEEDED.name.toLowerCase(),
-          [TaskState.QUEUED, TaskState.SUCCEEDED].map((state) => state.name.toLowerCase())],
+          TaskState.SUCCEEDED.name,
+          [TaskState.QUEUED, TaskState.SUCCEEDED].map((state) => state.name)],
         [
-          TaskState.RUNNING.name.toLowerCase(),
-          [TaskState.SUBMITTED, TaskState.RUNNING, TaskState.EXPIRED].map((state) => state.name.toLowerCase())]
+          TaskState.RUNNING.name,
+          [TaskState.SUBMITTED, TaskState.RUNNING, TaskState.EXPIRED].map((state) => state.name)]
       ].forEach((val) => {
         const groupState = extractGroupState(val[1], true)
         expect(groupState).to.equal(val[0])

--- a/tests/unit/utils/tasks.spec.js
+++ b/tests/unit/utils/tasks.spec.js
@@ -25,10 +25,10 @@ describe('tasks', () => {
       [
         [
           TaskState.FAILED.name.toLowerCase(), // expected
-          [TaskState.WAITING, TaskState.HELD, TaskState.FAILED].map((state) => state.name.toLowerCase())], // childStates
+          [TaskState.WAITING, TaskState.FAILED].map((state) => state.name.toLowerCase())], // childStates
         [
           TaskState.WAITING.name.toLowerCase(),
-          [TaskState.WAITING, TaskState.HELD].map((state) => state.name.toLowerCase())],
+          [TaskState.WAITING].map((state) => state.name.toLowerCase())],
         [
           TaskState.RUNNING.name.toLowerCase(),
           [TaskState.SUBMITTED, TaskState.RUNNING].map((state) => state.name.toLowerCase())]


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

Minor tweaks to get all the task icons working properly on master.
- remove vestiges of the obsolete held task state
- corrected several uses of `submit_failed` to `submit-failed`
- use `WorkflowState` instead of `TaskState` in a bunch of places
- make the queued state get recognized properly (it hasn't been removed quite yet)

Result:
- queued tasks (correctly) get the waiting icon, not the unknown state icon
- nonexistent held state removed from state filter drop-down
- submit-failed and queued get the correct icon in the state filter drop-down

Note this overlaps a little with #575 but that might not be merged for a little while.

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (erm, I think?).
- [x] No change log entry required (? invisible to users).
- [x] No documentation update required.
