### PR TITLE
toolbar: fix line break for narrow displays

### DIFF
--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -89,17 +89,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </template>
         <v-list class="pa-0">
           <v-list-item
-            v-bind:class="[
-              'py-0',
-              'px-8',
-              'ma-0',
-              'c-add-view',
-              `c-add-view-${ view.name }`
-            ]"
             :id="`toolbar-add-${ view.name }-view`"
-            @click="$listeners['add']"
             v-for="view in views"
-            v-bind:key="view.title"
+            :key="view.title"
+            @click="$listeners['add'](view.name)"
+            class="py-0 px-8 ma-0 c-add-view"
           >
             <v-list-item-icon>
               <v-icon>{{ view.icon }}</v-icon>

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -37,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </v-btn>
     <!-- title -->
     <v-toolbar-title
-      class="tertiary--text font-weight-light"
+      class="font-weight-light"
     >
       <span class="c-toolbar-title">{{ title }}</span>
     </v-toolbar-title>
@@ -81,23 +81,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       >
         <template v-slot:activator="{ on }">
           <a class="add-view" v-on="on">
-            {{ $t('Toolbar.addView') }} <v-icon color="#5995EB">{{ svgPaths.add }}</v-icon>
+            <v-icon class="icon" color="#5995EB">{{ svgPaths.add }}</v-icon>
+            <span class="label">
+              {{ $t('Toolbar.addView') }}
+            </span>
           </a>
         </template>
         <v-list class="pa-0">
           <v-list-item
-            class="py-0 px-8 ma-0"
-            @click="$listeners['add-tree']"
-            id="toolbar-add-tree-view"
+            v-bind:class="[
+              'py-0',
+              'px-8',
+              'ma-0',
+              'c-add-view',
+              `c-add-view-${ view.name }`
+            ]"
+            :id="`toolbar-add-${ view.name }-view`"
+            @click="$listeners['add']"
+            v-for="view in views"
+            v-bind:key="view.title"
           >
-            <v-list-item-title><v-icon>{{ svgPaths.tree }}</v-icon> Tree</v-list-item-title>
-          </v-list-item>
-          <v-list-item
-            class="py-0 px-8 ma-0"
-            @click="$listeners['add-mutations']"
-            id="toolbar-add-mutations-view"
-          >
-            <v-list-item-title><v-icon>{{ svgPaths.mutations }}</v-icon> Mutations</v-list-item-title>
+            <v-list-item-icon>
+              <v-icon>{{ view.icon }}</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>{{ view.title }}</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>
@@ -125,14 +132,14 @@ import { mapGetters, mapState } from 'vuex'
 import toolbar from '@/mixins/toolbar'
 import WorkflowState from '@/model/WorkflowState.model'
 import {
-  mdiViewList,
-  mdiPlay,
-  mdiPause,
-  mdiStop,
-  mdiPlusCircle,
-  mdiFileTree,
   mdiAppleKeyboardCommand,
-  mdiMicrosoftXboxControllerMenu
+  mdiFileTree,
+  mdiMicrosoftXboxControllerMenu,
+  mdiPause,
+  mdiPlay,
+  mdiPlusBoxMultiple,
+  mdiStop,
+  mdiViewList
 } from '@mdi/js'
 
 import {
@@ -150,20 +157,32 @@ export default {
     extended: false,
     // FIXME: remove local state once we have this data in the workflow - https://github.com/cylc/cylc-ui/issues/221
     svgPaths: {
-      list: mdiViewList,
+      add: mdiPlusBoxMultiple,
       hold: mdiPause,
+      list: mdiViewList,
+      menu: mdiMicrosoftXboxControllerMenu,
       run: mdiPlay,
-      stop: mdiStop,
-      tree: mdiFileTree,
-      mutations: mdiAppleKeyboardCommand,
-      add: mdiPlusCircle,
-      menu: mdiMicrosoftXboxControllerMenu
+      stop: mdiStop
     },
     expecting: {
       // store state from mutations in order to compute the "enabled" attrs
       paused: null,
       stop: null
-    }
+    },
+    views: [
+      {
+        name: 'tree',
+        title: 'Tree',
+        icon: mdiFileTree
+
+      },
+      {
+        name: 'mutations',
+        title: 'Mutations',
+        icon: mdiAppleKeyboardCommand
+
+      }
+    ]
   }),
 
   computed: {

--- a/src/styles/cylc/_toolbar.scss
+++ b/src/styles/cylc/_toolbar.scss
@@ -26,14 +26,20 @@
 .c-toolbar {
   background-color: map-get($grey, 'lighten-4') !important;
 
+  .v-toolbar__title {
+    // clear default padding (too much space on the left)
+    padding: 0!important;
+  }
+
   .c-toolbar-title, .add-view {
-    font-size: 1.4rem;
     color: $font-default-color;
     font-weight: map-get($font-weights, medium);
   }
 
   .c-toolbar-title {
-    padding-right: 12px;
+    font-size: 1.4rem;
+    // put some space between the title and the icons that follow
+    padding-right: 0.5rem;
   }
 
   span {
@@ -41,5 +47,18 @@
   }
 
   .add-view {
+    // force overflow onto a new line where we can hide it
+    height: 1.1em;
+    overflow: hidden;
+
+    .label {
+      float: left;
+      font-size: 1rem;
+      margin-right: 0.5em;
+    }
+
+    .icon {
+      float: right;
+    }
   }
 }

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <div>
     <CylcObjectMenu />
     <toolbar
-      v-on:add="this.clickAddView"
+      v-on:add="this.addView"
     ></toolbar>
     <div class="workflow-panel fill-height">
       <lumino
@@ -177,27 +177,6 @@ export default {
       }
       this.deltaSubscriptions.push(id)
       return id
-    },
-    /**
-     * Handle click events on elements designed to add new views.
-     *
-     * Clickable element must have the ID "c-add-view-<name-of-view>".
-     */
-    clickAddView (e) {
-      let ele = e.target
-      while (ele && !ele.classList.contains('c-add-view')) {
-        // go up the element tree until we find the c-add-view list item
-        ele = ele.parentElement
-      }
-      if (!ele) {
-        return
-      }
-      // const cls = ele.classList.filter(
-      const cls = Array.from(ele.classList.values()).filter(
-        (x) => { return x.startsWith('c-add-view-') }
-      )[0]
-      // extract the name of the view from the element id
-      this.addView(cls.replace('c-add-view-', ''))
     },
     /**
      * Add a new view widget.


### PR DESCRIPTION
Fix a small responsive display bug using a float trick.

Also had a go at centralising the view logic so we don't have to manually write out each view. One day views should be pluggable things that users could contribute.

Before:

![before](https://user-images.githubusercontent.com/16705946/113288921-713f3300-92e7-11eb-8faf-03904611f73f.gif)

After:

![after](https://user-images.githubusercontent.com/16705946/113296091-f2e78e80-92f0-11eb-8609-fd124befa448.gif)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.