### PR TITLE
actions: fix release workflow

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set the package version
         run: |
-          npm version $VERSION
+          npm version ${{ github.event.inputs.version }}
 
       - name: Update "released on" date in changelog
         continue-on-error: true

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -516,7 +516,7 @@ export default {
     },
 
     /**
-     * Get number of tasks we have in a given state. The states are retrieved 
+     * Get number of tasks we have in a given state. The states are retrieved
      * from `latestStateTasks`, and the number of tasks in each state is from
      * the `stateTotals`. (`latestStateTasks` includes old tasks).
      *


### PR DESCRIPTION
Run 1 of the release action stage 1 failed:

https://github.com/cylc/cylc-ui/runs/2191797691?check_suite_focus=true

Is this used?

https://github.com/cylc/cylc-ui/blob/11b8f87d506fdf6fec1150f81d3892db966d8ffa/.github/workflows/create_release_pr.yml#L9-L12