### PR TITLE
aotf: support flow arguments

### DIFF
--- a/src/components/graphqlFormGenerator/components/vuetify.js
+++ b/src/components/graphqlFormGenerator/components/vuetify.js
@@ -62,7 +62,9 @@ const RULES = {
     x => Boolean(!x || x.match(/^((\[[^=\]]+\])+)?([^[=\]-]+)?$/)) || 'Invalid',
   taskID:
     // PERMIT 1/a PROHIBIT a, 1
-    x => Boolean(!x || x.match(/^(.){1,}\/(.){1,}$/)) || 'Invalid'
+    x => Boolean(!x || x.match(/^(.){1,}\/(.){1,}$/)) || 'Invalid',
+  flow:
+    x => Boolean(!x || x.match(/(^\d+$|^(all|new|none)$)/)) || 'Invalid'
 }
 
 export default {
@@ -169,6 +171,13 @@ export default {
       placeholder: '[section]setting',
       rules: [
         RULES.cylcConfigItem
+      ]
+    },
+    Flow: {
+      is: VTextField,
+      placeholder: 'flow number',
+      rules: [
+        RULES.flow
       ]
     }
   },

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -345,13 +345,14 @@ export function processArguments (mutation, types) {
     required = false
     cylcObject = null
     cylcType = null
+    if (pointer && pointer.kind === 'NON_NULL') {
+      required = true
+    }
     while (pointer) {
       // walk down the nested type tree
       if (pointer.kind === 'LIST') {
         multiple = true
-      } else if (pointer.kind === 'NON_NULL') {
-        required = true
-      } else if (pointer.name) {
+      } else if (pointer.kind !== 'NON_NULL' && pointer.name) {
         for (const objectName in mutationMapping) {
           for (
             const [type, impliesMultiple] of mutationMapping[objectName]


### PR DESCRIPTION
To accompany https://github.com/cylc/cylc-flow/pull/4739

This allows the "trigger" mutation to be run without providing additional context (i.e. you shouldn't need to go through the mutation editor unless you want to fiddle with the defaults) and performs flow validation client-side.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
