### PR TITLE
Eslint: use `no-only-tests` in production only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
         run: yarn install
 
       - name: Lint
+        env:
+          NODE_ENV: production
         run: |
           yarn run lint --no-fix
 
@@ -71,9 +73,9 @@ jobs:
           node-version: '16'
 
       - name: e2e
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         with:
-          start: yarn run serve
+          start: yarn run serve --hide=CLIENT  # turn off build output because it's absurdly long
           wait-on: http://localhost:8080/
           config-file: cypress.json
           spec: "tests/e2e/**/*"

--- a/src/services/mock/.eslintrc.js
+++ b/src/services/mock/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-console': 'off'
+  }
+}

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'no-only-tests'
   ],
   rules: {
-    'no-only-tests/no-only-tests': 'error'
+    'no-console': 'off',
+    'no-only-tests/no-only-tests': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   }
 }


### PR DESCRIPTION
This is a small change with no associated Issue. Follow-up to #978 

The eslint plugin `no-only-tests` was preventing using `it.only()` locally. This PR makes it enabled only in production mode.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
