### PR TITLE
aotf: reset forms correctly

### DIFF
--- a/src/components/cylc/Mutation.vue
+++ b/src/components/cylc/Mutation.vue
@@ -136,6 +136,7 @@ export default {
 
     /* Reset this component to it's initial state. */
     reset () {
+      this.$refs.formGenerator.reset()
       Object.assign(this.$data, initialState())
     }
   },

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -167,6 +167,11 @@ export default {
       this.y = event.clientY
       this.$nextTick(() => {
         this.showMenu = true
+        if (this.$refs && this.$refs.mutationComponent) {
+          // reset the mutation component if present
+          // (this is because we re-use the same component)
+          this.$refs.mutationComponent.reset()
+        }
       })
     },
 

--- a/tests/e2e/specs/mutation.js
+++ b/tests/e2e/specs/mutation.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+describe('Mutations component', () => {
+  /**
+   * @param {string} nodeName - the tree node name, to search for and open the mutations form
+   */
+  const openMutationsForm = (nodeName) => {
+    cy
+      .get('span')
+      .contains(nodeName)
+      .parent()
+      .find('.c-task')
+      .click({ force: true })
+    cy
+      .get('.c-mutation-menu-list')
+      .find('span')
+      .contains('Edit')
+      .parent()
+      .click()
+  }
+  const submitMutationForms = () => {
+    cy.visit('/#/workflows/one')
+    openMutationsForm('BAD')
+    // fill mocked mutation form with any data
+    cy
+      .get('.v-dialog')
+      .within(() => {
+        // type anything in the text inputs
+        cy
+          .get('input[type="text"]')
+          .each(($el) => {
+            cy.wrap($el).clear()
+            cy.wrap($el).type('ABC')
+          })
+        // click on the submit button
+        cy
+          .get('span')
+          .contains('Submit')
+          .parent()
+          .click()
+        // we should now have a c-task icon
+        cy
+          .get('.c-task')
+          .should('be.visible')
+      })
+  }
+  it('should submit a mutation form', () => {
+    submitMutationForms()
+  })
+  it.only('should not remember data after submitting a mutation form', () => {
+    submitMutationForms()
+    // close submit form (not clicking on cancel, as it appears to clear the form, but outside the dialog)
+    cy
+      .get('.v-overlay')
+      .click({ force: true })
+    // click on the GOOD family proxy now
+    openMutationsForm('GOOD')
+    cy
+      .get('.v-dialog')
+      .within(() => {
+        // type anything in the text inputs
+        cy
+          .get('input[type="text"]')
+          .each(($el) => {
+            cy.wrap($el).should('not.contain.value', 'ABC')
+          })
+      })
+  })
+})


### PR DESCRIPTION
Small fix, make sure the form is properly reset.

Fixes a bug where inputs made to one mutation on one task could be "remembered" when you open the mutation editor for the same mutation but on a different task. After this change no information entered into the mutation editor should be "remembered" from one task to another.

It was kinda useful in some respects to have the values from the last mutation remembered, however, in its current for it is unsafe so better to reset everything.

Tricky to test, any e2e test would need to be written into the structure of the form generator which would be fragile.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
