### PR TITLE
aotf: display mutation errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ None or N/A.
 
 ### Enhancements
 
+[#623](https://github.com/cylc/cylc-ui/pull/623) - Display errors from
+mutations.
+
 [#598](https://github.com/cylc/cylc-ui/pull/598) - Add mutation button
 
 [#530](https://github.com/cylc/cylc-ui/pull/530) - Display message triggers.


### PR DESCRIPTION
Attempt to detect errors from called mutations and present them to the user:

<img width="927" alt="Screenshot 2021-03-22 at 10 45 50" src="https://user-images.githubusercontent.com/16705946/111978711-23af1300-8afc-11eb-8635-9dce5300ff21.png">

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (out of time pre-beta, need some full system tests)
- [x] Appropriate change log entry included.
- [x] No documentation update required.