### PR TITLE
deps: bump nanoid 3.1.20 => 3.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12067,11 +12067,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:3.1.20":
-  version: 3.1.20
-  resolution: "nanoid@npm:3.1.20"
+  version: 3.2.0
+  resolution: "nanoid@npm:3.2.0"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: f6246023d5d8313c2c16be05c18cdb189a6de50ab6418b513b34086eda4aabd12866b2cbe435548c760dc43cf11830b26b14b113afde47305398e3345795e433
+  checksum: 3d1d5a69fea84e538057cf64106e713931c4ef32af344068ecff153ff91252f39b0f2b472e09b0dfff43ac3cf520c92938d90e6455121fe93976e23660f4fccc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Mocha pins all its deps to hardcoded versions so we didn't get the
  bugfix.
* The [changelog](https://github.com/ai/nanoid/blob/main/CHANGELOG.md#32)
  shows a single feature added.
* It's a test dependency so if there are issues they should show
  themselves.
* Closes https://github.com/cylc/cylc-ui/security/dependabot/28

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.