### PR TITLE
Use WorkflowState to control Tree view state, ignoring the shutdown property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,6 +137,13 @@ in the tree view structure.
 
 [#554](https://github.com/cylc/cylc-ui/pull/554) - Fix icons in the Dashboard.
 
+[#556](https://github.com/cylc/cylc-ui/issues/556) - UI sees old and new state
+of a re-run flow.
+
+[#700](https://github.com/cylc/cylc-ui/issues/700) - Use WorkflowState to control Tree view state,
+ignoring the shutdown property. This fixes console messages like "Received a delta before
+the workflow initial data burst".
+
 ### Documentation
 
 None.

--- a/src/components/cylc/common/deltas.js
+++ b/src/components/cylc/common/deltas.js
@@ -23,7 +23,6 @@
 /**
  * @typedef {Object} Deltas
  * @property {string} id
- * @property {boolean} shutdown
  * @property {?DeltasAdded} added
  * @property {?DeltasUpdated} updated
  * @property {?DeltasPruned} pruned

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -124,7 +124,6 @@ subscription OnWorkflowTreeDeltasData ($workflowId: ID) {
 
 fragment WorkflowTreeDeltas on Deltas {
   id
-  shutdown
   added {
     ...WorkflowTreeAddedData
   }
@@ -204,7 +203,6 @@ subscription GscanSubscriptionQuery {
 
 fragment GScanTreeDeltas on Deltas {
   id
-  shutdown
   added {
     ...GscanAddedData
   }
@@ -243,7 +241,6 @@ const DASHBOARD_DELTAS_SUBSCRIPTION = gql`
 subscription DashboardSubscriptionQuery {
   deltas (stripNull: true) {
     id
-    shutdown
     added {
       workflow {
         ...WorkflowData
@@ -272,7 +269,6 @@ const WORKFLOWS_TABLE_DELTAS_SUBSCRIPTION = gql`
 subscription WorkflowsTableQuery {
   deltas (stripNull: true) {
     id
-    shutdown
     added {
       workflow {
         ...WorkflowData


### PR DESCRIPTION
These changes:

- close #689 
- close #556 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
