### PR TITLE
aotf: make mutation menu directive reactive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ of cycle points.
 
 ### Fixes
 
+[#691](https://github.com/cylc/cylc-ui/pull/691) -
+Fix bug that could cause mutations to be run against the wrong workflow.
+
 [#649](https://github.com/cylc/cylc-ui/pull/649) - Avoid re-sorting a
 sorted array, instead adding a new element in its sorted index (respecting
 locale, and numeric on).


### PR DESCRIPTION
* closes #690

Sadly not possible to test at the moment as we would require a second workflow.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.