### PR TITLE
Remove useless job latestMessage item.

### DIFF
--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -190,10 +190,6 @@ export default {
         {
           title: 'finish time',
           property: 'finishedTime'
-        },
-        {
-          title: 'latest message',
-          property: 'latestMessage'
         }
       ],
       filtered: true

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -528,7 +528,6 @@ class CylcTree {
    * @param {{
    *   id: string,
    *   node: Object,
-   *   latestMessage: string
    * }} job
    */
   addJob (job) {
@@ -550,7 +549,6 @@ class CylcTree {
    *   id: string,
    *   type: string,
    *   node: Object,
-   *   latestMessage: string
    * }} job
    */
   updateJob (job) {

--- a/src/components/cylc/tree/deltas.js
+++ b/src/components/cylc/tree/deltas.js
@@ -64,7 +64,7 @@ function applyDeltasPruned (pruned, tree) {
  *
  * @type {{
  *   jobs: [
- *     function(Object, *=): {id: string, type: string, node: Object, latestMessage: string},
+ *     function(Object, *=): {id: string, type: string, node: Object},
  *     string],
  *   familyProxies: [
  *     function(Object): {id: string, type: string, node: Object, children: *[]},
@@ -114,7 +114,7 @@ function applyDeltasAdded (added, tree) {
  *
  * @type {{
  *   jobs: [
- *     function(Object, *=): {id: string, type: string, node: Object, latestMessage: string},
+ *     function(Object, *=): {id: string, type: string, node: Object},
  *     string],
  *   familyProxies: [
  *     function(Object): {id: string, type: string, node: Object, children: *[]},

--- a/src/components/cylc/tree/index.js
+++ b/src/components/cylc/tree/index.js
@@ -152,10 +152,6 @@ function createJobDetailsNode (job) {
     {
       title: 'finish time',
       value: job.finishedTime
-    },
-    {
-      title: 'latest message',
-      property: job.latestMessage
     }
   ]
   return {
@@ -172,20 +168,18 @@ function createJobDetailsNode (job) {
  * only adding new properties such as type, name, etc.
  *
  * @param job {Object} job
- * @param [latestMessage] {string} latest message of the job's task, defaults to an empty string
- * @return {{node: Object, latestMessage: string}}
- * @return {{id: string, type: string, expanded: boolean, latestMessage: string, node: Object, children: []}}
+ * @return {{node: Object}}
+ * @return {{id: string, type: string, expanded: boolean, node: Object, children: []}}
  */
 // TODO: re-work the latest message, as this is the task latest message, not the job's...
 // TODO: add job-leaf (details) in the hierarchy later for infinite-tree
-function createJobNode (job, latestMessage = '') {
+function createJobNode (job) {
   const jobDetailsNode = createJobDetailsNode(job)
   return {
     id: job.id,
     type: 'job',
     expanded: false,
     node: job,
-    latestMessage: latestMessage,
     children: [jobDetailsNode]
   }
 }
@@ -231,7 +225,7 @@ function populateTreeFromGraphQLData (tree, workflow) {
     // A TaskProxy could no jobs (yet)
     if (taskProxy.jobs) {
       for (const job of taskProxy.jobs) {
-        const jobNode = createJobNode(job, taskProxy.latestMessage)
+        const jobNode = createJobNode(job)
         tree.addJob(jobNode)
       }
     }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -135,7 +135,6 @@ fragment TaskProxyData on TaskProxy {
   state
   isHeld
   cyclePoint
-  latestMessage
   firstParent {
     id
     name
@@ -199,7 +198,6 @@ subscription {
       name
       state
       cyclePoint
-      latestMessage
       task {
         meanElapsedTime
         name

--- a/src/services/mock/checkpoint.js
+++ b/src/services/mock/checkpoint.js
@@ -32,7 +32,6 @@ const checkpoint = {
                     "state": "running",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "started",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|root",
                         "name": "root",
@@ -66,7 +65,6 @@ const checkpoint = {
                     "state": "submitted",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "submitted",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|SUCCEEDED",
                         "name": "SUCCEEDED",
@@ -142,7 +140,6 @@ const checkpoint = {
                     "state": "submitted",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "submitted",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|BAD",
                         "name": "BAD",
@@ -176,7 +173,6 @@ const checkpoint = {
                     "state": "waiting",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "failed, retrying in PT5M (after 2020-11-08T23:02:16Z)",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|BAD",
                         "name": "BAD",
@@ -210,7 +206,6 @@ const checkpoint = {
                     "state": "",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|root",
                         "name": "root",
@@ -229,7 +224,6 @@ const checkpoint = {
                     "state": "submitted",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "submitted",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|SUCCEEDED",
                         "name": "SUCCEEDED",
@@ -263,7 +257,6 @@ const checkpoint = {
                     "state": "",
                     "isHeld": false,
                     "cyclePoint": "20000102T0000Z",
-                    "latestMessage": "",
                     "firstParent": {
                         "id": "user|one|20000102T0000Z|root",
                         "name": "root",

--- a/src/services/mock/checkpoint/get_checkpoint.py
+++ b/src/services/mock/checkpoint/get_checkpoint.py
@@ -70,7 +70,6 @@ fragment TaskProxyData on TaskProxy {
   state
   isHeld
   cyclePoint
-  latestMessage
   firstParent {
     id
     name

--- a/tests/unit/components/cylc/gscan/gscan.data.js
+++ b/tests/unit/components/cylc/gscan/gscan.data.js
@@ -30,7 +30,6 @@ const simpleWorkflowGscanNodes = [
         name: 'foo',
         state: 'succeeded',
         cyclePoint: '20130829T0000Z',
-        latestMessage: 'succeeded',
         task: {
           meanElapsedTime: 60,
           name: 'foo'
@@ -54,7 +53,6 @@ const simpleWorkflowGscanNodes = [
         name: 'bar',
         state: 'succeeded',
         cyclePoint: '20130829T0000Z',
-        latestMessage: 'succeeded',
         task: {
           meanElapsedTime: 59.900001525878906,
           name: 'bar'
@@ -78,7 +76,6 @@ const simpleWorkflowGscanNodes = [
         name: 'foo',
         state: 'succeeded',
         cyclePoint: '20130829T1200Z',
-        latestMessage: 'succeeded',
         task: {
           meanElapsedTime: 60,
           name: 'foo'
@@ -102,7 +99,6 @@ const simpleWorkflowGscanNodes = [
         name: 'bar',
         state: 'running',
         cyclePoint: '20130829T1200Z',
-        latestMessage: 'started',
         task: {
           meanElapsedTime: 59.900001525878906,
           name: 'bar'
@@ -126,7 +122,6 @@ const simpleWorkflowGscanNodes = [
         name: 'foo',
         state: 'running',
         cyclePoint: '20130830T0000Z',
-        latestMessage: 'started',
         task: {
           meanElapsedTime: 60,
           name: 'foo'
@@ -150,7 +145,6 @@ const simpleWorkflowGscanNodes = [
         name: 'bar',
         state: 'waiting',
         cyclePoint: '20130830T0000Z',
-        latestMessage: '',
         task: {
           meanElapsedTime: 59.900001525878906,
           name: 'bar'
@@ -162,7 +156,6 @@ const simpleWorkflowGscanNodes = [
         name: 'foo',
         state: 'waiting',
         cyclePoint: '20130830T1200Z',
-        latestMessage: '',
         task: {
           meanElapsedTime: 60,
           name: 'foo'

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -94,7 +94,6 @@ const sampleWorkflow1 = {
       name: 'eventually_succeeded',
       state: 'succeeded',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|SUCCEEDED',
         __typename: 'FamilyProxy',
@@ -180,7 +179,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|root',
         state: 'failed',
@@ -217,7 +215,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|SUCCEEDED',
         __typename: 'FamilyProxy',
@@ -255,7 +252,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'failed, retrying in PT5M (after 2019-10-23T07:07:39Z)',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|BAD',
         __typename: 'FamilyProxy',
@@ -293,7 +289,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|root',
         __typename: 'FamilyProxy',
@@ -331,7 +326,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'failed',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'failed/EXIT',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|BAD',
         __typename: 'FamilyProxy',
@@ -369,7 +363,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000101T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000101T0000Z|root',
         __typename: 'FamilyProxy',
@@ -407,7 +400,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'waiting',
       cyclePoint: '20000102T0000Z',
-      latestMessage: '',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|root',
         __typename: 'FamilyProxy',
@@ -428,7 +420,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000102T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|SUCCEEDED',
         __typename: 'FamilyProxy',
@@ -466,7 +457,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'failed',
       cyclePoint: '20000102T0000Z',
-      latestMessage: 'failed/EXIT',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|BAD',
         __typename: 'FamilyProxy',
@@ -504,7 +494,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'waiting',
       cyclePoint: '20000102T0000Z',
-      latestMessage: '',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|root',
         __typename: 'FamilyProxy',
@@ -525,7 +514,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'running',
       cyclePoint: '20000102T0000Z',
-      latestMessage: 'started',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|root',
         __typename: 'FamilyProxy',
@@ -563,7 +551,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'running',
       cyclePoint: '20000102T0000Z',
-      latestMessage: 'started',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|root',
         __typename: 'FamilyProxy',
@@ -601,7 +588,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'succeeded',
       cyclePoint: '20000102T0000Z',
-      latestMessage: 'succeeded',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|SUCCEEDED',
         __typename: 'FamilyProxy',
@@ -687,7 +673,6 @@ const sampleWorkflow1 = {
       __typename: 'TaskProxy',
       state: 'waiting',
       cyclePoint: '20000102T0000Z',
-      latestMessage: 'failed, retrying in PT5M (after 2019-10-23T07:08:10Z)',
       firstParent: {
         id: 'cylc|one|20000102T0000Z|BAD',
         __typename: 'FamilyProxy',


### PR DESCRIPTION
This is a small change with no associated Issue: remove "latest message" item currently shown in task job leaves.

"Latest message" is a hold-over from the old GUI tree/table view, which could not accommodate more than one message.

In the new UI:
- standard messages correspond to task job status (no need to show)
- non-standard messages registered as job outputs will be shown by #530 
- (we should display other non-standard messages: e.g. warnings and messages not used for triggering: #595)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
