### PR TITLE
Use Lodash's mergeWith and warn when losing reactivity

### DIFF
--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { extractGroupState } from '@/utils/tasks'
-import { merge, sortedIndex } from 'lodash'
+import { mergeWith, sortedIndex } from 'lodash'
 import { createFamilyProxyNode, getCyclePointId } from '@/components/cylc/tree/index'
 import TaskState from '@/model/TaskState.model'
 
@@ -133,6 +133,27 @@ function sortTaskProxyOrFamilyProxy (left, right) {
       right.node.name.toLowerCase(),
       undefined,
       { numeric: true, sensitivity: 'base' })
+}
+
+/**
+ * Only effectively used if we return something. Otherwise Lodash will use its default merge
+ * function. We use it here not to mutate objects, but to check that we are not losing
+ * reactivity in Vue by adding a non-reactive property into an existing object (which should
+ * be reactive and used in the node tree component).
+ *
+ * @see https://docs-lodash.com/v4/merge-with/
+ * @param {*} objValue - destination value in the existing object (same as object[key])
+ * @param {*} srcValue - source value from the object with new values to be merged
+ * @param {string} key - name of the property being merged (used to access object[key])
+ * @param {*} object - the object being mutated (original, destination, the value is retrieved with object[key])
+ */
+function mergeWithCustomizer (objValue, srcValue, key, object) {
+  // when this is true, it means that we have a value for `srcValue`, that was not defined in the object
+  // while object[key], or objValue, is defined.
+  if (objValue === undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(`We are adding a new property '${key}' into the tree object (or child object like treeitem.node) ${JSON.stringify(object)}!`)
+  }
 }
 
 /**
@@ -301,7 +322,7 @@ class CylcTree {
   updateCyclePoint (cyclePoint) {
     const node = this.lookup.get(cyclePoint.id)
     if (node) {
-      merge(node, cyclePoint)
+      mergeWith(node, cyclePoint, mergeWithCustomizer)
     }
   }
 
@@ -348,7 +369,7 @@ class CylcTree {
       // family proxy. In that case, we create an orphan node in the lookup table.
       // The second time will be node with more information, such as .firstParent {}. When this happens,
       // we must remember to merge the objects.
-      merge(existingFamilyProxy, familyProxy)
+      mergeWith(existingFamilyProxy, familyProxy, mergeWithCustomizer)
       this.lookup.set(existingFamilyProxy.id, existingFamilyProxy)
       // NOTE: important, replace the version so that we use the existing one
       // when linking with the parent node in the tree, not the new GraphQL data
@@ -397,7 +418,7 @@ class CylcTree {
   updateFamilyProxy (familyProxy) {
     const node = this.lookup.get(familyProxy.id)
     if (node) {
-      merge(node, familyProxy)
+      mergeWith(node, familyProxy, mergeWithCustomizer)
       if (!node.node.state) {
         node.node.state = ''
       }
@@ -503,7 +524,7 @@ class CylcTree {
     const node = this.lookup.get(taskProxy.id)
     if (node) {
       computeTaskProgress(taskProxy)
-      merge(node, taskProxy)
+      mergeWith(node, taskProxy, mergeWithCustomizer)
     }
   }
 
@@ -556,7 +577,7 @@ class CylcTree {
   updateJob (job) {
     const node = this.lookup.get(job.id)
     if (node) {
-      merge(node, job)
+      mergeWith(node, job, mergeWithCustomizer)
       if (job.node.firstParent) {
         const parent = this.lookup.get(job.node.firstParent.id)
         // re-calculate the job's task progress

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -313,8 +313,6 @@ describe('CylcTree', () => {
       })
       cylcTree.addFamilyProxy(familyProxy1)
       cylcTree.addFamilyProxy(familyProxy1)
-      console.log(cyclePoint2.id)
-      console.log(cylcTree.root.children[0])
       expect(cylcTree.root.children[0].children.length).to.equal(1)
     })
     it('Should update family proxies', () => {

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -70,6 +70,30 @@ describe('CylcTree', () => {
     cylcTree.clear()
     expect(cylcTree.isEmpty()).to.equal(true)
   })
+  it('Should warn if we add a non-existent property to a reactive object', () => {
+    const cylcTree = new CylcTree(createWorkflowNode({
+      id: WORKFLOW_ID
+    }))
+    const cyclePoint1 = createCyclePointNode({
+      id: `${WORKFLOW_ID}|1|root`,
+      cyclePoint: '1'
+    })
+    cylcTree.addCyclePoint(cyclePoint1)
+    // Now add a new property to cyclepoint; this is the same that happened in the past (fixed)
+    // when we had an update-delta with properties that did not exist in the data. Issue being that
+    // these new properties are not reactive, but UI components could be using the undefined values.
+    // This resulted in a nasty and difficult to identify bug.
+    const newCyclePoint = createCyclePointNode({
+      id: `${WORKFLOW_ID}|1|root`,
+      cyclePoint: '1'
+    })
+    newCyclePoint.node.superStatus = 'super'
+    const sandbox = sinon.createSandbox()
+    sandbox.stub(console, 'warn')
+    cylcTree.updateCyclePoint(newCyclePoint)
+    expect(console.warn.calledOnce).to.equal(true)
+    sandbox.restore()
+  })
   // cycle points
   describe('Cycle points', () => {
     let cylcTree


### PR DESCRIPTION
These changes close #589 (and removes an unnecessary `console.log` from tests)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
