### PR TITLE
tree: swap task name and job order

### DIFF
--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -57,6 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </slot>
       <slot name="task-proxy" v-else-if="node.type === 'task-proxy'">
         <div :class="getNodeDataClass()" @click="nodeClicked">
+          <!-- Task summary -->
           <task
             v-cylc-object="node.node.id"
             :key="node.node.id"
@@ -64,15 +65,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :isHeld="node.node.isHeld"
             :progress="node.node.progress"
           />
-          <span class="mx-1">{{ node.node.name }}</span>
           <div v-if="!isExpanded" class="node-summary">
-            <!-- Task summary -->
+            <!-- most recent job summary -->
             <job
-              v-for="(job, index) in node.children"
+              v-for="(job, index) in node.children.slice(0, 1)"
               v-cylc-object="job.id"
               :key="`${job.id}-summary-${index}`"
-              :status="job.node.state" />
+              :status="job.node.state"
+              style="margin-left: 0.25em;"
+            />
           </div>
+          <span class="mx-1">{{ node.node.name }}</span>
         </div>
       </slot>
       <slot name="job" v-else-if="node.type === 'job'">


### PR DESCRIPTION
completes point one of #333 

Swap the job and task name for readability.

![Screenshot from 2021-03-04 13-16-53](https://user-images.githubusercontent.com/16705946/109969528-ea993500-7ceb-11eb-91a5-0c1766e7f0f6.png)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
