### PR TITLE
task: update progress with css animation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ None or N/A.
 
 ### Enhancements
 
+[#607](https://github.com/cylc/cylc-ui/pull/607) - Animate task progress
+using average run times.
+
 [#598](https://github.com/cylc/cylc-ui/pull/598) - Add mutation button
 
 [#530](https://github.com/cylc/cylc-ui/pull/530) - Display message triggers.

--- a/src/components/cylc/Mutation.vue
+++ b/src/components/cylc/Mutation.vue
@@ -57,10 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
        style="font-size:1.5em;"
        v-if="status != 'waiting'"
       >
-        <Task
-         :status="status"
-         :progress="0"
-        />
+        <Task :status="status"/>
         {{ status }}
       </p>
       <pre v-if="status === 'failed'">{{ response }}</pre>

--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -20,6 +20,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
          which can sit in text.
 -->
 <script>
+import TaskState from '@/model/TaskState.model'
+
+/* Compute the style attribute that makes the progress animation work. */
+function getRunningStyle (context) {
+  if (
+    context.props.status === TaskState.RUNNING.name &&
+    context.props.startTime &&
+    context.props.estimatedDuration
+  ) {
+    const startTime = Date.parse(context.props.startTime)
+    const now = Date.now()
+    const elapsedTime = ((now - startTime) / 1000)
+    return `
+      animation-name: c-task-progress-animation;
+      /* clock position should be proportional to elapsed time */
+      animation-timing-function: linear;
+      /* run this animation once and only once /*
+      animation-iteration-count: 1;
+      /* the duration of the animation (the estimated task run time) */
+      animation-duration: ${context.props.estimatedDuration}s;
+      /* start the animation at the right point (note negative duration) */
+      animation-delay: -${elapsedTime}s;
+      /* stay at 100% once the animation has finished */
+      animation-fill-mode: forwards;
+    `
+  }
+  return ''
+}
+
 export default {
   name: 'Task',
   functional: true,
@@ -36,7 +65,12 @@ export default {
       type: Boolean,
       require: true
     },
-    progress: {
+    startTime: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    estimatedDuration: {
       type: Number,
       required: false,
       default: 0
@@ -69,7 +103,7 @@ export default {
               r: '25',
               'stroke-width': '50',
               'stroke-dasharray': '157',
-              style: `stroke-dashoffset: ${157 - (157 * (context.props.progress / 100))}`
+              style: getRunningStyle(context)
             }
           }
         ),

--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -34,8 +34,8 @@ function getRunningStyle (context) {
     const elapsedTime = ((now - startTime) / 1000)
     return `
       animation-name: c-task-progress-animation;
-      /* clock position should be proportional to elapsed time */
-      animation-timing-function: linear;
+      /* restrict the number of frames in the animation for performance */
+      animation-timing-function: steps(50);
       /* run this animation once and only once /*
       animation-iteration-count: 1;
       /* the duration of the animation (the estimated task run time) */

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -66,12 +66,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-model="tasksFilter.states"
             >
               <template v-slot:item="slotProps">
-                <Task :status="slotProps.item.value" :progress=0 />
+                <Task :status="slotProps.item.value"/>
                 <span class="ml-2">{{ slotProps.item.value }}</span>
               </template>
               <template v-slot:selection="slotProps">
                 <div class="mr-2" v-if="slotProps.index >= 0 && slotProps.index < maximumTasks">
-                  <Task :status="slotProps.item.value" :progress=0 />
+                  <Task :status="slotProps.item.value"/>
                 </div>
                 <span
                   v-if="slotProps.index === maximumTasks"

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -39,7 +39,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :status="node.node.state"
             :isHeld="node.node.isHeld"
             :isQueued="node.node.isQueued"
-            :progress=0
           />
           <span class="mx-1">{{ node.node.name }}</span>
         </div>
@@ -52,7 +51,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :status="node.node.state"
             :isHeld="node.node.isHeld"
             :isQueued="node.node.isQueued"
-            :progress="node.node.progress"
           />
           <span class="mx-1">{{ node.node.name }}</span>
         </div>
@@ -66,7 +64,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :status="node.node.state"
             :isHeld="node.node.isHeld"
             :isQueued="node.node.isQueued"
-            :progress="node.node.progress"
+            :startTime="taskStartTime(node)"
+            :estimatedDuration="taskEstimatedDuration(node)"
           />
           <div v-if="!isExpanded" class="node-summary">
             <!-- most recent job summary -->
@@ -212,6 +211,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import Task from '@/components/cylc/Task'
 import Job from '@/components/cylc/Job'
+import TaskState from '@/model/TaskState.model'
 
 /**
  * Offset used to move nodes to the right or left, to represent the nodes hierarchy.
@@ -352,6 +352,28 @@ export default {
       classes['node-data'] = true
       classes[`node-data-${this.node.type}`] = true
       return classes
+    },
+    taskStartTime (taskProxy) {
+      if (
+        taskProxy.node.state === TaskState.RUNNING.name &&
+        taskProxy.children.length > 0 &&
+        taskProxy.children[0] &&
+        taskProxy.children[0].node &&
+        taskProxy.children[0].node.startedTime
+      ) {
+        return taskProxy.children[0].node.startedTime
+      }
+      return null
+    },
+    taskEstimatedDuration (taskProxy) {
+      if (
+        taskProxy.node &&
+        taskProxy.node.task &&
+        taskProxy.node.task.meanElapsedTime
+      ) {
+        return taskProxy.node.task.meanElapsedTime
+      }
+      return null
     }
   }
 }

--- a/src/model/TaskState.model.js
+++ b/src/model/TaskState.model.js
@@ -20,7 +20,7 @@ import { Enumify } from 'enumify'
 /**
  * Cylc valid task states.
  */
-class TaskState extends Enumify {
+export class TaskState extends Enumify {
   // NOTE: the order of the enum values is important to calculate the group states in the UI. Items at
   // the top of the list have preference over the items below in the algorithm.
   static SUBMIT_FAILED = new TaskState('submit-failed')
@@ -42,5 +42,19 @@ class TaskState extends Enumify {
     this.name = name
   }
 }
+
+/**
+ * Task states ordered for display purposes.
+ */
+export const TaskStateUserOrder = [
+  TaskState.WAITING,
+  TaskState.PREPARING,
+  TaskState.SUBMITTED,
+  TaskState.RUNNING,
+  TaskState.SUCCEEDED,
+  TaskState.SUBMIT_FAILED,
+  TaskState.FAILED,
+  TaskState.EXPIRED
+]
 
 export default TaskState

--- a/src/styles/cylc/_job.scss
+++ b/src/styles/cylc/_job.scss
@@ -35,7 +35,7 @@ $cjob: ".c-job svg.job rect";
 }
 
 @mixin job_theme_default() {
-    $teal: rgb(125,207,212);
+    $teal: rgb(109,213,194);
     $blue: rgb(106,164,241);
     $green: rgb(81,175,81);
     $red: rgb(207,72,72);

--- a/src/styles/cylc/_task.scss
+++ b/src/styles/cylc/_task.scss
@@ -15,6 +15,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@keyframes c-task-progress-animation {
+  from {
+    /* 0% progress */
+    stroke-dashoffset: 157;
+
+  }
+  to {
+    /* 100% progress */
+    stroke-dashoffset: 0;
+  }
+}
+
 .c-task {
 
   $foreground: rgb(90,90,90);
@@ -52,6 +64,8 @@
       transform-origin: 50% 50%;
       transform: rotate(-90deg);
       opacity: 0.4;
+      /* 0% progress */
+      stroke-dashoffset: 157;
     }
   }
 

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -73,7 +73,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 v-for="state in states"
               >
                 <td style="font-size: 2em;">
-                  <task :status="state" :progress="33" />
+                  <task :status="state"/>
                 </td>
                 <td>
                   <span>{{ state }}</span>

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -52,34 +52,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <tr>
                 <td>
                   <p>
-                    <!-- TODO - this better -->
-                    The part which is related to the
-                    workflow itself. These are states
-                    which can be triggered off of
+                    The status of the task in the workflow.
                   </p>
                 </td>
                 <td></td>
                 <td>
                   <p>
-                    <!-- TODO - this better -->
-                    The status of a running job
-                    which may or may not be the
-                    same as the task status
+                    The status of a single job submission,
+                    one task can have multiple jobs.
                   </p>
                 </td>
               </tr>
               <tr
-                v-bind:key="state"
-                v-for="state in states"
+                v-bind:key="state.name.name"
+                v-for="state of states"
               >
                 <td style="font-size: 2em;">
-                  <task :status="state"/>
+                  <!-- set times to make the progrees change -->
+                  <task
+                    :status="state.name"
+                    :startTime="Date.now()"
+                    :estimatedDuration="30"
+                  />
                 </td>
                 <td>
-                  <span>{{ state }}</span>
+                  <span>{{ state.name }}</span>
                 </td>
                 <td style="font-size: 2em;">
-                  <job :status="state" />
+                  <job :status="state.name" />
                 </td>
               </tr>
             </table>
@@ -100,22 +100,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               three-line
             >
               <v-list-tile>
-                  <v-list-tile-avatar>
-                    <task
-                      style="font-size: 2em;"
-                      status="waiting"
-                      :isHeld="true"
-                    />
-                  </v-list-tile-avatar>
-                  <v-list-tile-content>
-                    <v-list-tile-title>
-                      Held
-                    </v-list-tile-title>
-                    <v-list-tile-sub-title>
-                      When a task is "held" no new job submissions will be made
-                    </v-list-tile-sub-title>
-                  </v-list-tile-content>
-
+                <v-list-tile-avatar>
+                  <task
+                    style="font-size: 2em;"
+                    status="waiting"
+                    :isHeld="true"
+                  />
+                </v-list-tile-avatar>
+                <v-list-tile-content>
+                  <v-list-tile-title>
+                    Held
+                  </v-list-tile-title>
+                  <v-list-tile-sub-title>
+                    When a task is "held" no new job submissions will be made
+                  </v-list-tile-sub-title>
+                </v-list-tile-content>
               </v-list-tile>
               <v-list-tile>
                   <v-list-tile-avatar>
@@ -172,6 +171,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import Task from '@/components/cylc/Task'
 import Job from '@/components/cylc/Job'
+import { TaskStateUserOrder } from '@/model/TaskState.model'
 
 export default {
   components: {
@@ -181,15 +181,7 @@ export default {
   // TODO: extract task states and descriptions from the GraphQL API
   //       once this is an enumeration.
   data: () => ({
-    states: [
-      'waiting',
-      'submitted',
-      'running',
-      'succeeded',
-      'failed',
-      'submit-failed',
-      'expired'
-    ]
+    states: TaskStateUserOrder
   })
 }
 </script>
@@ -214,9 +206,8 @@ export default {
     border-spacing: 0;
 
     p {
-      font-size: 0.6em;
+      margin-top: 1em;
       line-height: 1.2em;
-      /*color: $grey;*/
     }
 
     tr:nth-child(1) {

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -653,7 +653,6 @@ describe('CylcTree', () => {
       cylcTree.addTaskProxy(taskProxy)
     })
     it('Should add jobs', () => {
-      expect(taskProxy.node.progress).to.equal(0)
       const jobId = `${taskProxy.id}|1`
       const fmt = new Intl.DateTimeFormat('en', { year: 'numeric', month: '2-digit', day: '2-digit' })
       const startedDate = new Date()
@@ -675,8 +674,6 @@ describe('CylcTree', () => {
       const task = family.children[0]
       const createdJob = task.children[0]
       expect(createdJob.id).to.equal(jobId)
-      // should have updated the parent progress now
-      expect(taskProxy.node.progress).to.be.greaterThan(0)
     })
     it('Should not add jobs twice', () => {
       const jobId = `${taskProxy.id}|1`
@@ -786,34 +783,6 @@ describe('CylcTree', () => {
       expect(createdJob.id).to.equal(jobId)
       cylcTree.removeJob('-1')
       expect(cylcTree.root.children[0].children[0].children[0].children.length).to.equal(1)
-    })
-    it('Should set progress as zero even if there is no meanElapsedTime (and not NaN)', () => {
-      expect(taskProxy.node.progress).to.equal(0)
-      // a TaskProxy may not have a meanElapsedTime until it has had previous executions to calculate it
-      delete taskProxy.node.task.meanElapsedTime
-      const jobId = `${taskProxy.id}|1`
-      const fmt = new Intl.DateTimeFormat('en', { year: 'numeric', month: '2-digit', day: '2-digit' })
-      const startedDate = new Date()
-      const startedTime = fmt.format(startedDate)
-      const job = createJobNode({
-        id: jobId,
-        firstParent: {
-          id: taskProxy.id
-        },
-        state: TaskState.FAILED.name,
-        startedTime
-      })
-      const sandbox = sinon.createSandbox()
-      sandbox.stub(Date, 'now').returns(startedDate.getTime() + 15000)
-      cylcTree.addJob(job)
-      sandbox.restore()
-      const cyclepoint = cylcTree.root.children[0]
-      const family = cyclepoint.children[0]
-      const task = family.children[0]
-      const createdJob = task.children[0]
-      expect(createdJob.id).to.equal(jobId)
-      // the calculation will have failed since there is no meanElapsedTime, so the progress remains at 0
-      expect(taskProxy.node.progress).to.equal(0)
     })
   })
   describe('Recursive delete nodes', () => {

--- a/tests/unit/model/taskstate.model.spec.js
+++ b/tests/unit/model/taskstate.model.spec.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai'
+import {
+  TaskState,
+  TaskStateUserOrder
+} from '@/model/TaskState.model.js'
+
+describe('TaskState', () => {
+  describe('TaskStateUserOrder', () => {
+    it('contains the same states as TaskState in a different order', () => {
+      expect([...TaskState].sort()).to.deep.equal(TaskStateUserOrder.sort())
+    })
+  })
+})


### PR DESCRIPTION
closes #563

Also:

* Upgrade the Guide page from Vuetify1->2
* Use the task state enum in the Guide to keep it in sync with task state changes.
* Change the submitted task colour
  * see also https://github.com/cylc/cylc-flow/pull/3831
  * note the terminal colours need to be more vibrant so don't match

Start a CSS3 animation for each `<task :status="running" />` component that will keep the progress clock-face up to date for the life of the running job.

This saves having to routinely compute the progress and should, hopefully, be pretty efficient.

Example screen grab, the page is reloaded a few times to show that the animations are started with the correct offset for tasks that are already running before the page is loaded.

![progress](https://user-images.githubusercontent.com/16705946/109998802-82f1e280-7d09-11eb-9e79-253c3d61a2af.gif)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [ ] Tests :( (see comment)
