### PR TITLE
Remove flex-basis and flex-wrap from gscan

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -118,7 +118,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :class="getWorkflowClass(scope.node.node)"
             >
               <v-list-item-title>
-                <v-layout align-center align-content-center d-flex flex-wrap>
+                <v-layout align-center align-content-center d-flex flex-nowrap>
                   <v-flex
                     v-if="scope.node.type === 'workflow'"
                     class="c-gscan-workflow-name"

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -30,10 +30,8 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        flex-basis: 60%;
       }
       .c-gscan-workflow-states {
-        flex-basis: 40%;
         span.empty-state {
           opacity: 0.2;
         }


### PR DESCRIPTION
This is a small change with no associated Issue.

Another iteration on responsiveness for GScan. Noticed this while testing GScan for recent PR's. The flex-basis ratio of `40/60` worked well in the past. But after we got more states displayed in GScan, it didn't work that well.

![image](https://user-images.githubusercontent.com/304786/120250341-defce080-c2d1-11eb-8c6e-531f31609143.png)


The reason is that 5 states, with the icon now bigger, passes the flex-basis limit we set. That, combined with flex-wrap, cause the GScan workflow row to grow.

Tested with a really long workflow name, and hacking the code to allow several states. Then adding more than 5 states. Screenshots below show what it looks like after this PR.

![Screenshot from 2021-06-01 11-48-33](https://user-images.githubusercontent.com/304786/120250143-35b5ea80-c2d1-11eb-92d1-2d59edb364a1.png)
![Screenshot from 2021-06-01 11-52-08](https://user-images.githubusercontent.com/304786/120250146-36e71780-c2d1-11eb-8366-1e6829afce18.png)
![Screenshot from 2021-06-01 11-52-39](https://user-images.githubusercontent.com/304786/120250148-377fae00-c2d1-11eb-8ee7-c367fc6327a5.png)
![Screenshot from 2021-06-01 11-56-35](https://user-images.githubusercontent.com/304786/120250150-38184480-c2d1-11eb-9466-e2d98b950ac0.png)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
