### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -1,0 +1,83 @@
+name: Release stage 2 - auto publish
+
+on:
+  pull_request:  # types AND paths
+    types: [closed]
+    paths: ['package.json']
+    # NOTE: While this is too generic, we use the `if` condition of the job to narrow it down
+    # NOTE: Don't use `branches` as we might create release on any branch
+
+env:
+  # Best not to include the GH token here, only do it for the steps that need it
+  MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+  CHANGELOG_FILE: CHANGES.md
+
+jobs:
+  publish:
+    if: >-  # NOTE: Can't use top-level env here unfortunately
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.MERGE_SHA }}
+
+      - name: Install
+        run: yarn install
+
+      - name: Build
+        run: yarn build --optimize
+
+      - name: Get the version number
+        run: |
+          VERSION=$(node -p -e "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create ZIP archive
+        run: |
+          cd dist && zip -r ../cylc-ui-${{ env.VERSION }}-dist.zip *
+
+      - name: sha256sum
+        run: |
+          SHA256SUM=$(sha256sum cylc-ui-${{ env.VERSION }}-dist.zip)
+          echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
+
+      - name: Publish GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitish: ${{ env.MERGE_SHA }}
+          tag_name: ${{ env.VERSION }}
+          release_name: cylc-ui ${{ env.VERSION }}
+          prerelease: ${{ env.PRERELEASE }}
+          draft: false
+          body: |
+            See [${{ env.CHANGELOG_FILE }}](https://github.com/${{ github.repository }}/blob/master/${{ env.CHANGELOG_FILE }}) for detail.
+
+            sha256sum ${{ env.SHA256SUM }}
+          # TODO: Get topmost changelog section somehow and use that as the body?
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./cylc-ui-${{ env.VERSION }}-dist.zip
+          asset_name: cylc-ui-${{ env.VERSION }}-dist.zip
+          asset_content_type: application/zip
+
+      - name: Comment on the release PR with the results & next steps
+        if: always()
+        uses: cylc/release-actions/stage-2/comment-on-pr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release-url: ${{ steps.create-release.outputs.html_url }}

--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -55,7 +55,8 @@ jobs:
           commitish: ${{ env.MERGE_SHA }}
           tag_name: ${{ env.VERSION }}
           release_name: cylc-ui ${{ env.VERSION }}
-          prerelease: ${{ env.PRERELEASE }}
+          # TODO: `npm version` doesn't indicate whether it's a prerelease or not
+          # prerelease: ${{ env.PRERELEASE }}
           draft: false
           body: |
             See [${{ env.CHANGELOG_FILE }}](https://github.com/${{ github.repository }}/blob/master/${{ env.CHANGELOG_FILE }}) for detail.

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -1,0 +1,44 @@
+name: Release stage 1 - create release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        required: true
+      branch:
+        description: The branch to open the PR against
+        required: false
+        default: 'master'
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+      - name: Sanitise workflow inputs # Should be 1st step
+        uses: cylc/release-actions/stage-1/sanitize-inputs@v1
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BASE_REF }}
+
+      - name: Create & checkout PR branch
+        uses: cylc/release-actions/stage-1/checkout-pr-branch@v1
+
+      - name: Set the package version
+        run: |
+          npm version $VERSION
+
+      - name: Update "released on" date in changelog
+        continue-on-error: true
+        uses: cylc/release-actions/stage-1/update-changelog-release-date@v1
+        with:
+          changelog-file: 'CHANGES.md'
+
+      - name: Create pull request
+        uses: cylc/release-actions/stage-1/create-release-pr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ milestones](https://github.com/cylc/cylc-ui/milestones?state=closed) for each
 release.
 
 -------------------------------------------------------------------------------
-## __cylc-ui-0.3 (2020-??-??)__
+## __cylc-ui-0.3 (<span actions:bind='release-date'>Upcoming, 2021</span>)__
 
 Release 0.3 of Cylc UI.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cylc-ui",
-  "version": "0.3.0",
+  "version": "0.3.0-0",
   "private": true,
   "license": "GPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
These changes close #475 

Adds two new workflows, with the same names as in isodatetime (which I used as reference). The first just creates a PR with updated changelog date, and `package.json` version. Merging that PR triggers the second PR which will create the release/tag, upload the generated production build, and add comments.

The `package.json` is updated too to use `0.3.0-0`. That's the equivalent of Python's `0.3.0dev`, or Java's `0.3.0-SNAPSHOT`. A pre-release as in https://semver.org/ (see item 9).

With all that done, we can safely update our Conda Forge recipe with the sha25sum value, and the zip URL. Credits go to @MetRonnie & @oliver-sanders who did most of the work I copied to automate this release.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? build CI change).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
