### PR TITLE
Remove cylc hub button in single user mode

### DIFF
--- a/src/model/User.model.js
+++ b/src/model/User.model.js
@@ -24,7 +24,7 @@
  * @property {string} server - server URL
  */
 export default class User {
-  constructor (username, groups, created, admin, server, owner, permissions) {
+  constructor (username, groups, created, admin, server, owner, permissions, mode) {
     // the authenticated user
     // (full info only available when authenticated via the hub)
     this.username = username
@@ -37,5 +37,6 @@ export default class User {
     // (this might not be the authenticated user for multi-user setups)
     this.owner = owner
     this.permissions = permissions
+    this.mode = mode
   }
 }

--- a/src/services/mock/json/userprofile.json
+++ b/src/services/mock/json/userprofile.json
@@ -31,6 +31,8 @@
     "workflowMutation",
     "cycleMutation",
     "jobMutation",
-    "namespaceMutation"
-  ]
+    "namespaceMutation",
+    "hold"
+  ],
+  "mode": "single user"
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -33,7 +33,8 @@ class UserService {
         response.data.admin,
         response.data.server,
         response.data.owner,
-        response.data.permissions
+        response.data.permissions,
+        response.data.mode
       )
     })
   }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -106,19 +106,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
-          <v-list-item id = "cylc-hub-button" v-if=multiUserMode :href=hubUrl>
+          <v-tooltip :disabled=multiUserMode bottom>
+            <template v-slot:activator="{ on }">
+          <div v-on="on" >
+          <v-list-item id = "cylc-hub-button" :disabled=!multiUserMode :href=hubUrl>
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon large>{{ svgPaths.hub }}</v-icon>
             </v-list-item-avatar>
             <v-list-item-content>
-              <v-list-item-title class="title font-weight-light">
-                Cylc Hub
-              </v-list-item-title>
+                <v-list-item-title class="title font-weight-light">
+                  Cylc Hub
+                </v-list-item-title>
               <v-list-item-subtitle>
                 Visit the Hub to manage your running UI Servers
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
+          </div>
+            </template>
+            <span>Only available in multi user mode.</span>
+          </v-tooltip>
         </v-list>
       </v-flex>
       <v-flex xs12 md6 lg6>
@@ -129,7 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
-                Cylc UI Quickstart
+                Cylc UI Quickstart2
               </v-list-item-title>
               <v-list-item-subtitle>
                 Learn how to use the Cylc UI

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -106,7 +106,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
-          <v-list-item :href=hubUrl>
+          <v-list-item :id = "cylc-hub-button" v-if=multiUserMode :href=hubUrl>
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon large>{{ svgPaths.hub }}</v-icon>
             </v-list-item-avatar>
@@ -257,6 +257,13 @@ export default {
             count: count[state.name] || 0
           }
         })
+    },
+    ...mapState('user', ['user']),
+    multiUserMode () {
+      if (this.user.mode === 'single user') {
+        return false
+      }
+      return true
     }
   }
 }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -107,24 +107,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-content>
           </v-list-item>
           <v-tooltip :disabled=multiUserMode bottom>
-            <template v-slot:activator="{ on }">
-          <div v-on="on" >
-          <v-list-item id="cylc-hub-button" :disabled=!multiUserMode :href=hubUrl>
-            <v-list-item-avatar size="60" style="font-size: 2em;">
-              <v-icon large>{{ svgPaths.hub }}</v-icon>
-            </v-list-item-avatar>
-            <v-list-item-content>
-                <v-list-item-title class="title font-weight-light">
-                  Cylc Hub
-                </v-list-item-title>
-              <v-list-item-subtitle>
-                Visit the Hub to manage your running UI Servers
-              </v-list-item-subtitle>
-            </v-list-item-content>
-          </v-list-item>
-          </div>
-            </template>
-            <span>You are not running Cylc UI via Cylc Hub.</span>
+            <template v-slot:activator="{ on }"> <div v-on="on" >
+                <v-list-item id="cylc-hub-button" :disabled=!multiUserMode :href=hubUrl>
+                  <v-list-item-avatar size="60" style="font-size: 2em;">
+                    <v-icon large>{{ svgPaths.hub }}</v-icon>
+                  </v-list-item-avatar>
+                  <v-list-item-content>
+                    <v-list-item-title class="title font-weight-light">
+                      Cylc Hub
+                    </v-list-item-title>
+                    <v-list-item-subtitle>
+                      Visit the Hub to manage your running UI Servers
+                    </v-list-item-subtitle>
+                  </v-list-item-content>
+                </v-list-item>
+            </div></template>
+          <span>You are not running Cylc UI via Cylc Hub.</span>
           </v-tooltip>
         </v-list>
       </v-flex>
@@ -267,10 +265,7 @@ export default {
     },
     ...mapState('user', ['user']),
     multiUserMode () {
-      if (this.user.mode === 'single user') {
-        return false
-      }
-      return true
+      return this.user.mode !== 'single user'
     }
   }
 }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -106,7 +106,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
-          <v-list-item :id = "cylc-hub-button" v-if=multiUserMode :href=hubUrl>
+          <v-list-item id = "cylc-hub-button" v-if=multiUserMode :href=hubUrl>
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon large>{{ svgPaths.hub }}</v-icon>
             </v-list-item-avatar>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -109,7 +109,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <v-tooltip :disabled=multiUserMode bottom>
             <template v-slot:activator="{ on }">
           <div v-on="on" >
