### PR TITLE
Use eslint-plugin-no-only-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-config-standard": "^16.0.3",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.1",
     "eslint-plugin-vue": "^8.4.0",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -18,5 +18,11 @@
 module.exports = {
   env: {
     mocha: true
+  },
+  plugins: [
+    'no-only-tests'
+  ],
+  rules: {
+    'no-only-tests/no-only-tests': 'error'
   }
 }

--- a/tests/e2e/.eslintrc.js
+++ b/tests/e2e/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     'cypress'
   ],
   env: {
-    mocha: true,
     'cypress/globals': true
   },
   rules: {

--- a/tests/e2e/specs/dashboard.js
+++ b/tests/e2e/specs/dashboard.js
@@ -33,7 +33,7 @@ describe('Dashboard', () => {
       .find('svg')
       .should('be.visible')
   })
-  it.only('Should display the states in order', () => {
+  it('Should display the states in order', () => {
     cy.visit('/#/')
     cy
       .get('#dashboard-workflows table tbody tr')

--- a/tests/e2e/specs/table.js
+++ b/tests/e2e/specs/table.js
@@ -57,9 +57,6 @@ describe('Table view', () => {
         .get('#c-table-filter-task-name')
         .type('eep')
       cy
-        .get('#c-table-filter-btn')
-        .click()
-      cy
         .get('td > div.d-flex > div')
         .contains('sleepy')
         .should('be.visible')
@@ -94,7 +91,7 @@ describe('Table view', () => {
         .should('have.length', 1)
         .should('be.visible')
     })
-    it.only('Should filter by task name and states', () => {
+    it('Should filter by task name and states', () => {
       cy.visit('/#/table/one')
       cy
         .get('.c-table table > tbody > tr')

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,6 +7183,7 @@ __metadata:
     eslint-config-standard: ^16.0.3
     eslint-import-resolver-node: ^0.3.6
     eslint-plugin-import: ^2.23.4
+    eslint-plugin-no-only-tests: ^2.6.0
     eslint-plugin-node: ^11.1.0
     eslint-plugin-promise: ^5.1.1
     eslint-plugin-vue: ^8.4.0
@@ -8399,6 +8400,13 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
   checksum: df570aec83ffa126fd80596d9fb1b6799d3cde025ceeb159eb28383541ebbb855468c9a2dbc670ab9e91dd0a8f8a82e52fd909a7c61e9ffa585bcce84ae1aec4
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-no-only-tests@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "eslint-plugin-no-only-tests@npm:2.6.0"
+  checksum: 4e3c9cc7e09c13e855fd7af4a8969128f766dcf32a0680715ebcaa903c7fe44db8e45e994c8b908443a6019cbd9ea1b51f413bf968a0c58214aded930a863df9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There were 2 tests where `.only()` was seemingly accidentally committed, leading to other tests in those files being excluded. This PR removes those `.only()`s and adds https://github.com/levibuzolic/eslint-plugin-no-only-tests to prevent it happening again.

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
