### PR TITLE
Silence babel warning

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,6 +23,7 @@ module.exports = (api) => {
   const plugins = [
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-private-methods', { loose: true }],
+    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
     ['@babel/plugin-proposal-nullish-coalescing-operator'],
     ['@babel/plugin-proposal-optional-chaining'],
     ['babel-plugin-istanbul', { extension: ['.js', '.vue'] }]


### PR DESCRIPTION
This is a small change with no associated Issue.

Silence this warning:
> The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.

---

(Now, if only we could silence
> You are running Vue in development mode.
>Make sure to turn on production mode when deploying for production.
>See more tips at https://vuejs.org/guide/deployment.html
>Download the Vue Devtools extension for a better development experience:
>https://github.com/vuejs/vue-devtools

when running the unit tests - https://github.com/vuejs/vue/issues/10472)