### PR TITLE
tree: job icon size

### DIFF
--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -76,7 +76,7 @@ $visible-outputs: 5;
       }
     }
 
-    .c-task {
+    .c-task, .c-job {
       font-size: 1.2em;
     }
   }


### PR DESCRIPTION
Boost the job icon size in the tree view 20% (inline with the task icon).

The icons were a bit small, especially now we have the multi job icon.

*before*
<img width="287" alt="Screenshot 2021-05-14 at 14 50 02" src="https://user-images.githubusercontent.com/16705946/118280409-1727b500-b4c4-11eb-8229-c5852771a391.png">

*after*
<img width="287" alt="Screenshot 2021-05-14 at 14 49 53" src="https://user-images.githubusercontent.com/16705946/118280405-168f1e80-b4c4-11eb-973d-071cd5e041f5.png">


**Requirements check-list**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? very minor change)
- [x] No documentation update required.