### PR TITLE
Prevent mutation menu closing when clicking on another task or cycle

### DIFF
--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div class="c-mutation-menu-holder">
+  <div>
     <!-- dropdown menu -->
     <v-menu
       offset-y
@@ -265,11 +265,9 @@ export default {
       this.y = event.clientY
       this.$nextTick(() => {
         this.showMenu = true
-        if (this.$refs && this.$refs.mutationComponent) {
-          // reset the mutation component if present
-          // (this is because we re-use the same component)
-          this.$refs.mutationComponent.reset()
-        }
+        // reset the mutation component if present
+        // (this is because we re-use the same component)
+        this.$refs?.mutationComponent?.reset()
       })
     },
 

--- a/src/components/cylc/cylcObject/plugin.js
+++ b/src/components/cylc/cylcObject/plugin.js
@@ -53,7 +53,7 @@ function bind (el, binding, vnode) {
 
 function unbind (el) {
   // clean up to avoid memory issues
-  el.removeEventListener('show-mutations-menu', listener)
+  el.removeEventListener('click', listener)
   listener = null
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -56,8 +56,15 @@
   fontRootSize: $font-size-root;
 }
 
-.c-interactive:hover {
+.c-interactive {
+  &:hover {
     cursor: pointer;
+  }
+
+  svg {
+    // Prevent click handler from thinking the svg is the target
+    pointer-events: none;
+  }
 }
 
 .position-relative {

--- a/tests/e2e/specs/menu.js
+++ b/tests/e2e/specs/menu.js
@@ -16,6 +16,9 @@
  */
 
 describe('CylcObject Menu component', () => {
+  const collapsedWorkflowMenuLength = 5 // (4 mutations + "show more" btn)
+  const expandedWorkflowMenuLength = 20
+
   it('should not be displayed initially on load', () => {
     cy.visit('/#/workflows/one')
     cy.get('.c-interactive:first') // wait for view to load
@@ -31,10 +34,69 @@ describe('CylcObject Menu component', () => {
       // the menu should now be open
       .get('.c-mutation-menu-list:first')
       .should('be.visible')
-      // length is 5, as 4 plus show more
       .children()
-      .should('have.length', 5)
+      .should('have.length', collapsedWorkflowMenuLength)
       .get('.c-mutation-menu')
       .should('be.visible')
+  })
+
+  it('expands when "show more" is clicked', () => {
+    cy.get('#less-more-button')
+      .click()
+      .get('.c-mutation-menu-list')
+      .should('be.visible')
+      .children()
+      .should('have.length', expandedWorkflowMenuLength)
+  })
+
+  it('closes when clicking outside of the menu', () => {
+    // Click on hidden element to avoid clicking on anything unexpected
+    cy.get('noscript')
+      .click({ force: true })
+      .get('.c-mutation-menu-list:first')
+      .should('not.be.visible')
+  })
+
+  it('should be collapsed next time it is opened', () => {
+    cy.get('.c-interactive:first')
+      .click()
+      .get('.c-mutation-menu-list')
+      .should('be.visible')
+      .children()
+      .should('have.length', collapsedWorkflowMenuLength)
+  })
+
+  it('updates when clicking on a different Cylc object', () => {
+    let firstID
+    cy.get('.c-mutation-menu')
+      .should('be.visible')
+      .find('.v-card__title')
+      .then(($el) => {
+        firstID = $el.text()
+      })
+      // Now click on other Cylc object
+      .get('.c-interactive').eq(2)
+      .click({ force: true })
+      .get('.c-mutation-menu')
+      .should('be.visible')
+      .find('.v-card__title')
+      .should(($el) => {
+        expect($el.text()).not.to.equal(firstID)
+      })
+  })
+
+  it('should not close when clicking inside menu', () => {
+    cy.get('.v-card__title')
+      .click()
+      .get('.c-mutation-menu')
+      .should('be.visible')
+  })
+
+  it('closes when clicking on mutation', () => {
+    cy.get('.c-mutation-menu-list')
+      .find('.c-mutation:not([aria-disabled]):first')
+      .click()
+      .get('.c-mutation-menu')
+      .should('not.be.visible')
   })
 })

--- a/tests/e2e/specs/menu.js
+++ b/tests/e2e/specs/menu.js
@@ -16,30 +16,25 @@
  */
 
 describe('CylcObject Menu component', () => {
-  it('Is displayed when a Cylc object is clicked on', () => {
+  it('should not be displayed initially on load', () => {
     cy.visit('/#/workflows/one')
-
-    cy
-      // wait for view to load
-      .get('.c-interactive:first')
-
-      // menu should not by displayed on load
+    cy.get('.c-interactive:first') // wait for view to load
       .get('.c-mutation-menu:first')
       .should('not.exist')
+  })
 
+  it('is displayed when a Cylc object is clicked on', () => {
+    cy
       // click on the first interactive thing
       .get('.c-interactive:first')
       .click()
-      .then(() => {
-        // the menu should now be open
-        // length is 5, as 4 plus show more
-        cy
-          .get('.c-mutation-menu-list:first')
-          .should('be.visible')
-          .children()
-          .should('have.length', 5)
-          .get('.v-menu__content:first')
-          .should('be.visible')
-      })
+      // the menu should now be open
+      .get('.c-mutation-menu-list:first')
+      .should('be.visible')
+      // length is 5, as 4 plus show more
+      .children()
+      .should('have.length', 5)
+      .get('.c-mutation-menu')
+      .should('be.visible')
   })
 })

--- a/tests/e2e/specs/tree.js
+++ b/tests/e2e/specs/tree.js
@@ -188,6 +188,7 @@ describe('Tree view', () => {
         .should('be.visible')
     }
   })
+
   describe('filters', () => {
     it('Should not filter by default', () => {
       cy.visit('/#/tree/one')


### PR DESCRIPTION
These changes close #916

![demo6](https://user-images.githubusercontent.com/61982285/154126974-72d1064a-54a0-443a-8ab3-41f926b1f1fb.gif)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (e2e).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
