### PR TITLE
Jupyter server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ release.
 
 [#502](https://github.com/cylc/cylc-ui/pull/502) - Hierarchical GScan.
 
+[#711](https://github.com/cylc/cylc-ui/pull/711) -
+Support Jupyter Server conversion. (the CylcUIServer has been converted
+to a Jupyter Server extension).
+
 ### Fixes
 
 -------------------------------------------------------------------------------

--- a/src/graphql/graphiql.js
+++ b/src/graphql/graphiql.js
@@ -18,7 +18,7 @@
 // Code related to GraphiQL
 
 import { parse } from 'graphql'
-import { createGraphQLUrls } from '@/graphql/index'
+import { createGraphQLUrls, getCylcHeaders } from '@/graphql/index'
 
 // TODO: https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher/issues/16
 //       the functions hasSubscriptionOperation and graphQLFetcher are both from
@@ -113,7 +113,8 @@ function fallbackGraphQLFetcher (graphQLParams) {
       method: 'post',
       headers: {
         Accept: 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...getCylcHeaders()
       },
       body: JSON.stringify(graphQLParams),
       credentials: 'include'

--- a/src/mixins/graphql.js
+++ b/src/mixins/graphql.js
@@ -51,7 +51,7 @@ export default {
      * @return {string} - the Workflow ID used in this view
      */
     workflowId () {
-      return `${this.user.username}|${this.workflowName}`
+      return `${this.user.owner}|${this.workflowName}`
     },
     /**
      * GraphQL query variables.

--- a/src/model/User.model.js
+++ b/src/model/User.model.js
@@ -24,11 +24,17 @@
  * @property {string} server - server URL
  */
 export default class User {
-  constructor (username, groups, created, admin, server) {
+  constructor (username, groups, created, admin, server, owner) {
+    // the authenticated user
+    // (full info only available when authenticated via the hub)
     this.username = username
     this.groups = groups
     this.created = created
     this.admin = admin
-    this.server = server
+    this.server = server || '?' // server can be unset
+    // the UIS owner
+    // (i.e. the user who's workflows we are looking at)
+    // (this might not be the authenticated user for multi-user setups)
+    this.owner = owner
   }
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -26,7 +26,14 @@ class UserService {
    */
   getUserProfile () {
     return axios.get(createUrl('userprofile')).then((response) => {
-      return new User(response.data.name, response.data.groups, response.data.created, response.data.admin, response.data.server)
+      return new User(
+        response.data.name,
+        response.data.groups,
+        response.data.created,
+        response.data.admin,
+        response.data.server,
+        response.data.owner
+      )
     })
   }
 }

--- a/tests/unit/mixins/graphql.spec.js
+++ b/tests/unit/mixins/graphql.spec.js
@@ -46,7 +46,7 @@ describe('GraphQL mixin', () => {
     })
     const variables = component.vm.variables
     const expected = {
-      workflowId: `${user.username}|${workflowName}`
+      workflowId: `${user.owner}|${workflowName}`
     }
     expect(variables).to.deep.equal(expected)
   })


### PR DESCRIPTION
jupyter_server: support Cylc UIS Jupyter Server extension
    
* https://github.com/cylc/cylc-uiserver/pull/230
* The UIS is now a Jupyter Server extension.
* The endpoint is now `cylc/#/` rather than `#/`
* Authentication via token/cookie is now supported.
* Sets XSRF header to support new hubless single-user mode.
* closes https://github.com/cylc/cylc-ui/issues/679


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] Docs: https://github.com/cylc/cylc-doc/pull/285