### PR TITLE
Use task icons in gscan, not job icons.

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -166,7 +166,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                           dark
                           icon
                         >
-                          <job :status="state" />
+                          <task :status="state"
+                            :startTime="Date.now()"
+                            :estimatedDuration="30"
+                          />
                         </v-btn>
                       </template>
                       <!-- tooltip text -->
@@ -204,7 +207,7 @@ import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import TaskState from '@/model/TaskState.model'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
 import { WorkflowState } from '@/model/WorkflowState.model'
-import Job from '@/components/cylc/Job'
+import Task from '@/components/cylc/Task'
 import Tree from '@/components/cylc/tree/Tree'
 import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon'
 import { addNodeToTree, createWorkflowNode } from '@/components/cylc/gscan/nodes'
@@ -215,7 +218,7 @@ import { GSCAN_DELTAS_SUBSCRIPTION } from '@/graphql/queries'
 export default {
   name: 'GScan',
   components: {
-    Job,
+    Task,
     Tree,
     WorkflowIcon
   },


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->
<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

As discussed in Element chat, the gscan panel shows task states represented by job icons. Technically this is a bug, even though it was deliberate, because task and jobs states are not quite the same thing. We apparently discussed this early in the project and decided to use job icons in gscan because:
- for the important states, there is a one-to-one mapping between task and job state
- coloured icons are better at-a-glance indicators
- existing users have been conditioned to seeing coloured icons, by the old Cylc 7 gscan GUI

However, the one-to-one mapping is somewhat beside the point in the case of retrying tasks, and I have evidence (a "bug" report) that users may find this confusing.

![ss1](https://user-images.githubusercontent.com/2362137/174175554-0f484ca7-9e05-4159-809f-32384c81c70c.png)

User: *"gscan showed no failed tasks, but when I opened the workflow there was a failed task[sic] in it"*.

On this branch:

![ss2](https://user-images.githubusercontent.com/2362137/174184625-682a50e9-f289-4d6d-98e6-d51b828f7c48.png)

(NB the task progress bar is not relevant here, would need to get rid of that of course).

Understanding this will still require understanding the difference between task and job icons, but unlike in the first case the result will not be confusing to those who do understand the difference.

So IMO we should change this. If others are super attached to a colourful gscan, we should consider making that a user preference (next to which we can document the failed job retrying task "subtlety" that results).

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] No documentation update required.
