### PR TITLE
aotf: fix small bug in mutation filtering

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -392,9 +392,7 @@ export function filterAssociations (cylcObject, tokens, mutations) {
           // this isn't the object type we are filtering for, but it'll do
           applies = true
         }
-        if (tokens[cylcObject]) {
-          // this can be satisfied by the context
-        } else if (arg._required) {
+        if (arg._required && !tokens[arg._cylcObject]) {
           // this cannot be satisfied by the context
           requiresInfo = true
         }


### PR DESCRIPTION
Quick bugfix for a small bug.

Mutations with required arguments that are cylc objects (e.g. tasks, cycle points, etc) would show up as not requiring additional information even when they did.

Example: the `set_hold_point` mutation introduced in the cylc-pause branch (currently still a PR on cylc-flow).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.