### PR TITLE
Alert the user if there are any errors processing the deltas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ None or N/A.
 
 ### Enhancements
 
+[#616](https://github.com/cylc/cylc-ui/pull/616) - Alert the user if there are
+any errors processing deltas.
+
 [#623](https://github.com/cylc/cylc-ui/pull/623) - Display errors from
 mutations.
 

--- a/src/components/cylc/tree/deltas.js
+++ b/src/components/cylc/tree/deltas.js
@@ -56,7 +56,7 @@ function applyDeltasPruned (pruned, tree) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error applying pruned-delta, will continue processing the remaining data', error, id)
-          store.dispatch('setAlert', new AlertModel('Error applying pruned-delta, see browser console logs for more', null, 'error'))
+          store.dispatch('setAlert', new AlertModel('Error applying pruned-delta, see browser console logs for more. Please reload your browser tab to retrieve the full flow state', null, 'error'))
         }
       }
     }
@@ -100,7 +100,7 @@ function applyDeltasAdded (added, tree) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error applying added-delta, will continue processing the remaining data', error, addedData)
-          store.dispatch('setAlert', new AlertModel('Error applying added-delta, see browser console logs for more', null, 'error'))
+          store.dispatch('setAlert', new AlertModel('Error applying added-delta, see browser console logs for more. Please reload your browser tab to retrieve the full flow state', null, 'error'))
         }
       })
     }
@@ -141,7 +141,7 @@ function applyDeltasUpdated (updated, tree) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error applying updated-delta, will continue processing the remaining data', error, updatedData)
-          store.dispatch('setAlert', new AlertModel('Error applying updated-delta, see browser console logs for more', null, 'error'))
+          store.dispatch('setAlert', new AlertModel('Error applying updated-delta, see browser console logs for more. Please reload your browser tab to retrieve the full flow state', null, 'error'))
         }
       })
     }
@@ -221,7 +221,7 @@ export function applyDeltas (deltas, tree) {
       if (!deltas.added || !deltas.added.workflow) {
         // eslint-disable-next-line no-console
         console.error('Received a delta before the workflow initial data burst')
-        store.dispatch('setAlert', new AlertModel('Received a delta before the workflow initial data burst', null, 'error'))
+        store.dispatch('setAlert', new AlertModel('Received a delta before the workflow initial data burst. Please reload your browser tab to retrieve the full flow state', null, 'error'))
         return
       }
       try {
@@ -229,7 +229,7 @@ export function applyDeltas (deltas, tree) {
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error applying initial data burst for deltas', error, deltas)
-        store.dispatch('setAlert', new AlertModel('Error applying initial data burst for deltas', null, 'error'))
+        store.dispatch('setAlert', new AlertModel('Error applying initial data burst for deltas. Please reload your browser tab to retrieve the full flow state', null, 'error'))
         throw error
       }
     } else {

--- a/src/components/cylc/tree/deltas.js
+++ b/src/components/cylc/tree/deltas.js
@@ -22,6 +22,8 @@ import {
   createTaskProxyNode
 } from '@/components/cylc/tree/tree-nodes'
 import { populateTreeFromGraphQLData } from '@/components/cylc/tree/index'
+import store from '@/store/'
+import AlertModel from '@/model/Alert.model'
 
 /**
  * Helper object used to iterate pruned deltas data.
@@ -54,6 +56,7 @@ function applyDeltasPruned (pruned, tree) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error applying pruned-delta, will continue processing the remaining data', error, id)
+          store.dispatch('setAlert', new AlertModel('Error applying pruned-delta, see browser console logs for more', null, 'error'))
         }
       }
     }
@@ -97,6 +100,7 @@ function applyDeltasAdded (added, tree) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error applying added-delta, will continue processing the remaining data', error, addedData)
+          store.dispatch('setAlert', new AlertModel('Error applying added-delta, see browser console logs for more', null, 'error'))
         }
       })
     }
@@ -137,6 +141,7 @@ function applyDeltasUpdated (updated, tree) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error applying updated-delta, will continue processing the remaining data', error, updatedData)
+          store.dispatch('setAlert', new AlertModel('Error applying updated-delta, see browser console logs for more', null, 'error'))
         }
       })
     }
@@ -216,6 +221,7 @@ export function applyDeltas (deltas, tree) {
       if (!deltas.added || !deltas.added.workflow) {
         // eslint-disable-next-line no-console
         console.error('Received a delta before the workflow initial data burst')
+        store.dispatch('setAlert', new AlertModel('Received a delta before the workflow initial data burst', null, 'error'))
         return
       }
       try {
@@ -223,6 +229,7 @@ export function applyDeltas (deltas, tree) {
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error applying initial data burst for deltas', error, deltas)
+        store.dispatch('setAlert', new AlertModel('Error applying initial data burst for deltas', null, 'error'))
         throw error
       }
     } else {
@@ -234,7 +241,7 @@ export function applyDeltas (deltas, tree) {
         handleDeltas(deltas, tree)
       } catch (error) {
         // eslint-disable-next-line no-console
-        console.error('Error applying deltas', error, deltas)
+        console.error('Unexpected error applying deltas', error, deltas)
         throw error
       }
     }

--- a/tests/unit/components/cylc/tree/deltas.spec.js
+++ b/tests/unit/components/cylc/tree/deltas.spec.js
@@ -24,11 +24,18 @@ import {
 } from '@/components/cylc/tree/tree-nodes'
 import sinon from 'sinon'
 import TaskState from '@/model/TaskState.model'
+import store from '@/store'
 
 /**
  * Tests for the tree deltas module.
  */
 describe('Deltas', () => {
+  beforeEach(() => {
+    sinon.stub(console, 'log')
+  })
+  afterEach(() => {
+    sinon.restore()
+  })
   const WORKFLOW_ID = 'cylc|workflow'
   it('Should skip if no deltas provided', () => {
     expect(() => applyDeltas(null, null)).to.throw(Error)
@@ -84,6 +91,7 @@ describe('Deltas', () => {
     applyDeltas(deltasAdded, cylcTree)
     expect(console.error.calledOnce).to.equal(true)
     sandbox.restore()
+    expect(store.state.alert.getText()).to.have.string('added-delta')
   })
   it('Should log to console and throw an error if it fails to handle deltas on the first data burst', () => {
     const sandbox = sinon.createSandbox()
@@ -105,6 +113,7 @@ describe('Deltas', () => {
     expect(() => applyDeltas(deltasAdded, cylcTree)).to.throw(Error)
     expect(console.error.calledOnce).to.equal(true)
     sandbox.restore()
+    expect(store.state.alert.getText()).to.have.string('initial data burst')
   })
   describe('Initial data burst', () => {
     let cylcTree


### PR DESCRIPTION
These changes partially address #614

When the deltas are applied to the existing tree data, multiple may fail. The current `Alert` component shows only a single message. So I've left the `console.error` entry, as it also contains more information such as the complete delta that was dropped.

This way the user will see an alert on the UI showing the latest message. But the console log will contain the other errors.

![image](https://user-images.githubusercontent.com/304786/111528472-11fd0100-87c6-11eb-804b-06a7d1e9993d.png)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
