### PR TITLE
Handle any deltas.workflow.added as an initial-data-burst

### DIFF
--- a/src/components/cylc/tree/deltas.js
+++ b/src/components/cylc/tree/deltas.js
@@ -24,7 +24,6 @@ import {
   createTaskProxyNode
 } from '@/components/cylc/tree/nodes'
 import * as CylcTree from '@/components/cylc/tree/index'
-import WorkflowState from '@/model/WorkflowState.model'
 
 /**
  * Helper object used to iterate added deltas data.
@@ -214,14 +213,9 @@ function handleDeltas (deltas, workflow, lookup, options) {
  */
 export default function (data, workflow, lookup, options) {
   const deltas = data.deltas
-  // first we check whether it is a new start
+  // first we check whether it is a new initial-data-burst
   if (deltas && deltas.added && deltas.added.workflow) {
-    if (deltas.added.workflow.status === WorkflowState.RUNNING.name) {
-      // The workflow could be stopped. In this case when restarted (cold or hot)
-      // it would be hard to apply the new deltas keeping the UI state valid. So
-      // for now we clear the tree, and start from scratch rebuilding it.
-      CylcTree.clear(workflow)
-    }
+    CylcTree.clear(workflow)
   }
   // Safe check in case the tree is empty.
   if (CylcTree.isEmpty(workflow)) {


### PR DESCRIPTION
These changes close #667 

It will basically handle any `deltas.added.workflow` as an initial-data-burst. Previously, only the workflows with status=running would be handled.

With this, executing the mutation to reload the workflow does not break the tree view :+1: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
