### PR TITLE
Handle the preparing job state properly.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ to a Jupyter Server extension).
 
 ### Fixes
 
+[#824](https://github.com/cylc/cylc-ui/pull/844) - Fix handling of task/job
+"preparing" state.
+
 -------------------------------------------------------------------------------
 ## __cylc-ui-0.5 (<span actions:bind='release-date'>Released 2021-07-28</span>)__
 

--- a/src/model/JobState.model.js
+++ b/src/model/JobState.model.js
@@ -23,6 +23,7 @@ import { Enumify } from 'enumify'
  * @see https://cylc.github.io/cylc-admin/proposal-state-names.html#taskjob-states
  */
 class JobState extends Enumify {
+  static PREPARING = new JobState('preparing')
   static SUBMITTED = new JobState('submitted')
   static SUBMIT_FAILED = new JobState('submit-failed')
   static RUNNING = new JobState('running')

--- a/src/styles/cylc/_job.scss
+++ b/src/styles/cylc/_job.scss
@@ -35,6 +35,7 @@ $cjob: ".c-job svg.job rect";
 }
 
 @mixin job_theme_default() {
+    $concrete: rgb(213,213,194);
     $teal: rgb(109,213,194);
     $blue: rgb(106,164,241);
     $green: rgb(81,175,81);
@@ -42,6 +43,11 @@ $cjob: ".c-job svg.job rect";
     $pink: rgb(190,106,192);
 
     #{$cjob} {
+        &.preparing {
+            fill: $concrete;
+            stroke: $concrete;
+        }
+
         &.submitted {
             fill: $teal;
             stroke: $teal;
@@ -70,11 +76,17 @@ $cjob: ".c-job svg.job rect";
 }
 
 @mixin job_theme_greyscale() {
-    $light: rgb(208,208,208);
+    $light: rgb(152,152,152);
+    $lighter: rgb(192,192,192);
     $medium: rgb(133,133,133);
     $dark: rgb(0,0,0);
 
     #{$cjob} {
+        &.preparing {
+            fill: transparent;
+            stroke: $lighter;
+        }
+
         &.submitted {
             fill: transparent;
             stroke: $light;
@@ -104,10 +116,16 @@ $cjob: ".c-job svg.job rect";
 
 @mixin job_theme_colour-blind() {
     $grey: rgb(152,152,152);
+    $lightgrey: rgb(192,192,192);
     $success: rgb(108,218,255);
     $error: rgb(146,0,0);
 
     #{$cjob} {
+        &.preparing {
+            fill: transparent;
+            stroke: $lightgrey;
+        }
+
         &.submitted {
             fill: transparent;
             stroke: $grey;


### PR DESCRIPTION
This is a small change with no associated Issue.

Togehter with the datastore tweak in https://github.com/cylc/cylc-flow/pull/4482 this makes the UI handle the `preparing` task and job states properly.

![shot](https://user-images.githubusercontent.com/2362137/139361518-88c421b2-7e36-463d-b387-0e2295f7d9a7.png)


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [x] Does not need tests (why?).
<!-- choose one: -->
- [x] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No documentation update required.
