### PR TITLE
Renovatebot labels; bring back Dependabot for GH Actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - 'dependencies'
+      - 'infrastructure'

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ selenium-debug.log*
 *.sln
 *.sw*
 
+# Editor-related config that we may want to commit down the line,
+# just not yet
+jsconfig.json
+vue-shim.d.js
+
 # Yarn
 .yarn/*
 !.yarn/patches

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "labels": ["dependencies", "javascript"],
   "packageRules": [
     {
       "matchPackagePatterns": [
@@ -9,5 +10,8 @@
       ],
       "rangeStrategy": "replace"
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "addLabels": ["security"]
+  }
 }


### PR DESCRIPTION
This is a small change with no associated Issue, follow-up to #1007 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests 
- [x] No change log entry required 
- [x] No documentation update required.