-          <v-list-item id = "cylc-hub-button" :disabled=!multiUserMode :href=hubUrl>
+          <v-list-item :disabled=!multiUserMode :href=hubUrl>
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon large>{{ svgPaths.hub }}</v-icon>
             </v-list-item-avatar>
@@ -124,7 +124,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list-item>
           </div>
             </template>
-            <span>Only available in multi user mode.</span>
+            <span>You are not running Cylc UI via Cylc Hub.</span>
           </v-tooltip>
         </v-list>
       </v-flex>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -109,7 +109,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <v-tooltip :disabled=multiUserMode bottom>
             <template v-slot:activator="{ on }">
           <div v-on="on" >
-          <v-list-item :disabled=!multiUserMode :href=hubUrl>
+          <v-list-item id="cylc-hub-button" :disabled=!multiUserMode :href=hubUrl>
             <v-list-item-avatar size="60" style="font-size: 2em;">
               <v-icon large>{{ svgPaths.hub }}</v-icon>
             </v-list-item-avatar>
@@ -136,7 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title class="title font-weight-light">
-                Cylc UI Quickstart2
+                Cylc UI Quickstart
               </v-list-item-title>
               <v-list-item-subtitle>
                 Learn how to use the Cylc UI

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -44,12 +44,14 @@ describe('Dashboard', () => {
       })
       .should('equal', [...WorkflowStateOrder.entries()][0][0])
   })
-  it.only('Should not display the cylc hub button in single user mode', () => {
+  it.only('Should disable the cylc hub button with a tooltip in single user mode', () => {
     cy
       .visit('/#/')
       .get('.container > :nth-child(3) > :nth-child(1)')
       .find('#cylc-hub-button')
-      .should('not.exist')
+      .should('be.disabled')
+      .trigger('mouseover').invoke('show')
+      .contains('Only available in multi user mode')
   })
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
 })

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -44,7 +44,7 @@ describe('Dashboard', () => {
       })
       .should('equal', [...WorkflowStateOrder.entries()][0][0])
   })
-  it('Should have disabled cylc hub button', () => {
+  it('Should have disabled cylc hub button in single user mode', () => {
     cy.visit('/#/')
     cy
       .get('#cylc-hub-button')

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -33,7 +33,7 @@ describe('Dashboard', () => {
       .find('svg')
       .should('be.visible')
   })
-  it.only('Should display the states in order', () => {
+  it('Should display the states in order', () => {
     cy.visit('/#/')
     cy
       .get('#dashboard-workflows table tbody tr')
@@ -43,15 +43,6 @@ describe('Dashboard', () => {
         return $tdElement[1].textContent.toLowerCase()
       })
       .should('equal', [...WorkflowStateOrder.entries()][0][0])
-  })
-  it.only('Should disable the cylc hub button with a tooltip in single user mode', () => {
-    cy
-      .visit('/#/')
-      .get('.container > :nth-child(3) > :nth-child(1)')
-      .find('#cylc-hub-button')
-      .should('be.disabled')
-      .trigger('mouseover').invoke('show')
-      .contains('Only available in multi user mode')
   })
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
 })

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -44,5 +44,12 @@ describe('Dashboard', () => {
       })
       .should('equal', [...WorkflowStateOrder.entries()][0][0])
   })
+  it.only('Should not display the cylc hub button in single user mode', () => {
+    cy
+      .visit('/#/')
+      .get('.container > :nth-child(3) > :nth-child(1)')
+      .find('#cylc-hub-button')
+      .should('not.exist')
+  })
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
 })

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -44,5 +44,11 @@ describe('Dashboard', () => {
       })
       .should('equal', [...WorkflowStateOrder.entries()][0][0])
   })
+  it('Should have disabled cylc hub button', () => {
+    cy.visit('/#/')
+    cy
+      .get('#cylc-hub-button')
+      .should('have.class', 'v-list-item--disabled')
+  })
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
 })

--- a/tests/e2e/specs/table.js
+++ b/tests/e2e/specs/table.js
@@ -94,7 +94,7 @@ describe('Table view', () => {
         .should('have.length', 1)
         .should('be.visible')
     })
-    it.only('Should filter by task name and states', () => {
+    it('Should filter by task name and states', () => {
       cy.visit('/#/table/one')
       cy
         .get('.c-table table > tbody > tr')


### PR DESCRIPTION
The cylc hub button on the dashboard used to be available in single user mode (`cylc gui`). If clicked this resulted in a 404 page.
This change adds a condition that the gui mode should be multi-user if the button is to display.

I am not sure the preference on the links in the dashboard if the cylc hub button is not visible.

I have stuck with keeping the help links to the right, and the functional links to the left; as currently is the case. I think this looks a little lopsided in single user mode. I’m happy to move the Cylc UI Quickstart to the left list and move the cylc hub to the right for aesthetics. 
 
In single user mode the dashboard now looks as follows: 

 
![image](https://user-images.githubusercontent.com/37735232/159478772-3e9bd41a-6c40-4217-952b-bf5ef3f519f2.png)
In multi-user mode: 
 ![image](https://user-images.githubusercontent.com/37735232/159478942-75c45dc1-c5b7-45ad-9c13-2e2a6feb4ba2.png)


These changes close https://github.com/cylc/cylc-ui/issues/737 
Sibling: https://github.com/cylc/cylc-uiserver/pull/331


- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
