### PR TITLE
Add Cylc 7 job colour theme.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,10 @@ menu would show the wrong workflow.
 [#1027](https://github.com/cylc/cylc-ui/pull/1027) - Remove development
 "Mutations View".
 
+[#1053](https://github.com/cylc/cylc-ui/pull/1053) - Add optional Cylc 7 colour
+theme for job icons.
+
+
 ### Fixes
 
 [#979](https://github.com/cylc/cylc-ui/pull/979) - Fix bug where the mutations

--- a/src/styles/cylc/_job.scss
+++ b/src/styles/cylc/_job.scss
@@ -69,6 +69,41 @@ $cjob: ".c-job svg.job rect";
     }
 }
 
+@mixin job_theme_cylc7() {
+    $grey: rgb(173,165,165);
+    $green: rgb(0,193,64);
+    $green2: rgb(161,207,37);
+    $red: rgb(255,0,0);
+    $red2: rgb(255,136,204);
+
+    #{$cjob} {
+        &.submitted {
+            fill: $green2;
+            stroke: $green2;
+        }
+
+        &.running {
+            fill: $green;
+            stroke: $green;
+        }
+
+        &.succeeded {
+            fill: $grey;
+            stroke: $grey;
+        }
+
+        &.failed {
+            fill: $red;
+            stroke: $red;
+        }
+
+        &.submit-failed {
+            fill: $red2;
+            stroke: $red2;
+        }
+    }
+}
+
 @mixin job_theme_greyscale() {
     $light: rgb(208,208,208);
     $medium: rgb(133,133,133);
@@ -140,6 +175,10 @@ $cjob: ".c-job svg.job rect";
     @include job_theme_default
 }
 
+#app.job_theme--cylc7 {
+    @include job_theme_cylc7
+}
+
 #app.job_theme--greyscale {
     @include job_theme_greyscale
 }
@@ -152,6 +191,10 @@ $cjob: ".c-job svg.job rect";
 // (this allows us to override the theme in the user-profile
 #app .job_theme--default {
     @include job_theme_default
+}
+
+#app .job_theme--cylc7 {
+    @include job_theme_cylc7
 }
 
 #app .job_theme--greyscale {

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -241,7 +241,8 @@ export default {
       jobThemes: [
         'default',
         'greyscale',
-        'colour_blind'
+        'colour_blind',
+        'cylc7'
       ],
       jobTheme: localStorage.jobTheme || 'default'
     }


### PR DESCRIPTION

I'm a convert to the new default colour theme myself, but have had several requests already for the old Cylc 7 "green == running" theme.

![Screenshot from 2022-06-20 13-39-13](https://user-images.githubusercontent.com/2362137/174510744-4330fb91-b7f8-48f5-a812-ea975c2df20f.png)


<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [x] Appropriate change log entry included.
- [x] No documentation update required.
