### PR TITLE
Attempt number two at auto collapsing single task workflows in the g-scan menu

### DIFF
--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -178,11 +178,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </div>
         </div>
       </slot>
-      <slot
-        v-bind:node="node"
-        name="node"
-        v-else
-      >
+      <slot v-bind:node="node" name="node" v-else>
+        <div :class="getNodeDataClass()" @click="nodeClicked">
+          <task
+            v-cylc-object="node.node"
+            :key="node.node.id"
+            :status="node.node.state"
+            :isHeld="node.node.isHeld"
+            :isQueued="node.node.isQueued"
+            :isRunahead="node.node.isRunahead"
+          />
+          <span class="mx-1">{{ node.node.name }}</span>
+        </div>
         <div :class="getNodeDataClass()">
           <span
             v-if="node && node.node"
@@ -253,7 +260,7 @@ export default {
     return {
       active: false,
       selected: false,
-      isExpanded: this.initialExpanded,
+      isExpanded: undefined,
       filtered: true,
       leafProperties: [
         {
@@ -344,6 +351,17 @@ export default {
     if (this.node.expanded !== undefined && this.node.expanded !== null) {
       this.isExpanded = this.node.expanded
       this.emitExpandCollapseEvent(this.isExpanded)
+    }
+  },
+  watch: {
+    node: {
+      deep: true,
+      handler: function () {
+        if (this.initialExpanded && this.isExpanded === undefined && this.node.children && this.node.children.length > 1) {
+          this.isExpanded = true
+          this.emitExpandCollapseEvent(this.isExpanded)
+        }
+      }
     }
   },
   methods: {


### PR DESCRIPTION
This is an update on the first MR I created attempting to fix this which I accidentally deleted by removing the branch (sorry past reviewers). This one keeps the collapse chevron, but has to lose the inactive states to avoid wrapping onto a new line with large labels.

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address #xxxx
These changes close #xxxx
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [x] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [x] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No documentation update required.
