### PR TITLE
Focus the latest input box created when user clicks add button

### DIFF
--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -94,17 +94,12 @@ export default {
       this.value.push(
         newInput
       )
-      // this is not ideal, but I believe whats happening is the orignal tick creates the new 'component'
-      // from the new array item, and the next tick actually creates the content of the component (including the input)
+      // this is not ideal, but I believe whats happening is the new (wrapper) component is created over the first tick from the new array item
+      // the component content is created over the next tick (including the input)
       Vue.nextTick(() => {
         Vue.nextTick(() => {
-          const toolTip = this.$refs.inputs[this.$refs.inputs.length - 1].$el
-          if (toolTip && toolTip.parentNode) {
-            const newInput = toolTip.parentNode.querySelector('input')
-            if (newInput) {
-              newInput.focus()
-            }
-          }
+          // get the latest input ref (which is a tooltip for some reason), get its parent, then the input itself and focus() it (if it exists)
+          this.$refs.inputs[this.$refs.inputs.length - 1].$el?.parentNode?.querySelector('input')?.focus()
         })
       })
     },

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
            :gqlType="gqlType.ofType"
            :types="types"
            :is="FormInput"
+            ref="inputs"
           >
             <template v-slot:append-outer>
               <v-icon
@@ -68,6 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { formElement } from '@/components/graphqlFormGenerator/mixins'
 import { getNullValue } from '@/utils/aotf'
 import { mdiPlusCircle, mdiCloseCircle } from '@mdi/js'
+import Vue from 'vue'
 
 export default {
   name: 'g-list',
@@ -88,9 +90,20 @@ export default {
   methods: {
     /* Add an item to the list. */
     add () {
+      const newInput = getNullValue(this.gqlType.ofType, this.types)
       this.value.push(
-        getNullValue(this.gqlType.ofType, this.types)
+        newInput
       )
+      // this is not ideal, but I believe whats happening is the orignal tick creates the new 'component'
+      // from the new array item, and the next tick actually creates the content of the component (including the input)
+      Vue.nextTick(() => {
+        Vue.nextTick(() => {
+          const toolTip = this.$refs.inputs[this.$refs.inputs.length - 1].$el
+          if (toolTip && toolTip.parentNode) {
+            toolTip.parentNode.querySelector('input').focus()
+          }
+        })
+      })
     },
 
     /* Remove the item at `index` from the list. */

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -100,7 +100,10 @@ export default {
         Vue.nextTick(() => {
           const toolTip = this.$refs.inputs[this.$refs.inputs.length - 1].$el
           if (toolTip && toolTip.parentNode) {
-            toolTip.parentNode.querySelector('input').focus()
+            const newInput = toolTip.parentNode.querySelector('input')
+            if (newInput) {
+              newInput.focus()
+            }
           }
         })
       })


### PR DESCRIPTION
Attempt to focus the latest element when the add button is pushed in the mutation menu. This works but is not ideal because of the use of two 'Vue.nextTick' calls, but Im not sure refactoring the markup to not have this requirement is worth it for the amount of value this ticket will add.

These changes close #890

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [x] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [x] No documentation update required.
