### PR TITLE
tree: boost task icon size 20%

### DIFF
--- a/src/components/cylc/Task.vue
+++ b/src/components/cylc/Task.vue
@@ -410,8 +410,7 @@ export default {
     //       https://github.com/vuejs/vue-loader/issues/1433
     const attrs = Object.assign(context.data, {
       attrs: {
-        class: 'c-task',
-        style: 'display:inline-block; vertical-align:middle'
+        class: 'c-task'
       }
     })
     return createElement(

--- a/src/styles/cylc/_task.scss
+++ b/src/styles/cylc/_task.scss
@@ -16,7 +16,6 @@
  */
 
 .c-task {
-
   $foreground: rgb(90,90,90);
   $background: rgb(255,255,255);
 

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -45,7 +45,8 @@ $visible-outputs: 5;
 }
 
 .treeitem {
-  display: block;
+  display:inline-block;
+  vertical-align:middle;
   width: 100%;
   .node {
     line-height: $line-height;
@@ -73,6 +74,10 @@ $visible-outputs: 5;
         flex-wrap: nowrap;
         flex-direction: row;
       }
+    }
+
+    .c-task {
+      font-size: 1.2em;
     }
   }
   .type {


### PR DESCRIPTION
See https://github.com/cylc/cylc-ui/issues/605#issuecomment-795197316

Boost the task icon size in the tree view by 20%.

(Related to #605 but that is a different issue about a global configuration for scaling these icons in all contexts.)

Before:
![before](https://user-images.githubusercontent.com/16705946/110617198-4d2b7e80-818d-11eb-9a38-51befa5c238e.png)

After:
![after](https://user-images.githubusercontent.com/16705946/110617225-54eb2300-818d-11eb-8f62-f33dc68ca5cf.png)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
