### PR TITLE
deps: bump selfsigned 1.10.14 => 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
   "bugs": {
     "url": "https://github.com/cylc/cylc-ui/issues"
   },
+  "resolutions": {
+    "webpack-dev-server/selfsigned": "^2.0.1"
+  },
   "packageManager": "yarn@3.2.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12220,10 +12220,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "node-forge@npm:0.10.0"
-  checksum: 5aa6dc9922e424a20ef101d2f517418e2bc9cfc0255dd22e0701c0fad1568445f510ee67f6f3fcdf085812c4ca1b847b8ba45683b34776828e41f5c1794e42e1
+"node-forge@npm:^1":
+  version: 1.3.1
+  resolution: "node-forge@npm:1.3.1"
+  checksum: 08fb072d3d670599c89a1704b3e9c649ff1b998256737f0e06fbd1a5bf41cae4457ccaee32d95052d80bbafd9ffe01284e078c8071f0267dc9744e51c5ed42a9
   languageName: node
   linkType: hard
 
@@ -14908,12 +14908,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selfsigned@npm:^1.10.8":
-  version: 1.10.14
-  resolution: "selfsigned@npm:1.10.14"
+"selfsigned@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "selfsigned@npm:2.0.1"
   dependencies:
-    node-forge: ^0.10.0
-  checksum: 616d131b18516ba2876398f0230987511d50a13816e0709b9f0d20246a524a2e83dfb27ea46ce2bfe331519583a156afa67bc3ece8bf0f9804aec06e2e8c7a21
+    node-forge: ^1
+  checksum: 864e65c2f31ca877bce3ccdaa3bdef5e1e992b63b2a03641e00c24cd305bf2acce093431d1fed2e5ae9f526558db4be5e90baa2b3474c0428fcf7e25cc86ac93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes:
* https://github.com/cylc/cylc-ui/security/dependabot/9
* https://github.com/cylc/cylc-ui/security/dependabot/10
* https://github.com/cylc/cylc-ui/security/dependabot/13
* https://github.com/cylc/cylc-ui/security/dependabot/29
* https://github.com/cylc/cylc-ui/security/dependabot/30
* https://github.com/cylc/cylc-ui/security/dependabot/31

Explanation:

* The selfsigned dependency is brought in by webpack-dev-server which is a dev dep used in testing.
* Resolve selfsigned dep to v2.
* v2.0.0 is the same as v1.10.14 but with the node-forge dep bumped so shouldn't cause issues with webpack-dev-server.

Tried out `yarn run serve`, everything seemed to be working fine.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.