### PR TITLE
aotf: niceify menu and pre-filter mutations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ None or N/A.
 ### Enhancements
 
 [#636](https://github.com/cylc/cylc-ui/pull/636) -
-Improve the appearence of mutation menus and display an expandable short list
+Improve the appearance of mutation menus and display an expandable short list
 of commands.
 
 [#616](https://github.com/cylc/cylc-ui/pull/616) - Alert the user if there are

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ None or N/A.
 
 ### Enhancements
 
+[#636](https://github.com/cylc/cylc-ui/pull/636) -
+Improve the appearence of mutation menus and display an expandable short list
+of commands.
+
 [#616](https://github.com/cylc/cylc-ui/pull/616) - Alert the user if there are
 any errors processing deltas.
 

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -163,7 +163,11 @@ export default {
       if (!this.expanded && shortList) {
         return this.mutations.filter(
           (x) => {
-            return shortList.indexOf(x[0].name) >= 0
+            return shortList.includes(x[0].name)
+          }
+        ).sort(
+          (x, y) => {
+            return shortList.indexOf(x[0].name) - shortList.indexOf(y[0].name)
           }
         )
       }
@@ -207,7 +211,9 @@ export default {
       this.type = type
       this.types = types
       this.tokens = tokens
-      this.mutations = mutations.sort()
+      this.mutations = mutations.sort(
+        (a, b) => a[0].name.localeCompare(b[0].name)
+      )
       this.x = event.clientX
       this.y = event.clientY
       this.$nextTick(() => {

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -19,60 +19,61 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <div class="c-mutation-menu-holder">
     <!-- dropdown menu -->
     <v-menu
+      offset-y
       class="c-mutation-menu"
       v-model="showMenu"
       :position-x="x"
       :position-y="y"
       v-on:show-mutations-menu="showMutationsMenu"
-      offset-y
       :disabled="!interactive"
+      @input="closeMenu"
     >
       <v-list
-        dense
         dark
         class="c-mutation-menu-list"
       >
-        <v-subheader>
-          <h2>
-            {{id}}
-          </h2>
-        </v-subheader>
-        <v-list-item-group
-          color="primary"
-          v-if="mutations"
+        <v-list-item
+          v-for="[mutation, requiresInfo] in displayMutations"
+          :key="mutation.name"
+          @click.stop="enact(mutation, requiresInfo)"
+          class="c-mutation"
         >
-          <v-list-item two-line
-            v-for="[mutation, requiresInfo] in mutations"
-            :key="mutation.name"
-            @click.stop="enact(mutation, requiresInfo)"
+          <v-list-item-avatar>
+            <v-icon large>{{ mutation._icon }}</v-icon>
+          </v-list-item-avatar>
+          <v-list-item-content>
+            <v-list-item-title v-html="mutation._title" />
+            <!--
+            don't use v-list-item-description here, vuetify will standardise
+            line heights and cuts off text that overspills this way we can
+            have the required number of lines of text
+            -->
+            <span class="c-description">{{ mutation._shortDescription }}</span>
+          </v-list-item-content>
+          <v-list-item-action>
+            <v-icon
+             medium
+             class="float-right"
+             @click.stop="openDialog(mutation)"
+            >
+              {{ icons.pencil }}
+            </v-icon>
+          </v-list-item-action>
+        </v-list-item>
+        <v-list-item
+          v-if="canExpand"
+        >
+          <v-list-item-content
+            @click="expandCollapse"
+            @click.stop.prevent
           >
-            <!--@click="callMutationFromContext(mutation)"-->
-            <v-list-item-icon>
-              <div style="font-size:0.5rem;">
-                <v-icon medium>{{ mutation._icon }}</v-icon>
-              </div>
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title>
-                <span>{{mutation._title}}</span>
-              </v-list-item-title>
-              <v-list-item-subtitle>
-                <span>{{mutation._shortDescription}}</span>
-              </v-list-item-subtitle>
-            </v-list-item-content>
-            <!-- This is how to add buttons for standard operations later -->
-            <v-list-item-action>
-              <v-btn
-                small rounded
-                color="primary"
-                dark
-                @click.stop="openDialog(mutation)"
-              >
-                Edit
-              </v-btn>
-            </v-list-item-action>
-          </v-list-item>
-        </v-list-item-group>
+            <v-btn
+              rounded
+            >
+              {{ expanded ? 'See Less' : 'See More' }}
+            </v-btn>
+          </v-list-item-content>
+        </v-list-item>
       </v-list>
     </v-menu>
     <v-dialog
@@ -97,6 +98,9 @@ import {
   mutate
 } from '@/utils/aotf'
 import Mutation from '@/components/cylc/Mutation'
+import {
+  mdiPencil
+} from '@mdi/js'
 
 export default {
   name: 'CylcObjectMenu',
@@ -115,15 +119,20 @@ export default {
 
   data () {
     return {
-      showMenu: false,
-      id: '',
-      mutations: [],
-      tokens: [],
-      x: 0,
-      y: 0,
+      allMutations: [],
       dialog: false,
       dialogMutation: null,
-      types: []
+      expanded: false,
+      id: '',
+      mutations: [],
+      showMenu: false,
+      tokens: [],
+      types: [],
+      x: 0,
+      y: 0,
+      icons: {
+        pencil: mdiPencil
+      }
     }
   },
 
@@ -135,15 +144,50 @@ export default {
     this.$eventBus.off('show-mutations-menu', this.showMutationsMenu)
   },
 
+  computed: {
+    canExpand () {
+      if (!this.mutations) {
+        return false
+      }
+      if (this.$workflowService.primaryMutations[this.type]) {
+        return true
+      }
+      return false
+    },
+
+    displayMutations () {
+      if (!this.mutations) {
+        return []
+      }
+      const shortList = this.$workflowService.primaryMutations[this.type]
+      if (!this.expanded && shortList) {
+        return this.mutations.filter(
+          (x) => {
+            return shortList.indexOf(x[0].name) >= 0
+          }
+        )
+      }
+      return this.mutations
+    }
+  },
+
   methods: {
     openDialog (mutation) {
       this.dialog = mutation
       this.dialogMutation = mutation
     },
 
+    closeMenu () {
+      this.expanded = false
+    },
+
     closeDialog () {
       this.dialog = null
       this.dialogMutation = null
+    },
+
+    expandCollapse () {
+      this.expanded = !this.expanded
     },
 
     /* Call a mutation using only the tokens for args. */
@@ -158,11 +202,12 @@ export default {
       this.showMenu = false
     },
 
-    showMutationsMenu ({ id, types, tokens, mutations, event }) {
+    showMutationsMenu ({ id, type, types, tokens, mutations, event }) {
       this.id = id
+      this.type = type
       this.types = types
       this.tokens = tokens
-      this.mutations = mutations
+      this.mutations = mutations.sort()
       this.x = event.clientX
       this.y = event.clientY
       this.$nextTick(() => {

--- a/src/components/cylc/cylcObject/plugin.js
+++ b/src/components/cylc/cylcObject/plugin.js
@@ -51,6 +51,7 @@ export default {
           )
           vnode.context.$eventBus.emit('show-mutations-menu', {
             id: cylcId,
+            type: type,
             types: types,
             tokens: tokens,
             mutations: componentMutations,

--- a/src/services/mock/workflow.service.mock.js
+++ b/src/services/mock/workflow.service.mock.js
@@ -19,6 +19,7 @@ import { checkpoint } from '@/services/mock/checkpoint.js'
 import { GQuery } from '@/services/gquery'
 import store from '@/store/index'
 import {
+  cylcObjects,
   mutationStatus,
   processMutations
 } from '@/utils/aotf'
@@ -111,6 +112,9 @@ const MUTATIONS = [
     ]
   }
 ]
+
+const primaryMutations = {}
+primaryMutations[cylcObjects.Workflow] = ['workflowMutation']
 
 const TYPES = []
 
@@ -229,6 +233,7 @@ class MockWorkflowService extends GQuery {
     this.mutations = MUTATIONS
     this.types = TYPES
     processMutations(this.mutations, this.types)
+    this.primaryMutations = primaryMutations
   }
 }
 

--- a/src/services/workflow.service.js
+++ b/src/services/workflow.service.js
@@ -27,11 +27,12 @@ import { DocumentNode } from 'graphql'
 /* eslint-enable no-unused-vars */
 
 import {
-  getMutationArgsFromTokens,
-  tokenise,
-  mutate,
   getIntrospectionQuery,
-  processMutations
+  getMutationArgsFromTokens,
+  mutate,
+  primaryMutations,
+  processMutations,
+  tokenise
 } from '@/utils/aotf'
 
 class WorkflowService extends GQuery {
@@ -61,6 +62,7 @@ class WorkflowService extends GQuery {
     this.mutations = null
     this.types = null
     this.associations = null
+    this.primaryMutations = primaryMutations
 
     this.loadMutations()
   }

--- a/src/styles/cylc/_aotf.scss
+++ b/src/styles/cylc/_aotf.scss
@@ -1,0 +1,15 @@
+.c-menu {
+  width: 25em;
+  max-height: 60vh;
+  overflow-y: scroll;
+
+  .c-title {
+    font-size: 1rem;
+  }
+
+  .c-description {
+    opacity: 0.7;
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -19,6 +19,7 @@
 
 @import "cylc/variables";
 
+@import "cylc/aotf";
 @import "cylc/dashboard";
 @import "cylc/drawer";
 @import "cylc/gscan";

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -87,6 +87,29 @@ export const cylcObjects = Object.freeze({
 })
 
 /**
+ * Most important mutations for each object type.
+ */
+export const primaryMutations = {}
+primaryMutations[cylcObjects.Workflow] = [
+  'play',
+  'pause',
+  'stop',
+  'reload'
+]
+primaryMutations[cylcObjects.CyclePoint] = [
+  'hold',
+  'release',
+  'trigger',
+  'kill'
+]
+primaryMutations[cylcObjects.Namespace] = [
+  'hold',
+  'release',
+  'trigger',
+  'kill'
+]
+
+/**
  * Cylc "objects" in hierarchy order.
  *
  * Note, this is the order they would appear in a tree representation.

--- a/tests/e2e/specs/aotf.js
+++ b/tests/e2e/specs/aotf.js
@@ -119,7 +119,7 @@ describe('Api On The Fly', () => {
               .should('have.length', 1)
               .get('.v-list-item__title:first')
               .should('have.text', test.mutationTitle)
-              .get('.v-list-item__subtitle:first')
+              .get('.c-description:first')
               .should('have.text', test.mutationText)
           })
         // click outside of the menu
@@ -191,7 +191,7 @@ describe('Api On The Fly', () => {
       // click on the first mutation
       cy
         .get('.c-mutation-menu-list:first')
-        .find('.v-list-item__action > .v-btn')
+        .find('.v-list-item__action > .v-icon')
         .should('exist')
         .should('be.visible')
         .click()
@@ -277,13 +277,26 @@ describe('Api On The Fly', () => {
         .get('.c-mutation-menu-list:first')
         .should('exist')
         .should('be.visible')
-        // the workflow should be the subject of the mutation selection
-        .find('h2:first')
-        .should('have.text', ' user|one ')
-        // it should list the four workflow mutations
+        // it should list the one default workflow mutation
+        // (see workflowService.primaryMutations)
         .get('.c-mutation-menu-list:first')
         .find('.v-list-item')
-        .should('have.length', 4)
+        .should('have.length', 2) // +1 because of the "see more" button
+        // toggle the menu to "see more" items
+        .find('.v-btn:first')
+        .click()
+        // it should now list the four workflow mutations
+        .get('.c-mutation-menu-list:first')
+        .find('.v-list-item')
+        .should('have.length', 5) // +1 because of the "see less" button
+        // toggle the menu to "see less" items
+        .find('.v-btn:first')
+        .click()
+        // it should list the one default workflow mutation
+        // (see workflowService.primaryMutations)
+        .get('.c-mutation-menu-list:first')
+        .find('.v-list-item')
+        .should('have.length', 2) // +1 because of the "see more" button
     })
   })
 })

--- a/tests/e2e/specs/mutation.js
+++ b/tests/e2e/specs/mutation.js
@@ -28,9 +28,7 @@ describe('Mutations component', () => {
       .click({ force: true })
     cy
       .get('.c-mutation-menu-list')
-      .find('span')
-      .contains('Edit')
-      .parent()
+      .find('.v-list-item__action')
       .click()
   }
   const submitMutationForms = () => {


### PR DESCRIPTION
closes #621 
addresses #622

Before:
<img width="688" alt="Screenshot 2021-03-31 at 15 22 22" src="https://user-images.githubusercontent.com/16705946/113160587-88254d00-9235-11eb-871e-47ac8b86bd02.png">

After:
<img width="688" alt="Screenshot 2021-03-31 at 15 22 27" src="https://user-images.githubusercontent.com/16705946/113160600-8a87a700-9235-11eb-98e4-5e441adbac66.png">

Lessons learned:

* The `dense` prop doesn't really help with space efficiency and makes the fonts go nasty.
* Easier to get layout/style right without using the `v-list` component, however, hard to get the hover effects standard without it.

Screengrab:

![Kapture 2021-03-31 at 17 03 21](https://user-images.githubusercontent.com/16705946/113175168-0fc58880-9243-11eb-990e-3757de96e374.gif)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
