### PR TITLE
aotf: toolbar mutate button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ None or N/A.
 
 ### Enhancements
 
+[#598](https://github.com/cylc/cylc-ui/pull/598) - Add mutation button
+to the toolbar component.
+
 [#544](https://github.com/cylc/cylc-ui/pull/544) - Enable editing
 mutation inputs and support broadcasts in the UI.
 

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -44,34 +44,31 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- control bar elements displayed only when there is a current workflow in the store -->
     <template v-if="currentWorkflow">
-      <a
+      <v-icon
+        id="workflow-mutate-button"
+        color="#5E5E5E"
+        v-cylc-object="currentWorkflow.id"
+      >
+        {{ svgPaths.menu }}
+      </v-icon>
+
+      <v-icon
         id="workflow-release-hold-button"
-        @click="onClickReleaseHold">
-        <v-icon
-          color="#5E5E5E"
-          :disabled="!enabled.holdToggle"
-        >
-          {{ isHeld ? svgPaths.run : svgPaths.hold }}
-        </v-icon>
-      </a>
+        color="#5E5E5E"
+        :disabled="!enabled.holdToggle"
+        @click="onClickReleaseHold"
+      >
+        {{ isHeld ? svgPaths.run : svgPaths.hold }}
+      </v-icon>
 
-      <a
+      <v-icon
         id="workflow-stop-button"
-        @click="onClickStop">
-        <v-icon
-          color="#5E5E5E"
-          :disabled="!enabled.stopToggle"
-        >
-          {{ svgPaths.stop }}
-        </v-icon>
-      </a>
-
-      <!-- TODO: add control options and call mutations -->
-      <!--
-      <a>
-        <v-chip color="#E7E7E7" @click="toggleExtended">{{ $t('Toolbar.control') }}</v-chip>
-      </a>
-      -->
+        color="#5E5E5E"
+        :disabled="!enabled.stopToggle"
+        @click="onClickStop"
+      >
+        {{ svgPaths.stop }}
+      </v-icon>
 
       <!-- TODO: add workflow latest message -->
       <span></span>
@@ -134,7 +131,8 @@ import {
   mdiStop,
   mdiPlusCircle,
   mdiFileTree,
-  mdiAppleKeyboardCommand
+  mdiAppleKeyboardCommand,
+  mdiMicrosoftXboxControllerMenu
 } from '@mdi/js'
 
 import {
@@ -158,7 +156,8 @@ export default {
       stop: mdiStop,
       tree: mdiFileTree,
       mutations: mdiAppleKeyboardCommand,
-      add: mdiPlusCircle
+      add: mdiPlusCircle,
+      menu: mdiMicrosoftXboxControllerMenu
     },
     expecting: {
       // store state from mutations in order to compute the "enabled" attrs

--- a/src/services/mock/workflow.service.mock.js
+++ b/src/services/mock/workflow.service.mock.js
@@ -41,7 +41,7 @@ const MUTATIONS = [
       {
         name: 'workflow',
         type: {
-          name: 'workflowID',
+          name: 'WorkflowID',
           kind: null
         }
       }
@@ -55,7 +55,7 @@ const MUTATIONS = [
       {
         name: 'workflow',
         type: {
-          name: 'workflowID',
+          name: 'WorkflowID',
           kind: null
         }
       },
@@ -76,7 +76,7 @@ const MUTATIONS = [
       {
         name: 'workflow',
         type: {
-          name: 'workflowID',
+          name: 'WorkflowID',
           kind: null
         }
       },
@@ -97,7 +97,7 @@ const MUTATIONS = [
       {
         name: 'workflow',
         type: {
-          name: 'workflowID',
+          name: 'WorkflowID',
           kind: null
         }
       },

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -28,13 +28,18 @@ import {
   print
 } from 'graphql'
 import {
+  mdiBullhorn,
   mdiCloseCircle,
   mdiCog,
   mdiCursorPointer,
   mdiDelete,
+  mdiEmail,
+  mdiGraph,
   mdiPause,
   mdiPlay,
-  mdiRefreshCircle
+  mdiRefreshCircle,
+  mdiReload,
+  mdiStop
 } from '@mdi/js'
 import TaskState from '@/model/TaskState.model'
 
@@ -44,11 +49,17 @@ import TaskState from '@/model/TaskState.model'
  */
 export const mutationIcons = {
   '': mdiCog, // default fallback
+  broadcast: mdiBullhorn,
   hold: mdiPause,
-  release: mdiPlay,
   kill: mdiCloseCircle,
+  message: mdiEmail,
+  play: mdiPlay,
   poll: mdiRefreshCircle,
+  release: mdiPlay,
+  reload: mdiReload,
   remove: mdiDelete,
+  setOutputs: mdiGraph,
+  stop: mdiStop,
   trigger: mdiCursorPointer
 }
 

--- a/tests/e2e/specs/aotf.js
+++ b/tests/e2e/specs/aotf.js
@@ -260,4 +260,30 @@ describe('Api On The Fly', () => {
         })
     })
   })
+
+  describe('Mutation Button', () => {
+    it('should list all workflow mutations', () => {
+      cy.visit('/#/workflows/one')
+
+      // mock the mutation method
+      mockWorkflowService()
+
+      // click the mutations button
+      cy
+        .get('#workflow-mutate-button')
+        .should('be.visible')
+        .click()
+        // this should open the mutations menu
+        .get('.c-mutation-menu-list:first')
+        .should('exist')
+        .should('be.visible')
+        // the workflow should be the subject of the mutation selection
+        .find('h2:first')
+        .should('have.text', ' user|one ')
+        // it should list the four workflow mutations
+        .get('.c-mutation-menu-list:first')
+        .find('.v-list-item')
+        .should('have.length', 4)
+    })
+  })
 })


### PR DESCRIPTION
addresses: #339 
built on: #544 
related sibling pr: https://github.com/cylc/cylc-uiserver/pull/175

Add a button in the workflow toolbar that lists workflow mutations.

![kap](https://user-images.githubusercontent.com/16705946/108732982-f899c980-7525-11eb-9058-99e26b43cfd8.gif)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
