### PR TITLE
Fix broken workflow design guide link

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -137,7 +137,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-content>
           </v-list-item>
           <!-- TODO: change from latest to stable once out of beta -->
-          <v-list-item href="https://cylc.github.io/cylc-doc/latest/html/suite-design-guide/index.html">
+          <v-list-item href="https://cylc.github.io/cylc-doc/latest/html/workflow-design-guide/index.html">
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon large>{{ svgPaths.workflow }}</v-icon>
             </v-list-item-avatar>
@@ -146,7 +146,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 Workflow Design Guide
               </v-list-item-title>
               <v-list-item-subtitle>
-                How to make complex Cylc and Rose workflows simpler and easier to maintain
+                How to make complex Cylc workflows and Rose suites simpler and easier to maintain
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>


### PR DESCRIPTION
This is a very small change with no associated Issue.

Fixes broken link which was pointing to https://cylc.github.io/cylc-doc/latest/html/suite-design-guide/index.html

Also changed the description in line with the decision that rose suites should not be changed to workflows.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (small link change).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
