### PR TITLE
cylc-pause: change held->paused

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -311,7 +311,7 @@ export default {
   },
   computed: {
     /**
-     * Sort workflows by type first, showing running or held workflows first,
+     * Sort workflows by type first, showing running or paused workflows first,
      * then stopped. Within each group, workflows are sorted alphabetically
      * (natural sort).
      */
@@ -443,7 +443,8 @@ export default {
      * a name) and a given list of filters.
      *
      * The list of filters may contain workflow states ("running", "stopped",
-     * "held"), and/or task states ("running", "waiting", "submit-failed", etc).
+     * "paused"), and/or task states ("running", "waiting", "submit-failed",
+     * etc).
      *
      * Does not return any value, but modifies the data variable
      * filteredWorkflows, used in the template.

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -53,12 +53,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </v-icon>
 
       <v-icon
-        id="workflow-release-hold-button"
+        id="workflow-play-pause-button"
         color="#5E5E5E"
-        :disabled="!enabled.holdToggle"
+        :disabled="!enabled.pauseToggle"
         @click="onClickReleaseHold"
       >
-        {{ isHeld ? svgPaths.run : svgPaths.hold }}
+        {{ isPaused ? svgPaths.run : svgPaths.hold }}
       </v-icon>
 
       <v-icon
@@ -161,7 +161,7 @@ export default {
     },
     expecting: {
       // store state from mutations in order to compute the "enabled" attrs
-      held: null,
+      paused: null,
       stop: null
     }
   }),
