### PR TITLE
Allow user to set the order of cycle points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ release.
 [#657](https://github.com/cylc/cylc-ui/pull/657) - Display a different icon, with
 a shadow underneath, for the Job component.
 
+[#658](https://github.com/cylc/cylc-ui/pull/658) - Allow user to set the order
+of cycle points.
+
 ### Fixes
 
 [#649](https://github.com/cylc/cylc-ui/pull/649) - Avoid re-sorting a

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -263,8 +263,13 @@ class CylcTree {
    * a workflow in Cylc.
    *
    * @param {?WorkflowNode} workflow
+   * @param {*} options
    */
-  constructor (workflow) {
+  constructor (workflow, options) {
+    const defaults = {
+      cyclePointsOrderDesc: true
+    }
+    this.options = Object.assign(defaults, options)
     this.lookup = new Map()
     if (!workflow) {
       this.root = {
@@ -335,10 +340,14 @@ class CylcTree {
         cyclePoint,
         (c) => c.node.name
       )
-      // cycle points are inserted in the reverse order, so we have to handle that sortedIndex will give you the
-      // wrong index (except when the list is empty). That's why we reverse the list first, to get the index, and
-      // find where it would be in the not-reversed list.
-      parent.children.splice(parent.children.length - insertIndex, 0, cyclePoint)
+      if (this.options.cyclePointsOrderDesc) {
+        // cycle points are inserted in the reverse order, so we have to handle that sortedIndex will give you the
+        // wrong index (except when the list is empty). That's why we reverse the list first, to get the index, and
+        // find where it would be in the not-reversed list.
+        parent.children.splice(parent.children.length - insertIndex, 0, cyclePoint)
+      } else {
+        parent.children.splice(insertIndex, 0, cyclePoint)
+      }
     }
   }
 

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -258,6 +258,7 @@ function sortedIndexBy (array, value, iteratee, comparator) {
  * @class
  */
 class CylcTree {
+  static DEFAULT_CYCLE_POINTS_ORDER_DESC = true
   /**
    * Create a tree with an initial root node, representing
    * a workflow in Cylc.
@@ -267,7 +268,7 @@ class CylcTree {
    */
   constructor (workflow, options) {
     const defaults = {
-      cyclePointsOrderDesc: false
+      cyclePointsOrderDesc: CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC
     }
     this.options = Object.assign(defaults, options)
     this.lookup = new Map()
@@ -341,9 +342,9 @@ class CylcTree {
         (c) => c.node.name
       )
       if (this.options.cyclePointsOrderDesc) {
-        parent.children.splice(insertIndex, 0, cyclePoint)
-      } else {
         parent.children.splice(parent.children.length - insertIndex, 0, cyclePoint)
+      } else {
+        parent.children.splice(insertIndex, 0, cyclePoint)
       }
     }
   }

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -334,8 +334,8 @@ class CylcTree {
     if (!this.lookup.has(cyclePoint.id)) {
       this.lookup.set(cyclePoint.id, cyclePoint)
       const parent = this.root
-      // reverse to put cyclepoints in ascending order (i.e. 1, 2, 3)
-      const cyclePoints = [...parent.children].reverse()
+      // when DESC mode, reverse to put cyclepoints in ascending order (i.e. 1, 2, 3)
+      const cyclePoints = this.options.cyclePointsOrderDesc ? [...parent.children].reverse() : parent.children
       const insertIndex = sortedIndexBy(
         cyclePoints,
         cyclePoint,

--- a/src/components/cylc/tree/cylc-tree.js
+++ b/src/components/cylc/tree/cylc-tree.js
@@ -267,7 +267,7 @@ class CylcTree {
    */
   constructor (workflow, options) {
     const defaults = {
-      cyclePointsOrderDesc: true
+      cyclePointsOrderDesc: false
     }
     this.options = Object.assign(defaults, options)
     this.lookup = new Map()
@@ -341,12 +341,9 @@ class CylcTree {
         (c) => c.node.name
       )
       if (this.options.cyclePointsOrderDesc) {
-        // cycle points are inserted in the reverse order, so we have to handle that sortedIndex will give you the
-        // wrong index (except when the list is empty). That's why we reverse the list first, to get the index, and
-        // find where it would be in the not-reversed list.
-        parent.children.splice(parent.children.length - insertIndex, 0, cyclePoint)
-      } else {
         parent.children.splice(insertIndex, 0, cyclePoint)
+      } else {
+        parent.children.splice(parent.children.length - insertIndex, 0, cyclePoint)
       }
     }
   }

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -75,7 +75,9 @@ export default {
      * contains hierarchy, while the GraphQL is flat-ish.
      * @type {null|CylcTree}
      */
-    tree: new CylcTree()
+    tree: new CylcTree(null, {
+      cyclePointsOrderDesc: localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : false
+    })
   }),
 
   /**

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -76,7 +76,7 @@ export default {
      * @type {null|CylcTree}
      */
     tree: new CylcTree(null, {
-      cyclePointsOrderDesc: localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : false
+      cyclePointsOrderDesc: localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC
     })
   }),
 

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -176,7 +176,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
             <v-layout row align-center wrap>
               <v-flex xs3>
-                <span>Cycle points descending?</span>
+                <span>Latest cycle point at top</span>
               </v-flex>
               <v-checkbox
                 v-model="cyclePointsOrderDesc">

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -179,7 +179,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <span>Latest cycle point at top</span>
               </v-flex>
               <v-checkbox
-                v-model="cyclePointsOrderDesc">
+                v-model="cyclePointsOrderDesc"
+                id="input-cyclepoints-order"
+              >
               </v-checkbox>
             </v-layout>
           </v-container>
@@ -202,6 +204,7 @@ import {
 import { mdiCog, mdiFormatFontSizeIncrease, mdiFormatFontSizeDecrease } from '@mdi/js'
 import Job from '@/components/cylc/Job'
 import JobState from '@/model/JobState.model'
+import CylcTree from '@/components/cylc/tree/cylc-tree'
 
 // TODO: update where user preferences are stored after #335
 
@@ -212,7 +215,7 @@ export default {
   },
   data () {
     return {
-      cyclePointsOrderDesc: true,
+      cyclePointsOrderDesc: CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC,
       svgPaths: {
         settings: mdiCog,
         increase: mdiFormatFontSizeIncrease,

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -131,47 +131,56 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <v-flex xs3>
                 <span>Colour Theme</span>
               </v-flex>
-                <v-radio-group v-model="jobTheme" column>
-                  <table class="c-job-state-table">
-                    <tr>
-                      <th>State</th>
-                      <th
-                        v-for="theme in jobThemes"
-                        v-bind:key="theme"
-                      >
-                        {{theme}}
-                      </th>
-                    </tr>
-                    <tr
+              <v-radio-group v-model="jobTheme" column>
+                <table class="c-job-state-table">
+                  <tr>
+                    <th>State</th>
+                    <th
+                      v-for="theme in jobThemes"
+                      :key="theme"
                     >
-                      <td></td>
-                      <td
-                        v-for="theme in jobThemes"
-                        v-bind:key="theme"
-                      >
-                        <v-radio
-                          :value="theme"
-                          v-bind:id="`input-job-theme-${theme}`"
-                        />
-                      </td>
-                    </tr>
-                    <tr
-                      v-for="state in jobStates"
-                      v-bind:key="state"
+                      {{theme}}
+                    </th>
+                  </tr>
+                  <tr
+                  >
+                    <td></td>
+                    <td
+                      v-for="theme in jobThemes"
+                      :key="theme"
                     >
-                      <td>{{state}}</td>
-                      <td
-                        v-for="theme in jobThemes"
-                        v-bind:key="theme"
-                        v-bind:class="[`job_theme--${theme}`, 'job_theme_override']"
-                      >
-                        <job :status="state" />
-                      </td>
-                    </tr>
-                  </table>
-                </v-radio-group>
+                      <v-radio
+                        :value="theme"
+                        :id="`input-job-theme-${theme}`"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    v-for="state in jobStates"
+                    :key="state"
+                  >
+                    <td>{{state}}</td>
+                    <td
+                      v-for="theme in jobThemes"
+                      :key="theme"
+                      :class="[`job_theme--${theme}`, 'job_theme_override']"
+                    >
+                      <job :status="state" />
+                    </td>
+                  </tr>
+                </table>
+              </v-radio-group>
               <v-flex xs9>
               </v-flex>
+            </v-layout>
+
+            <v-layout row align-center wrap>
+              <v-flex xs3>
+                <span>Cycle points descending?</span>
+              </v-flex>
+              <v-checkbox
+                v-model="cyclePointsOrderDesc">
+              </v-checkbox>
             </v-layout>
           </v-container>
         </v-form>
@@ -203,6 +212,7 @@ export default {
   },
   data () {
     return {
+      cyclePointsOrderDesc: true,
       svgPaths: {
         settings: mdiCog,
         increase: mdiFormatFontSizeIncrease,
@@ -225,6 +235,11 @@ export default {
       title: this.getPageTitle('App.userProfile')
     }
   },
+  mounted () {
+    if (localStorage.cyclePointsOrderDesc) {
+      this.cyclePointsOrderDesc = JSON.parse(localStorage.cyclePointsOrderDesc)
+    }
+  },
   methods: {
     resetFontSize,
     decreaseFontSize,
@@ -235,6 +250,10 @@ export default {
   watch: {
     jobTheme: function (theme) {
       this.setJobTheme(theme)
+    },
+    cyclePointsOrderDesc (newOrder) {
+      localStorage.setItem('cyclePointsOrderDesc', newOrder)
+      this.cyclePointsOrderDesc = newOrder
     }
   }
 }

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -100,7 +100,9 @@ export default {
      *
      * @type {CylcTree}
      */
-    tree: new CylcTree(),
+    tree: new CylcTree(null, {
+      cyclePointsOrderDesc: localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : false
+    }),
     isLoading: true,
     // the widgets added to the view
     /**

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -101,7 +101,7 @@ export default {
      * @type {CylcTree}
      */
     tree: new CylcTree(null, {
-      cyclePointsOrderDesc: localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : false
+      cyclePointsOrderDesc: localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC
     }),
     isLoading: true,
     // the widgets added to the view

--- a/tests/e2e/specs/userprofile.js
+++ b/tests/e2e/specs/userprofile.js
@@ -21,6 +21,7 @@ import {
   resetFontSize,
   INITIAL_FONT_SIZE
 } from '@/utils/font-size'
+import CylcTree from '@/components/cylc/tree/cylc-tree'
 
 describe('User Profile', () => {
   it('Visits the user profile', () => {
@@ -103,5 +104,15 @@ describe('User Profile', () => {
             expect($fill1).not.to.equal($fill2)
           })
       })
+  })
+  it('Sets the cycle points order', () => {
+    cy.visit('/#/user-profile')
+    cy.get('#input-cyclepoints-order')
+      .should('have.attr', 'aria-checked', JSON.stringify(CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC))
+    // change the cycle points order
+    cy.get('#input-cyclepoints-order')
+      .click({ force: true })
+    cy.get('#input-cyclepoints-order')
+      .should('have.attr', 'aria-checked', JSON.stringify(!CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC))
   })
 })

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -186,42 +186,42 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|2`)
       expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|1`)
     })
-    it('Should add cycle points sorted ASC by default', () => {
+    it('Should add cycle points sorted DESC by default', () => {
       const cyclePoint1 = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
-        cyclePoint: '2'
+        cyclePoint: '1'
       })
       const cyclePoint2 = createCyclePointNode({
         id: `${WORKFLOW_ID}|2|root`,
-        cyclePoint: '1'
+        cyclePoint: '2'
       })
       cylcTree.addCyclePoint(cyclePoint1)
       expect(cylcTree.root.children.length).to.equal(1)
-      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
+      expect(cylcTree.root.children[0].id).to.equal(cyclePoint1.id)
 
       cylcTree.addCyclePoint(cyclePoint2)
       expect(cylcTree.root.children.length).to.equal(2)
-      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
-      expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|2`)
+      expect(cylcTree.root.children[0].id).to.equal(cyclePoint2.id)
+      expect(cylcTree.root.children[1].id).to.equal(cyclePoint1.id)
     })
-    it('Should add cycle points sorted DESC if cyclePointsOrderDesc', () => {
-      cylcTree.options.cyclePointsOrderDesc = true
+    it('Should add cycle points sorted ASC if !cyclePointsOrderDesc', () => {
+      cylcTree.options.cyclePointsOrderDesc = !CylcTree.DEFAULT_CYCLE_POINTS_ORDER_DESC
       const cyclePoint1 = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
-        cyclePoint: '2'
+        cyclePoint: '1'
       })
       const cyclePoint2 = createCyclePointNode({
         id: `${WORKFLOW_ID}|2|root`,
-        cyclePoint: '1'
+        cyclePoint: '2'
       })
-      cylcTree.addCyclePoint(cyclePoint1)
-      expect(cylcTree.root.children.length).to.equal(1)
-      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
-
       cylcTree.addCyclePoint(cyclePoint2)
+      expect(cylcTree.root.children.length).to.equal(1)
+      expect(cylcTree.root.children[0].id).to.equal(cyclePoint2.id)
+
+      cylcTree.addCyclePoint(cyclePoint1)
       expect(cylcTree.root.children.length).to.equal(2)
-      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|2`)
-      expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|1`)
+      expect(cylcTree.root.children[0].id).to.equal(cyclePoint1.id)
+      expect(cylcTree.root.children[1].id).to.equal(cyclePoint2.id)
     })
     it('Should not add a cycle point twice', () => {
       const cyclePoint1 = createCyclePointNode({

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -37,7 +37,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      const cylcTree = new CylcTree(workflow)
+      const cylcTree = new CylcTree(workflow, {})
       const cyclePoint = createCyclePointNode({
         id: 'cylc|workflow|1',
         cyclePoint: '1'
@@ -49,7 +49,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      const cylcTree = new CylcTree(workflow)
+      const cylcTree = new CylcTree(workflow, {})
       const cyclePoints = ['1', '10', '100', '2', '3', '4']
       for (const cyclePoint of cyclePoints) {
         cylcTree.addCyclePoint(createCyclePointNode({
@@ -67,7 +67,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      const cylcTree = new CylcTree(workflow)
+      const cylcTree = new CylcTree(workflow, {})
       cylcTree.addCyclePoint(createCyclePointNode({
         id: 'cylc|workflow|1',
         cyclePoint: '1'
@@ -123,7 +123,7 @@ describe('CylcTree', () => {
   it('Should create a tree with a given workflow', () => {
     const cylcTree = new CylcTree(createWorkflowNode({
       id: WORKFLOW_ID
-    }))
+    }), {})
     expect(cylcTree.root.id).to.equal(WORKFLOW_ID)
   })
   it('Should create a tree without a workflow', () => {
@@ -145,7 +145,7 @@ describe('CylcTree', () => {
   it('Should clear the tree and lookup map', () => {
     const cylcTree = new CylcTree(createWorkflowNode({
       id: WORKFLOW_ID
-    }))
+    }), {})
     cylcTree.lookup.set('name', 'abc')
     cylcTree.clear()
     expect(cylcTree.lookup.size).to.equal(0)
@@ -154,7 +154,7 @@ describe('CylcTree', () => {
   it('Should return true for isEmpty if empty, false otherwise', () => {
     const cylcTree = new CylcTree(createWorkflowNode({
       id: '1'
-    }))
+    }), {})
     expect(cylcTree.isEmpty()).to.equal(false)
     cylcTree.clear()
     expect(cylcTree.isEmpty()).to.equal(true)
@@ -166,7 +166,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      cylcTree = new CylcTree(workflow)
+      cylcTree = new CylcTree(workflow, {})
     })
     it('Should add cycle points', () => {
       const cyclePoint1 = createCyclePointNode({
@@ -294,7 +294,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      cylcTree = new CylcTree(workflow)
+      cylcTree = new CylcTree(workflow, {})
       cyclePoint1 = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
@@ -484,7 +484,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      cylcTree = new CylcTree(workflow)
+      cylcTree = new CylcTree(workflow, {})
       cyclePoint = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
@@ -730,7 +730,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      cylcTree = new CylcTree(workflow)
+      cylcTree = new CylcTree(workflow, {})
       cyclePoint = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
@@ -902,7 +902,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      const cylcTree = new CylcTree(workflow)
+      const cylcTree = new CylcTree(workflow, {})
       cylcTree.addCyclePoint(createCyclePointNode({
         id: 'cylc|workflow|1',
         cyclePoint: '1'
@@ -961,7 +961,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      cylcTree = new CylcTree(workflow)
+      cylcTree = new CylcTree(workflow, {})
       cyclePoint = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'
@@ -1025,7 +1025,7 @@ describe('CylcTree', () => {
       const workflow = createWorkflowNode({
         id: WORKFLOW_ID
       })
-      cylcTree = new CylcTree(workflow)
+      cylcTree = new CylcTree(workflow, {})
       cyclePoint1 = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,
         cyclePoint: '1'

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -118,6 +118,31 @@ describe('CylcTree', () => {
         expect(children[index].node.name).to.equal(expected)
       })
     })
+    it('should sort cyclepoints ascending correctly', () => {
+      const workflow = createWorkflowNode({
+        id: WORKFLOW_ID
+      })
+      const cylcTree = new CylcTree(workflow, {
+        cyclePointsOrderDesc: false
+      })
+      cylcTree.addCyclePoint(createCyclePointNode({
+        id: 'cylc|workflow|7',
+        cyclePoint: '7'
+      }))
+      cylcTree.addCyclePoint(createCyclePointNode({
+        id: 'cylc|workflow|5',
+        cyclePoint: '5'
+      }))
+      cylcTree.addCyclePoint(createCyclePointNode({
+        id: 'cylc|workflow|6',
+        cyclePoint: '6'
+      }))
+      const expectedChildren = ['5', '6', '7']
+      const cyclePoints = cylcTree.root.children
+      expectedChildren.forEach((expected, index) => {
+        expect(cyclePoints[index].node.name).to.equal(expected)
+      })
+    })
   })
   const WORKFLOW_ID = 'cylc|workflow'
   it('Should create a tree with a given workflow', () => {

--- a/tests/unit/components/cylc/tree/tree.spec.js
+++ b/tests/unit/components/cylc/tree/tree.spec.js
@@ -186,6 +186,43 @@ describe('CylcTree', () => {
       expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|2`)
       expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|1`)
     })
+    it('Should add cycle points sorted ASC by default', () => {
+      const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
+        cyclePoint: '2'
+      })
+      const cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
+        cyclePoint: '1'
+      })
+      cylcTree.addCyclePoint(cyclePoint1)
+      expect(cylcTree.root.children.length).to.equal(1)
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
+
+      cylcTree.addCyclePoint(cyclePoint2)
+      expect(cylcTree.root.children.length).to.equal(2)
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
+      expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|2`)
+    })
+    it('Should add cycle points sorted DESC if cyclePointsOrderDesc', () => {
+      cylcTree.options.cyclePointsOrderDesc = true
+      const cyclePoint1 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|1|root`,
+        cyclePoint: '2'
+      })
+      const cyclePoint2 = createCyclePointNode({
+        id: `${WORKFLOW_ID}|2|root`,
+        cyclePoint: '1'
+      })
+      cylcTree.addCyclePoint(cyclePoint1)
+      expect(cylcTree.root.children.length).to.equal(1)
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|1`)
+
+      cylcTree.addCyclePoint(cyclePoint2)
+      expect(cylcTree.root.children.length).to.equal(2)
+      expect(cylcTree.root.children[0].id).to.equal(`${WORKFLOW_ID}|2`)
+      expect(cylcTree.root.children[1].id).to.equal(`${WORKFLOW_ID}|1`)
+    })
     it('Should not add a cycle point twice', () => {
       const cyclePoint1 = createCyclePointNode({
         id: `${WORKFLOW_ID}|1|root`,


### PR DESCRIPTION
These changes close #333 

A draft for discussion I think. @oliver-sanders , @hjoliver I've added a setting under the User Profile page. If you change that setting, then reload the tree view (or just navigate after you've set the value), then it should be displayed with the correct order.

<!--
This PR does not include tests, and the code is simply doing the simplest approach I could think of. Pending things I think:

- [ ] where should the setting for the tree view be set? In the user preference? After looking at #87 I had thought about adding it to the Table Widget menu, but that would probably apply to each tree widget? So I opted for a global setting
- [ ] we can make it reactive, so that any tabs open would re-render the whole tree, but I think that could lead to nasty reactivity errors if not done well (i.e. it might take a few iterations to get everything right), or we can leave it so that users have to refresh browser, or enter the workflow view to re-build the tree?
- [ ] I had not idea how to call that setting, so I just went with Cycle points descending (sorry, ~3PM Friday brain is not really sharp :grimacing: :coffee:  ) but perhaps we should have instead a section for the tree view if we want more values, or maybe a better name/description?

Feel free to check out and test if the tree view is indeed showing the items in the correct order, or if there's anything else that's pending (for this PR, and also #333, I set this PR as "closes #333" as I think this is the last bit missing).
-->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
