### PR TITLE
Improvements to tooltips and mutation edit form 

### DIFF
--- a/src/components/cylc/cylcObject/plugin.js
+++ b/src/components/cylc/cylcObject/plugin.js
@@ -67,8 +67,8 @@ function update (el, binding, newVnode, oldVnode) {
 export default {
   /**
    * Called when the Vue application is created, and this plug-in is loaded.
-   * @param Vue {object} - Vue application
-   * @param options {*} - options passed to the plug-in (if any)
+   * @param {object} Vue - Vue application
+   * @param {*} options - options passed to the plug-in (if any)
    */
   install (Vue, options) {
     // add a global directive

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -74,18 +74,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   {{ icons.help }}
                 </v-icon>
               </template>
-              <!-- wrap the tooltip in a div with restricted width to force
-                   line wrapping -->
-              <div
-                style="
-                  width: 20vw;
-                  text-align: center;
-                "
-              >
-                <vue-markdown :breaks="false">
-                  {{ input.description }}
-                </vue-markdown>
-              </div>
+              <vue-markdown :breaks="false">
+                {{ input.description }}
+              </vue-markdown>
             </v-tooltip>
           </v-list-item-title>
           <form-input

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -16,7 +16,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <v-form validate>
+  <v-form
+    validate
+    class="c-mutation-form"
+  >
     <!-- the mutation title -->
     <h3
      style="text-transform: capitalize;"

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -35,11 +35,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-expansion-panel-header>
           <vue-markdown
            :source="shortDescription"
+           :breaks="false"
           />
         </v-expansion-panel-header>
         <v-expansion-panel-content>
           <vue-markdown
            :source="longDescription"
+           :breaks="false"
           />
         </v-expansion-panel-content>
       </v-expansion-panel>
@@ -47,6 +49,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <vue-markdown
      v-else
      :source="shortDescription"
+     :breaks="false"
     />
 
     <!-- the form inputs -->
@@ -79,9 +82,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   text-align: center;
                 "
               >
-              <vue-markdown>
-                {{ input.description }}
-              </vue-markdown>
+                <vue-markdown :breaks="false">
+                  {{ input.description }}
+                </vue-markdown>
               </div>
             </v-tooltip>
           </v-list-item-title>
@@ -159,12 +162,11 @@ export default {
 
     /* Return the first line of the description. */
     shortDescription () {
-      return (this.mutation.description || '').split('\n', 1)[0] || ''
+      return this.mutation.description?.split('\n\n', 1)[0] || ''
     },
-
     /* Return the subsequent lines of the description */
     longDescription () {
-      return (this.mutation.description || '').split('\n').slice(1).join('\n')
+      return this.mutation.description?.split('\n\n').slice(1).join('\n\n')
     }
   },
 

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -28,17 +28,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <v-expansion-panels
      accordion
      flat
-     hover
-     v-if="longDescription"
+     v-bind="longDescription ? { hover: true } : { readonly: true }"
     >
-      <v-expansion-panel>
-        <v-expansion-panel-header>
+      <v-expansion-panel
+        class="mutation-desc"
+      >
+        <v-expansion-panel-header
+          v-bind="longDescription ? {} : {
+            expandIcon: null,
+            style: {
+              cursor: 'default'
+            }
+          }"
+        >
           <vue-markdown
            :source="shortDescription"
            :breaks="false"
           />
         </v-expansion-panel-header>
-        <v-expansion-panel-content>
+        <v-expansion-panel-content
+          v-if="longDescription"
+        >
           <vue-markdown
            :source="longDescription"
            :breaks="false"
@@ -46,11 +56,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
-    <vue-markdown
-     v-else
-     :source="shortDescription"
-     :breaks="false"
-    />
+
+    <v-divider></v-divider>
 
     <!-- the form inputs -->
     <v-list>

--- a/src/components/graphqlFormGenerator/FormInput.vue
+++ b/src/components/graphqlFormGenerator/FormInput.vue
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       </component>
     </template>
-    <vue-markdown>{{ help }}</vue-markdown>
+    <vue-markdown :breaks="false">{{ help }}</vue-markdown>
   </v-tooltip>
 </template>
 

--- a/src/styles/cylc/_mutation_form.scss
+++ b/src/styles/cylc/_mutation_form.scss
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ .mutation-desc {
+  .v-expansion-panel-header {
+    font-size: 1em;
+    line-height: inherit;
+    p {
+      margin-bottom: 0;
+    }
+  }
+ }

--- a/src/styles/cylc/_mutation_form.scss
+++ b/src/styles/cylc/_mutation_form.scss
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- .mutation-desc {
+ .c-mutation-form .mutation-desc {
   .v-expansion-panel-header {
     font-size: 1em;
     line-height: inherit;

--- a/src/styles/cylc/_tooltip.scss
+++ b/src/styles/cylc/_tooltip.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.v-tooltip__content {
+  max-width: 600px;
+
+  p:last-child {
+    // If we have vue-markdown paragraphs in the tooltip
+    margin-bottom: 0;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -31,6 +31,7 @@
 @import "cylc/user_profile";
 @import "cylc/warning";
 @import "cylc/workflow";
+@import "cylc/tooltip";
 
 .theme--light.v-application {
   background-color: transparent;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -32,6 +32,7 @@
 @import "cylc/warning";
 @import "cylc/workflow";
 @import "cylc/tooltip";
+@import "cylc/mutation_form";
 
 .theme--light.v-application {
   background-color: transparent;

--- a/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
+++ b/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
@@ -274,4 +274,46 @@ describe('FormGenerator Component', () => {
     wrapper.vm.reset()
     expect(wrapper.vm.$data.model).to.deep.equal(before)
   })
+
+  describe('Mutation descriptions', () => {
+    const mountWithDescription = (desc) => mountFunction({
+      propsData: {
+        mutation: {
+          name: 'Darmok',
+          description: desc,
+          args: []
+        }
+      }
+    })
+    describe('For a single line description', () => {
+      const desc = 'Lorem ipsum.'
+      const wrapper = mountWithDescription(desc)
+      describe('.shortDescription', () => {
+        it('should be the whole description', () => {
+          expect(wrapper.vm.shortDescription).to.equal(desc)
+        })
+      })
+      describe('.longDescription', () => {
+        it('should be empty', () => {
+          expect(wrapper.vm.longDescription).to.equal('')
+        })
+      })
+    })
+    describe('For a multiline description', () => {
+      const shortDesc = 'Darmok and Jalad at\nTanagra.'
+      const longDesc = 'Shaka when the\nwalls fell.\n\nTemba, his arms wide.'
+      const desc = `${shortDesc}\n\n${longDesc}`
+      const wrapper = mountWithDescription(desc)
+      describe('.shortDescription', () => {
+        it('should be the bit before the first double newline', () => {
+          expect(wrapper.vm.shortDescription).to.equal(shortDesc)
+        })
+      })
+      describe('.longDescription', () => {
+        it('should be everything after the first double newline', () => {
+          expect(wrapper.vm.longDescription).to.equal(longDesc)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
I made these changes while continuing to explore the UI codebase. Turns out this partially addresses #647

- Fix line breaks in markdown content and adjust style of mutation edit form description expansion panel

  | Before | After |
  | --- | --- |
  | ![image][before-collapsed] | ![image][after-collapsed] |
  | ![image][before-expanded] | ![image][after-expanded] |

  (Note the grey highlight when hovering on the expansion panel appeared in both "before" and "after" , it just didn't happen to get captured for the "before" screenshots)

- Also implement a max-width for all tooltips

[before-collapsed]: https://user-images.githubusercontent.com/61982285/138328312-ba2106c2-7519-4f18-8c4e-360c2eafa361.png
[before-expanded]: https://user-images.githubusercontent.com/61982285/138328637-206af2c5-ef30-4c0a-9d5e-b346afe883ea.png
[after-collapsed]: https://user-images.githubusercontent.com/61982285/138328669-8e500c96-ea25-487f-9151-01fe59739764.png
[after-expanded]: https://user-images.githubusercontent.com/61982285/138328834-98673eee-142e-45cc-8dca-f0fb601beba9.png

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (manually checked, not sure it warrants specs?).
- [x] No changelog entry needed (minor change)
- [x] No documentation update required.