@@ -169,10 +169,10 @@ export default {
   computed: {
     ...mapState('app', ['title']),
     ...mapGetters('workflows', ['currentWorkflow']),
-    isHeld () {
+    isPaused () {
       return (
         this.currentWorkflow &&
-        this.currentWorkflow.status === WorkflowState.HELD.name
+        this.currentWorkflow.status === WorkflowState.PAUSED.name
       )
     },
     isStopped () {
@@ -186,14 +186,14 @@ export default {
       // NOTE: this is a temporary solution until we are able to subscribe to
       // mutations to tell when they have completed
       return {
-        holdToggle: (
+        pauseToggle: (
           // the play/pause button
           !this.isStopped &&
           !this.expecting.stop &&
           this.currentWorkflow.status !== WorkflowState.STOPPING.name &&
           (
-            this.expecting.held === null ||
-            this.expecting.held === this.currentWorkflow.isHeld
+            this.expecting.paused === null ||
+            this.expecting.paused === this.currentWorkflow.isPaused
           )
         ),
         stopToggle: (
@@ -209,8 +209,8 @@ export default {
   },
 
   watch: {
-    isHeld () {
-      this.expecting.held = null
+    isPaused () {
+      this.expecting.paused = null
     },
     isStopped () {
       this.expecting.stop = null
@@ -220,11 +220,11 @@ export default {
   methods: {
     onClickReleaseHold () {
       const ret = this.$workflowService.mutate(
-        this.isHeld ? 'release' : 'hold',
+        this.isPaused ? 'resume' : 'pause',
         this.currentWorkflow.id
       )
       if (ret[0] === mutationStatus.SUCCEEDED) {
-        this.expecting.held = !this.isHeld
+        this.expecting.paused = !this.isPaused
       }
     },
     async onClickStop () {

--- a/src/model/WorkflowState.model.js
+++ b/src/model/WorkflowState.model.js
@@ -31,7 +31,7 @@ import {
 class WorkflowState extends Enumify {
   // NOTE: the order the enum values are created here is used in the UI for sorting
   static RUNNING = new WorkflowState('running', mdiPlayCircle)
-  static HELD = new WorkflowState('held', mdiPauseCircle)
+  static PAUSED = new WorkflowState('paused', mdiPauseCircle)
   static STOPPING = new WorkflowState('stopping', mdiSkipNextCircle)
   static STOPPED = new WorkflowState('stopped', mdiStopCircle)
   static ERROR = new WorkflowState('error', mdiHelpCircle)

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -36,10 +36,13 @@ import {
   mdiEmail,
   mdiGraph,
   mdiPause,
+  mdiPauseCircleOutline,
   mdiPlay,
+  mdiPlayCircleOutline,
   mdiRefreshCircle,
   mdiReload,
-  mdiStop
+  mdiStop,
+  mdiWifi
 } from '@mdi/js'
 import TaskState from '@/model/TaskState.model'
 
@@ -50,14 +53,17 @@ import TaskState from '@/model/TaskState.model'
 export const mutationIcons = {
   '': mdiCog, // default fallback
   broadcast: mdiBullhorn,
-  hold: mdiPause,
+  hold: mdiPauseCircleOutline, // to distinguish from pause
   kill: mdiCloseCircle,
   message: mdiEmail,
+  pause: mdiPause,
+  ping: mdiWifi,
   play: mdiPlay,
   poll: mdiRefreshCircle,
-  release: mdiPlay,
+  release: mdiPlayCircleOutline, // to distinguish from play
   reload: mdiReload,
   remove: mdiDelete,
+  resume: mdiPlay,
   setOutputs: mdiGraph,
   stop: mdiStop,
   trigger: mdiCursorPointer

--- a/tests/e2e/specs/aotf.js
+++ b/tests/e2e/specs/aotf.js
@@ -231,12 +231,12 @@ describe('Api On The Fly', () => {
 
       // click the hold-release button
       cy
-        .get('#workflow-release-hold-button')
+        .get('#workflow-play-pause-button')
         .should('be.visible')
         .click()
         .then(() => {
           expect(mutations.length).to.equal(1)
-          expect(mutations[0]).to.equal('hold')
+          expect(mutations[0]).to.equal('pause')
         })
     })
   })

--- a/tests/e2e/specs/gscan.js
+++ b/tests/e2e/specs/gscan.js
@@ -72,7 +72,7 @@ describe('GScan component', () => {
     cy
       .get('[role="menu"]:visible')
       .find('.v-label')
-      .contains('held')
+      .contains('pause')
       .click({ force: true })
     // OK
     cy

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -144,8 +144,8 @@ describe('GScan component', () => {
           workflows: createWorkflows([
             { name: 'a', status: WorkflowState.RUNNING },
             { name: 'b', status: WorkflowState.RUNNING },
-            { name: 'c', status: WorkflowState.HELD },
-            { name: 'd', status: WorkflowState.HELD },
+            { name: 'c', status: WorkflowState.PAUSED },
+            { name: 'd', status: WorkflowState.PAUSED },
             { name: 'e', status: WorkflowState.STOPPED }
           ]),
           expected: ['a', 'b', 'c', 'd', 'e']
@@ -161,11 +161,11 @@ describe('GScan component', () => {
           ]),
           expected: ['a', 'b', 'c', 'd', 'e']
         },
-        // running workflows are displayed first, then held, then the rest...
+        // running workflows are displayed first, then paused, then the rest...
         {
           workflows: createWorkflows([
             { name: 'a', status: WorkflowState.RUNNING },
-            { name: 'e', status: WorkflowState.HELD },
+            { name: 'e', status: WorkflowState.PAUSED },
             { name: 'c', status: WorkflowState.STOPPED },
             { name: 'b', status: WorkflowState.STOPPED },
             { name: 'd', status: WorkflowState.STOPPED }
@@ -175,8 +175,8 @@ describe('GScan component', () => {
         // sorted alphabetically within statuses
         {
           workflows: createWorkflows([
-            { name: 'e', status: WorkflowState.HELD },
-            { name: 'a', status: WorkflowState.HELD },
+            { name: 'e', status: WorkflowState.PAUSED },
+            { name: 'a', status: WorkflowState.PAUSED },
             { name: 'c', status: WorkflowState.STOPPED },
             { name: 'b', status: WorkflowState.RUNNING },
             { name: 'd', status: WorkflowState.STOPPED }
@@ -185,29 +185,29 @@ describe('GScan component', () => {
         },
         {
           workflows: createWorkflows([
-            { name: 'a', status: WorkflowState.HELD },
+            { name: 'a', status: WorkflowState.PAUSED },
             { name: 'c', status: WorkflowState.STOPPED },
             { name: 'b', status: WorkflowState.RUNNING },
             { name: 'd', status: WorkflowState.STOPPED },
-            { name: 'e', status: WorkflowState.HELD }
+            { name: 'e', status: WorkflowState.PAUSED }
           ]),
           expected: ['b', 'a', 'e', 'c', 'd']
         },
         // new statuses (stopping, error)
         {
           workflows: createWorkflows([
-            { name: 'a', status: WorkflowState.HELD },
+            { name: 'a', status: WorkflowState.PAUSED },
             { name: 'c', status: WorkflowState.STOPPED },
             { name: 'b', status: WorkflowState.RUNNING },
             { name: 'd', status: WorkflowState.STOPPED },
-            { name: 'e', status: WorkflowState.HELD },
-            { name: 'f', status: WorkflowState.HELD },
+            { name: 'e', status: WorkflowState.PAUSED },
+            { name: 'f', status: WorkflowState.PAUSED },
             { name: 'h', status: WorkflowState.STOPPING },
             { name: 'g', status: WorkflowState.ERROR },
             { name: 'j', status: WorkflowState.STOPPING },
             { name: 'i', status: WorkflowState.STOPPED },
             { name: 'k', status: WorkflowState.RUNNING },
-            { name: 'l', status: WorkflowState.HELD }
+            { name: 'l', status: WorkflowState.PAUSED }
           ]),
           expected: ['b', 'k', 'a', 'e', 'f', 'l', 'h', 'j', 'c', 'd', 'i', 'g']
         }
@@ -236,7 +236,7 @@ describe('GScan component', () => {
       {
         id: '1',
         name: 'new zealand',
-        status: WorkflowState.HELD.name,
+        status: WorkflowState.PAUSED.name,
         stateTotals: {
           [TaskState.FAILED.name]: 1
         }
@@ -283,7 +283,7 @@ describe('GScan component', () => {
           workflows
         }
       })
-      // read: give me all the workflows in RUNNING/HELD/STOPPED, no
+      // read: give me all the workflows in RUNNING/PAUSED/STOPPED, no
       //       matter their names or their tasks' states.
       // no workflow name filtered initially
       expect(wrapper.vm.searchWorkflows).to.equal('')
@@ -354,7 +354,7 @@ describe('GScan component', () => {
           },
           // enable only the ones we have in our test data set
           {
-            workflowStates: [WorkflowState.RUNNING, WorkflowState.HELD],
+            workflowStates: [WorkflowState.RUNNING, WorkflowState.PAUSED],
             expected: 2
           },
           // enable just one of the values we have in our test data set


### PR DESCRIPTION
Companion to https://github.com/cylc/cylc-flow/pull/4076

> **tldr:** We have separated the concepts of holding workflows and holding tasks within workflows.
>
> * Holding and releasing workflows is now play/pause.
> * Holding and releasing tasks is now hold/release.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (unreleased)
- [x] No documentation update required.