### PR TITLE
Remove margin/padding from Tree component

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -109,7 +109,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :filterable="false"
           :expand-collapse-toggle="false"
           :workflows="filteredWorkflows"
-          class="c-gscan-workflow ma-0 pl-2"
+          class="c-gscan-workflow ma-0 pa-0"
         >
           <template v-slot:node="scope">
             <v-list-item
@@ -128,10 +128,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     v-else-if="scope.node.type === 'workflow'"
                     class="c-gscan-workflow-name"
                   >
-                    <workflow-icon
-                      :status="scope.node.node.status"
-                      class="mr-2"
-                    />
+                    <span class="mr-2">
+                      <workflow-icon
+                        :status="scope.node.node.status"
+                      />
+                    </span>
                     <v-tooltip top>
                       <template v-slot:activator="{ on }">
                         <span v-on="on">{{ scope.node.name }}</span>

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -109,7 +109,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :filterable="false"
           :expand-collapse-toggle="false"
           :workflows="filteredWorkflows"
-          class="c-gscan-workflow"
+          class="c-gscan-workflow ma-0 pl-2"
         >
           <template v-slot:node="scope">
             <v-list-item

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <v-container
-    class="ma-0 pa-2"
+    class="ma-0 pa-0"
   >
     <!-- Toolbar -->
     <v-row

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -44,10 +44,17 @@
       }
 
       .treeitem {
+        /**
+         * The styles in this class are based off the v-list-item styles.
+         */
         .node-expand-collapse-button {
           margin: 0;
           letter-spacing: normal;
           min-height: 48px;
+          /**
+            1.5rem is the space the TreeItem component prepends for each hierarchy level in the tree.
+            4px is half the padding we are using for .v-list-item (see below).
+           */
           width: calc(1.5rem + 4px);
           outline: none;
           padding: 0;

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -17,6 +17,12 @@
 
 @import '~vuetify/src/styles/styles';
 
+@mixin hover {
+  &:hover {
+    background-color: map-get($grey, 'lighten-2');
+  }
+}
+
 .c-gscan {
   .v-skeleton-loader > div:first-child {
     background: inherit;
@@ -38,14 +44,26 @@
       }
 
       .treeitem {
+        .node-expand-collapse-button {
+          margin: 0;
+          letter-spacing: normal;
+          min-height: 48px;
+          width: calc(1.5rem + 4px);
+          outline: none;
+          padding: 0;
+          position: relative;
+          text-decoration: none;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
         .node {
           display: flex;
           align-items: center;
 
           .v-list-item {
-            &:hover {
-              background-color: map-get($grey, 'lighten-2');
-            }
+            padding: 0 8px;
+            @include hover;
           }
         }
       }

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div>
     <CylcObjectMenu />
-    <div class="c-tree">
+    <div class="c-tree pa-2">
       <tree-component
         :workflows="workflows"
         :hoverable="false"


### PR DESCRIPTION
These changes close #730 

The Tree component now has no borders, padding, margin, etc. This way the caller code can choose whether to add them or not.

For the Tree **view** we want padding to match the previous appearance. But for GScan we don't want any padding or spaces so that the hover effect occupies as much space as possible without distracting users.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? hard to test, small change).
- [x] No change log entry required (why? e.g. invisible to users (since the gscan-hierarchical code was not released yet)).
- [x] No documentation update required.
