### PR TITLE
Disable unauthorized buttons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ release.
 Support Jupyter Server conversion. (the CylcUIServer has been converted
 to a Jupyter Server extension).
 
+[#728](https://github.com/cylc/cylc-ui/pull/728) -
+Display authorized mutations in the User Profile and disable unauthorized
+mutations in the menu.
+
 ### Fixes
 
 -------------------------------------------------------------------------------

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div class="c-environment-info">
         <v-chip outlined color="grey lighten-1" text-color="grey darken-4">{{ user }}</v-chip>
         <span class="at">@</span>
-        <v-chip outlined color="grey lighten-1" text-color="grey darken-4">{{ environment }}</v-chip>
+        <v-chip outlined color="grey lighten-1" text-color="grey darken-4">authbranch</v-chip>
       </div>
     </v-layout>
   </v-list-item-action-text>

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div class="c-environment-info">
         <v-chip outlined color="grey lighten-1" text-color="grey darken-4">{{ user }}</v-chip>
         <span class="at">@</span>
-        <v-chip outlined color="grey lighten-1" text-color="grey darken-4">authbranch</v-chip>
+        <v-chip outlined color="grey lighten-1" text-color="grey darken-4">{{ environment }}</v-chip>
       </div>
     </v-layout>
   </v-list-item-action-text>

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-list-item
           v-for="[mutation, requiresInfo, authorised] in displayMutations"
           :key="mutation.name"
-          :disable=!authorised
+          :disabled=!authorised
           @click.stop="enact(mutation, requiresInfo)"
           class="c-mutation"
         >
@@ -47,7 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <!--
             don't use v-list-item-description here, vuetify will standardise
             line heights and cuts off text that overspills this way we can
-            have the required number of lines of text
+            have the required number of lines of text.
             -->
             <span class="c-description">{{ mutation._shortDescription }}</span>
           </v-list-item-content>
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             @click="expandCollapse"
             @click.stop.prevent
           >
-            <v-btn
+            <v-btn id="lessMoreButton"
               rounded
             >
               {{ expanded ? 'See Less' : 'See More' }}
@@ -160,15 +160,15 @@ export default {
     },
     authorizedMutations () {
       return this.mutations
-        .filter(mutation => this.userPermissions.includes(mutation[0].name.toLowerCase()))
         .map(mutation => {
-          mutation[2] = true
+          if (this.userPermissions.includes(mutation[0].name.toLowerCase())) {
+            mutation[2] = true
+          }
           return mutation
         })
     },
     displayMutations () {
-      if (!this.mutations) {
-      // || this.user.permissions.length < 2) {
+      if (!this.mutations || this.user.permissions.length < 2) {
         return []
       }
       const shortList = this.$workflowService.primaryMutations[this.type]
@@ -188,25 +188,6 @@ export default {
     }
   },
 
-  //   displayMutations () {
-  //     if (!this.mutations) {
-  //       return []
-  //     }
-  //     const shortList = this.$workflowService.primaryMutations[this.type]
-  //     if (!this.expanded && shortList) {
-  //       return this.mutations.filter(
-  //         (x) => {
-  //           return shortList.includes(x[0].name)
-  //         }
-  //       ).sort(
-  //         (x, y) => {
-  //           return shortList.indexOf(x[0].name) - shortList.indexOf(y[0].name)
-  //         }
-  //       )
-  //     }
-  //     return this.mutations
-  //   }
-  // },
   methods: {
     openDialog (mutation) {
       this.dialog = mutation

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             @click="expandCollapse"
             @click.stop.prevent
           >
-            <v-btn id="lessMoreButton"
+            <v-btn id="less-more-button"
               rounded
             >
               {{ expanded ? 'See Less' : 'See More' }}

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -167,7 +167,8 @@ export default {
         })
     },
     displayMutations () {
-      if (!this.mutations || this.user.permissions.length < 2) {
+      if (!this.mutations) {
+      // || this.user.permissions.length < 2) {
         return []
       }
       const shortList = this.$workflowService.primaryMutations[this.type]
@@ -187,6 +188,25 @@ export default {
     }
   },
 
+  //   displayMutations () {
+  //     if (!this.mutations) {
+  //       return []
+  //     }
+  //     const shortList = this.$workflowService.primaryMutations[this.type]
+  //     if (!this.expanded && shortList) {
+  //       return this.mutations.filter(
+  //         (x) => {
+  //           return shortList.includes(x[0].name)
+  //         }
+  //       ).sort(
+  //         (x, y) => {
+  //           return shortList.indexOf(x[0].name) - shortList.indexOf(y[0].name)
+  //         }
+  //       )
+  //     }
+  //     return this.mutations
+  //   }
+  // },
   methods: {
     openDialog (mutation) {
       this.dialog = mutation

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -33,13 +33,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="c-mutation-menu-list"
       >
         <v-list-item
-          v-for="[mutation, requiresInfo] in displayMutations"
+          v-for="[mutation, requiresInfo, authorised] in displayMutations"
           :key="mutation.name"
+          :disable=!authorised
           @click.stop="enact(mutation, requiresInfo)"
           class="c-mutation"
         >
           <v-list-item-avatar>
-            <v-icon large>{{ mutation._icon }}</v-icon>
+            <v-icon :disabled=!authorised large>{{ mutation._icon }}</v-icon>
           </v-list-item-avatar>
           <v-list-item-content>
             <v-list-item-title v-html="mutation._title" />
@@ -52,6 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list-item-content>
           <v-list-item-action>
             <v-icon
+             :disabled=!authorised
              medium
              class="float-right"
              @click.stop="openDialog(mutation)"
@@ -101,6 +103,7 @@ import Mutation from '@/components/cylc/Mutation'
 import {
   mdiPencil
 } from '@mdi/js'
+import { mapState } from 'vuex'
 
 export default {
   name: 'CylcObjectMenu',
@@ -151,14 +154,26 @@ export default {
       }
       return !!this.$workflowService.primaryMutations[this.type]
     },
-
+    ...mapState('user', ['user']),
+    userPermissions () {
+      return this.user.permissions.map((str) => str.toLowerCase())
+    },
+    authorizedMutations () {
+      return this.mutations
+        .filter(mutation => this.userPermissions.includes(mutation[0].name.toLowerCase()))
+        .map(mutation => {
+          mutation[2] = true
+          return mutation
+        })
+    },
     displayMutations () {
-      if (!this.mutations) {
+      if (!this.mutations || this.user.permissions.length < 2) {
         return []
       }
       const shortList = this.$workflowService.primaryMutations[this.type]
+
       if (!this.expanded && shortList) {
-        return this.mutations.filter(
+        return this.authorizedMutations.filter(
           (x) => {
             return shortList.includes(x[0].name)
           }
@@ -168,7 +183,7 @@ export default {
           }
         )
       }
-      return this.mutations
+      return this.authorizedMutations
     }
   },
 

--- a/src/lang/en-GB/UserProfile.json
+++ b/src/lang/en-GB/UserProfile.json
@@ -4,5 +4,6 @@
   "username": "Username",
   "administrator": "Administrator",
   "groups": "Groups",
-  "created": "Created"
+  "created": "Created",
+  "permissions": "Authorized Operations"
 }

--- a/src/lang/pt-BR/UserProfile.json
+++ b/src/lang/pt-BR/UserProfile.json
@@ -4,5 +4,6 @@
   "username": "Nome de Usuário",
   "administrator": "Administrador",
   "groups": "Grupos",
-  "created": "Criado"
+  "created": "Criado",
+  "permissions": "Operações Autorizadas"
 }

--- a/src/model/User.model.js
+++ b/src/model/User.model.js
@@ -24,7 +24,7 @@
  * @property {string} server - server URL
  */
 export default class User {
-  constructor (username, groups, created, admin, server, owner) {
+  constructor (username, groups, created, admin, server, owner, permissions) {
     // the authenticated user
     // (full info only available when authenticated via the hub)
     this.username = username
@@ -36,5 +36,6 @@ export default class User {
     // (i.e. the user who's workflows we are looking at)
     // (this might not be the authenticated user for multi-user setups)
     this.owner = owner
+    this.permissions = permissions
   }
 }

--- a/src/services/mock/json/userprofile.json
+++ b/src/services/mock/json/userprofile.json
@@ -11,6 +11,7 @@
     "play", "ping", "remove", "resume", "setgraphwindowextent",
     "setholdpoint", "setoutputs", "setverbosity", "stop", "trigger", "read",
     "broadcast", "ext-trigger", "pause", "kill", "message", "poll", "release",
-    "releaseholdpoint", "reload"
+    "releaseholdpoint", "reload", "workflowMutation", "cycleMutation",
+    "jobMutation", "namespaceMutation"
 ]
 }

--- a/src/services/mock/json/userprofile.json
+++ b/src/services/mock/json/userprofile.json
@@ -8,10 +8,29 @@
   "admin": true,
   "server": "/user/cylc/",
   "permissions": [
-    "play", "ping", "remove", "resume", "setgraphwindowextent",
-    "setholdpoint", "setoutputs", "setverbosity", "stop", "trigger", "read",
-    "broadcast", "ext-trigger", "pause", "kill", "message", "poll", "release",
-    "releaseholdpoint", "reload", "workflowMutation", "cycleMutation",
-    "jobMutation", "namespaceMutation"
-]
+    "play",
+    "ping",
+    "remove",
+    "resume",
+    "setgraphwindowextent",
+    "setholdpoint",
+    "setoutputs",
+    "setverbosity",
+    "stop",
+    "trigger",
+    "read",
+    "broadcast",
+    "ext-trigger",
+    "pause",
+    "kill",
+    "message",
+    "poll",
+    "release",
+    "releaseholdpoint",
+    "reload",
+    "workflowMutation",
+    "cycleMutation",
+    "jobMutation",
+    "namespaceMutation"
+  ]
 }

--- a/src/services/mock/json/userprofile.json
+++ b/src/services/mock/json/userprofile.json
@@ -6,5 +6,11 @@
   ],
   "created": "2021-03-23T23:26:23.606Z",
   "admin": true,
-  "server": "/user/cylc/"
+  "server": "/user/cylc/",
+  "permissions": [
+    "play", "ping", "remove", "resume", "setgraphwindowextent",
+    "setholdpoint", "setoutputs", "setverbosity", "stop", "trigger", "read",
+    "broadcast", "ext-trigger", "pause", "kill", "message", "poll", "release",
+    "releaseholdpoint", "reload"
+]
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -32,7 +32,8 @@ class UserService {
         response.data.created,
         response.data.admin,
         response.data.server,
-        response.data.owner
+        response.data.owner,
+        response.data.permissions
       )
     })
   }

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -408,10 +408,12 @@ export function getIntrospectionQuery () {
 export function filterAssociations (cylcObject, tokens, mutations) {
   const ret = []
   let requiresInfo = false
+  let authorised = false
   let applies = false
   let alternate = null
   for (const mutation of mutations) {
     requiresInfo = false
+    authorised = false
     applies = false
     for (const arg of mutation.args) {
       if (arg._cylcObject) {
@@ -437,7 +439,7 @@ export function filterAssociations (cylcObject, tokens, mutations) {
       continue
     }
     ret.push(
-      [mutation, requiresInfo]
+      [mutation, requiresInfo, authorised]
     )
   }
   return ret

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -91,7 +91,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 />
               </v-flex>
             </v-layout>
-
+            <v-layout row align-center wrap>
+              <v-flex xs3>
+                <span>{{ $t('UserProfile.permissions') }}</span>
+              </v-flex>
+              <v-flex xs9>
+                <v-select
+                    :items="user.permissions"
+                    v-model="user.permissions"
+                    attach
+                    multiple
+                    disabled
+                    id="profile-permissions"
+                    aria-disabled="true"
+                    class="body-1"
+                />
+              </v-flex>
+            </v-layout>
             <v-row mt-4>
               <v-flex xs12>
                 <p class="title">Preferences</p>

--- a/tests/e2e/specs/aotf.js
+++ b/tests/e2e/specs/aotf.js
@@ -29,13 +29,6 @@ function mockApolloClient () {
     service.primaryMutations = {
       workflow: ['workflowMutation']
     }
-    service.mutations = [[
-      {
-        name: 'workflowMutation'
-      }, true, true]]
-    cy.window().its('app.$store').then(store => {
-      store.user.permissions = ['workflowMutation', 'moo', 'baa']
-    })
     service.apolloClient.mutate = (args) => {
       // log this for later
       mutations.push(args)
@@ -325,12 +318,17 @@ describe('Api On The Fly', () => {
         // toggle the menu to "see more" items
         .find('.v-btn:first')
         .click({ force: true })
-        // it should now list the four workflow mutations
+        // it should now list the five workflow mutations
         .get('.c-mutation-menu-list:first')
         .find('.v-list-item')
-        .should('have.length', 5) // +1 because of the "see less" button
+        .should('have.length', 6) // +1 because of the "see less" button
+        // should have unauthorised mutation disabled
+        .get('.c-mutation-menu-list:first')
+        .find('.v-list-item:nth-child(4)')
+        .should('exist')
+        .should('have.class', 'v-list-item--disabled')
         // toggle the menu to "see less" items
-        .find('.v-btn:first')
+        .get('#lessMoreButton')
         .click()
         // it should list the one default workflow mutation
         // (see workflowService.primaryMutations)

--- a/tests/e2e/specs/aotf.js
+++ b/tests/e2e/specs/aotf.js
@@ -29,6 +29,13 @@ function mockApolloClient () {
     service.primaryMutations = {
       workflow: ['workflowMutation']
     }
+    service.mutations = [[
+      {
+        name: 'workflowMutation'
+      }, true, true]]
+    cy.window().its('app.$store').then(store => {
+      store.user.permissions = ['workflowMutation', 'moo', 'baa']
+    })
     service.apolloClient.mutate = (args) => {
       // log this for later
       mutations.push(args)

--- a/tests/e2e/specs/aotf.js
+++ b/tests/e2e/specs/aotf.js
@@ -328,7 +328,7 @@ describe('Api On The Fly', () => {
         .should('exist')
         .should('have.class', 'v-list-item--disabled')
         // toggle the menu to "see less" items
-        .get('#lessMoreButton')
+        .get('#less-more-button')
         .click()
         // it should list the one default workflow mutation
         // (see workflowService.primaryMutations)

--- a/tests/e2e/support/graphql.js
+++ b/tests/e2e/support/graphql.js
@@ -39,6 +39,22 @@ const MUTATIONS = [
     ]
   },
   {
+    name: 'unauthorisedMutation',
+    _title: 'Unauthorised Mutation',
+    description: `
+      A mutation user will not be authorised for.
+    `,
+    args: [
+      {
+        name: 'workflow',
+        type: {
+          name: 'WorkflowID',
+          kind: null
+        }
+      }
+    ]
+  },
+  {
     name: 'cycleMutation',
     _title: 'Cycle Mutation',
     description: 'cycle',

--- a/tests/unit/model/user.model.spec.js
+++ b/tests/unit/model/user.model.spec.js
@@ -26,12 +26,16 @@ describe('User model', () => {
       const admin = true
       const created = 'now'
       const server = '/cylc/user/john.foe'
-      const user = new User(name, groups, created, admin, server)
+      const owner = 'john.goe'
+      const permissions = ['play', 'ping', 'read']
+      const user = new User(name, groups, created, admin, server, owner, permissions)
       expect(user.username).to.equal(name)
       expect(user.groups.length === 2).to.equal(admin)
       expect(user.admin).to.equal(true)
       expect(user.created).to.equal(created)
       expect(user.server).to.equal(server)
+      expect(user.owner).to.equal(owner)
+      expect(user.permissions).to.equal(permissions)
     })
   })
 })


### PR DESCRIPTION
Putting this up as an initial PR to disable buttons for mutations that are not authorized.
I have not dealt with the tooltip, the `"workflow-play-pause-button"` or `"workflow-stop-button"` yet, will do a follow-up pr for those. 

This branch requires it's sibling PR: https://github.com/cylc/cylc-uiserver/pull/204
These changes partially address https://github.com/cylc/cylc-ui/issues/704



Changes look as follows: 
For `userB`, accessing `userA`'s ui-server with the following auth permissions in UserA's config files:

```
c.UIServer.site_authorization = {
    "*": {
        "*": {
            "default": ["ALL"],
            "limit": ["ALL"],}
    }
}

c.UIServer.user_authorization = {
    'userB': ['READ', 'trigger']
}
```

Going to : `/userA/userprofile`, when authenticated as `userB` will look as follows:

![image](https://user-images.githubusercontent.com/37735232/128869329-c00825f4-a526-4fb3-ad39-4033678025ca.png)

And, clicking on the mutation button of a workflow will look as follows:

![image](https://user-images.githubusercontent.com/37735232/128873003-ea9cbbb9-2ae9-4bc3-89a2-5eb5e1cdc55e.png)


Will put this up as a Draft PR for now... I am going to have a look at, rather than removing these buttons, greying these buttons out.


Update: Greyed out buttons now functioning and tested.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required (Will be covered by documentation for authorization).
