### PR TITLE
Add back macos to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,8 @@ jobs:
             browser: firefox
           - os: ubuntu-latest
             browser: chrome
-          # TODO: uncomment after #590
-          # - os: macos-latest
-          #   browser: edge
+          - os: macos-latest
+            browser: edge
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
These changes close #590 

We've updated to yarn v3. I think macos build should work fine now? It passed on my fork's GH actions. I'll retrigger it a couple times now to confirm it's working OK.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
