### PR TITLE
Use an array of enums to define order in the Dashboard

### DIFF
--- a/src/model/WorkflowState.model.js
+++ b/src/model/WorkflowState.model.js
@@ -29,7 +29,7 @@ import {
 /**
  * Cylc valid workflow states.
  */
-class WorkflowState extends Enumify {
+export class WorkflowState extends Enumify {
   // NOTE: the order the enum values are created here is used in the UI for sorting
   static RUNNING = new WorkflowState('running', mdiPlayCircle)
   static PAUSED = new WorkflowState('paused', mdiPauseCircle)
@@ -50,5 +50,19 @@ class WorkflowState extends Enumify {
     this.icon = icon
   }
 }
+
+/**
+ * Workflow states ordered for display purposes.
+ * @type {Map} - Using a map to prevent more unexpected sorting issues
+ * @see https://stackoverflow.com/questions/5525795/does-javascript-guarantee-object-property-order/38218582#38218582
+ */
+export const WorkflowStateOrder = new Map([
+  [WorkflowState.RUNNING.name, 0],
+  [WorkflowState.PAUSED.name, 0],
+  [WorkflowState.STOPPING.name, 0],
+  [WorkflowState.STOPPED.name, 1],
+  [WorkflowState.INSTALLED.name, 2],
+  [WorkflowState.ERROR.name, 3]
+])
 
 export default WorkflowState

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -30,6 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :loading="isLoading"
           hide-default-footer
           hide-default-header
+          id="dashboard-workflows"
         >
           <v-progress-linear slot="progress" color="grey" indeterminate></v-progress-linear>
           <!-- TODO: remove it if the linter is fixed later #510 -->
@@ -176,7 +177,7 @@ import pageMixin from '@/mixins/index'
 import subscriptionViewMixin from '@/mixins/subscriptionView'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import { createUrl } from '@/utils/urls'
-import WorkflowState from '@/model/WorkflowState.model'
+import { WorkflowState, WorkflowStateOrder } from '@/model/WorkflowState.model'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
 import { DASHBOARD_DELTAS_SUBSCRIPTION } from '@/graphql/queries'
 
@@ -247,7 +248,7 @@ export default {
           return acc
         }, {})
       return WorkflowState.enumValues
-        .sort((left, right) => left.name.localeCompare(right.name))
+        .sort((left, right) => WorkflowStateOrder.get(left) - WorkflowStateOrder.get(right))
         .map(state => {
           return {
             text: state.name.charAt(0).toUpperCase() + state.name.slice(1),

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { WorkflowStateOrder } from '@/model/WorkflowState.model'
+
 describe('Dashboard', () => {
   it('Displays the Dashboard link as active on the left sidebar menu', () => {
     cy.visit('/#/')
@@ -30,6 +32,17 @@ describe('Dashboard', () => {
       .get('.c-dashboard .v-icon:first')
       .find('svg')
       .should('be.visible')
+  })
+  it.only('Should display the states in order', () => {
+    cy.visit('/#/')
+    cy
+      .get('#dashboard-workflows table tbody tr')
+      .first()
+      .find('td')
+      .then($tdElement => {
+        return $tdElement[1].textContent.toLowerCase()
+      })
+      .should('equal', [...WorkflowStateOrder.entries()][0][0])
   })
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
 })


### PR DESCRIPTION
These changes close #693 

The fix uses an array of enums to sort the states displayed in the Dashboard view. I copied this array from this PR that is currently under review: #703 

Pushing to 0.6.0 since I think we are releasing 0.5.0 now and this would take a while to review.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No changelog required (no changes to users)
- [x] No documentation update required.
