### PR TITLE
Form validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,20 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-ui-1.3.0 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Enhancements
+
+[#1073](https://github.com/cylc/cylc-ui/pull/1073) - Improve validation of the
+command edit form.
+
+-------------------------------------------------------------------------------
 ## __cylc-ui-1.2.1 (<span actions:bind='release-date'>Released 2022-05-30</span>)__
 
 ### Fixes
 
-[#1011](https://github.com/cylc/cylc-ui/pull/1011) - Fix bug where the mutations
-menu would show the wrong workflow.
+[#1011](https://github.com/cylc/cylc-ui/pull/1011) - Fix bug where the
+workflow commands menu would show the wrong workflow.
 
 -------------------------------------------------------------------------------
 ## __cylc-ui-1.2.0 (<span actions:bind='release-date'>Released 2022-05-19</span>)__
@@ -30,7 +38,7 @@ menu would show the wrong workflow.
 
 ### Fixes
 
-[#979](https://github.com/cylc/cylc-ui/pull/979) - Fix bug where the mutations
+[#979](https://github.com/cylc/cylc-ui/pull/979) - Fix bug where the commands
 menu could sometimes break.
 
 -------------------------------------------------------------------------------
@@ -38,8 +46,8 @@ menu could sometimes break.
 
 ### Enhancements
 
-[#928](https://github.com/cylc/cylc-ui/pull/928) - Enable accessing mutations menu
-from GScan.
+[#928](https://github.com/cylc/cylc-ui/pull/928) - Enable accessing the workflow
+commands menu from GScan (sidebar).
 
 -------------------------------------------------------------------------------
 ## __cylc-ui-1.0.0 (<span actions:bind='release-date'>Released 2022-02-17</span>)__
@@ -65,7 +73,7 @@ or jobs now shows the relevant ID and status.
 
 ### Fixes
 
-[#927](https://github.com/cylc/cylc-ui/pull/927) - Fix bug where mutation
+[#927](https://github.com/cylc/cylc-ui/pull/927) - Fix bug where the commands
 menu would disappear when clicking on another task/cycle point/etc.
 
 -------------------------------------------------------------------------------
@@ -80,8 +88,8 @@ Support Jupyter Server conversion. (the CylcUIServer has been converted
 to a Jupyter Server extension).
 
 [#728](https://github.com/cylc/cylc-ui/pull/728) -
-Display authorized mutations in the User Profile and disable unauthorized
-mutations in the menu.
+Display authorized commands in the User Profile and disable unauthorized
+commands in the commands menu.
 
 [#749](https://github.com/cylc/cylc-ui/pull/749)
 & [#834](https://github.com/cylc/cylc-ui/issues/834)
@@ -146,7 +154,7 @@ are ignored.
 ### Fixes
 
 [#691](https://github.com/cylc/cylc-ui/pull/691) -
-Fix bug that could cause mutations to be run against the wrong workflow.
+Fix bug that could cause commands to be run against the wrong workflow.
 
 [#649](https://github.com/cylc/cylc-ui/pull/649) - Avoid re-sorting a
 sorted array, instead adding a new element in its sorted index (respecting
@@ -192,24 +200,24 @@ None or N/A.
 ### Enhancements
 
 [#636](https://github.com/cylc/cylc-ui/pull/636) -
-Improve the appearance of mutation menus and display an expandable short list
+Improve the appearance of commands menus and display an expandable short list
 of commands.
 
 [#616](https://github.com/cylc/cylc-ui/pull/616) - Alert the user if there are
 any errors processing deltas.
 
 [#623](https://github.com/cylc/cylc-ui/pull/623) - Display errors from
-mutations.
+commands.
 
 [#607](https://github.com/cylc/cylc-ui/pull/607) - Animate task progress
 using average run times.
 
-[#598](https://github.com/cylc/cylc-ui/pull/598) - Add mutation button
+[#598](https://github.com/cylc/cylc-ui/pull/598) - Add workflow commands menu.
 
 [#530](https://github.com/cylc/cylc-ui/pull/530) - Display message triggers.
 
 [#544](https://github.com/cylc/cylc-ui/pull/544) - Enable editing
-mutation inputs and support broadcasts in the UI.
+command inputs and support broadcasts in the UI.
 
 [#574](https://github.com/cylc/cylc-ui/pull/574) - Add collapse all and expand
 all buttons to Tree component.
@@ -221,7 +229,7 @@ in responsive mode (smaller viewports).
 in the tree, expand/collapse control, align tree-leaf-triangle. Also align
 job icons vertically in the middle of the HTML element.
 
-[#504](https://github.com/cylc/cylc-ui/pull/504) - Add mutations to the tree
+[#504](https://github.com/cylc/cylc-ui/pull/504) - Add commands menu to the tree
 view to allow interacting with tasks, families and cycles.
 
 [#499](https://github.com/cylc/cylc-ui/pull/499) - Add search and

--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -34,15 +34,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-if="responsive"
         >
           <v-text-field
-            class="purple-input search-input"
+            class="search-input"
             label="Search..."
-            color="purple"
           />
         </v-list-item>
 
         <v-list-item
           to="/"
-          active-class="primary grey--text text--darken-3"
         >
           <v-list-item-action>
             <v-icon>{{ svgPaths.home }}</v-icon>
@@ -52,7 +50,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <v-list-item
           to="/graphiql"
-          active-class="primary grey--text text--darken-3"
           class="v-list-item"
         >
           <v-list-item-action>
@@ -72,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
     <template v-slot:append>
       <div class="px-4 py-2 d-flex justify-center">
-        <span class="grey--text text--darken-2">
+        <span class="text--secondary">
           <strong v-if="environment !== 'PRODUCTION'">{{ environment }}</strong> {{ $t('App.name') }} {{ version }}
         </span>
       </div>

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -39,9 +39,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </svg>
       </div>
       <div class="c-environment-info">
-        <v-chip id="username" outlined color="grey lighten-1" text-color="grey darken-4">{{ user }}</v-chip>
+        <v-chip id="username" class="text--secondary" outlined>{{ user }}</v-chip>
         <span class="at">@</span>
-        <v-chip id="host" outlined color="grey lighten-1" text-color="grey darken-4">{{ environment }}</v-chip>
+        <v-chip id="host" class="text--secondary" outlined>{{ environment }}</v-chip>
       </div>
     </v-layout>
   </v-list-item-action-text>

--- a/src/components/cylc/Mutation.vue
+++ b/src/components/cylc/Mutation.vue
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
        :callbackSubmit='call'
        :initialData='initialData'
        ref="formGenerator"
+       v-model="isValid"
       />
       <br />
       <v-card-actions>
@@ -35,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           color="grey"
           @click="cancel()"
           text
+          data-cy="cancel"
         >
           Cancel
         </v-btn>
@@ -42,13 +44,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           color="orange"
           @click="$refs.formGenerator.reset()"
           text
+          data-cy="reset"
         >
           Reset
         </v-btn>
         <v-btn
           color="blue"
           @click="$refs.formGenerator.submit()"
+          :disabled="!isValid"
           text
+          data-cy="submit"
         >
           Submit
         </v-btn>
@@ -79,11 +84,12 @@ const status = {
 }
 Object.freeze(status)
 
-// the "data" function, defined here so we can easily reset the component
-const initialState = () => ({
+// initial state defined here so we can easily reset the component data
+const initialState = {
   response: '',
   status: status.waiting
-})
+}
+Object.freeze(initialState)
 
 export default {
   name: 'mutation',
@@ -115,7 +121,10 @@ export default {
     }
   },
 
-  data: initialState,
+  data: () => ({
+    ...initialState,
+    isValid: false
+  }),
 
   methods: {
     /* Execute the GraphQL mutation */
@@ -133,7 +142,7 @@ export default {
     /* Reset this component to it's initial state. */
     reset () {
       this.$refs.formGenerator.reset()
-      Object.assign(this.$data, initialState())
+      Object.assign(this.$data, initialState)
     }
   },
 

--- a/src/components/cylc/Mutation.vue
+++ b/src/components/cylc/Mutation.vue
@@ -48,15 +48,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         >
           Reset
         </v-btn>
-        <v-btn
-          color="blue"
-          @click="$refs.formGenerator.submit()"
-          :disabled="!isValid"
-          text
-          data-cy="submit"
+        <v-tooltip
+          top
+          color="error"
+          :disabled="isValid"
         >
-          Submit
-        </v-btn>
+          <template v-slot:activator="{ on, attrs }">
+            <v-btn
+              text
+              :color="isValid ? 'primary' : 'error'"
+              @click="$refs.formGenerator.submit()"
+              v-bind="attrs"
+              v-on="on"
+              data-cy="submit"
+            >
+              Submit
+            </v-btn>
+          </template>
+          <span>Form contains invalid or missing values!</span>
+        </v-tooltip>
       </v-card-actions>
       <p
        style="font-size:1.5em;"

--- a/src/components/graphqlFormGenerator/FormGenerator.vue
+++ b/src/components/graphqlFormGenerator/FormGenerator.vue
@@ -17,8 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <v-form
-    validate
     class="c-mutation-form"
+    :value="value"
+    @input="$emit('input', $event)"
   >
     <!-- the mutation title -->
     <h3
@@ -120,6 +121,12 @@ export default {
   },
 
   props: {
+    value: {
+      // validity of form
+      type: Boolean,
+      required: true,
+      default: () => false
+    },
     mutation: {
       type: Object,
       required: true
@@ -218,7 +225,6 @@ export default {
     },
 
     submit () {
-      // TODO: validate
       if (this.callbackSubmit) {
         this.callbackSubmit(this.model)
       }

--- a/src/components/graphqlFormGenerator/FormInput.vue
+++ b/src/components/graphqlFormGenerator/FormInput.vue
@@ -23,15 +23,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <!-- eslint-disable-next-line vue/no-unused-vars -->
     <template v-slot:activator="{ on }">
       <!-- TODO: fix the inputType form alignment thinggy -->
-      <!-- NOTE: the `is` field comes from `props` -->
+      <!-- NOTE: the `is` field comes from `props` v-bind -->
       <!-- eslint-disable-next-line vue/require-component-is -->
       <component
-       v-model="model"
-       v-bind="props"
-       v-mask="props.mask"
-       :gqlType="gqlType"
-       :types="types"
-       @blur="showHelp = false"
+        v-model="model"
+        v-bind="props"
+        v-mask="props.mask"
+        :gqlType="gqlType"
+        :types="types"
+        @blur="showHelp = false"
       >
         <template v-slot:append>
           <v-icon
@@ -117,8 +117,8 @@ export default {
       } else {
         componentProps = this.namedTypes.String
         // eslint-disable-next-line no-console
-        console.error(
-          'Warning: falling back to string for ' +
+        console.warn(
+          'Falling back to string for ' +
           `type: ${this.gqlType.name}, kind: ${this.gqlType.kind}`
         )
       }

--- a/src/components/graphqlFormGenerator/components/Enum.vue
+++ b/src/components/graphqlFormGenerator/components/Enum.vue
@@ -19,9 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <v-select
     persistent-hint
     v-model="model"
+    v-bind="$attrs"
     :items="type.enumValues"
     item-text="name"
     :hint="itemDesc"
+    placeholder="Select an option"
   />
 </template>
 

--- a/src/components/graphqlFormGenerator/components/Enum.vue
+++ b/src/components/graphqlFormGenerator/components/Enum.vue
@@ -17,11 +17,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <v-select
-   persistent-hint
-   v-model="model"
-   :items="type.enumValues"
-   item-text="name"
-   :hint="itemDesc"
+    persistent-hint
+    v-model="model"
+    :items="type.enumValues"
+    item-text="name"
+    :hint="itemDesc"
   />
 </template>
 

--- a/src/components/graphqlFormGenerator/components/List.vue
+++ b/src/components/graphqlFormGenerator/components/List.vue
@@ -29,12 +29,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-list-item-content>
           <!-- The input -->
           <component
-           v-model="value[index]"
-           :propOverrides="{'dense': true}"
-           :gqlType="gqlType.ofType"
-           :types="types"
-           :is="FormInput"
-            ref="inputs"
+            v-model="value[index]"
+            :propOverrides="{dense: true}"
+            :gqlType="gqlType.ofType"
+            :types="types"
+            :is="FormInput"
+             ref="inputs"
           >
             <template v-slot:append-outer>
               <v-icon

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -17,12 +17,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <component
-   v-model="model"
-   :propOverrides="{rules: [x => Boolean(x) || 'Required!']}"
-   :gqlType="gqlType.ofType"
-   :types="types"
-   label="(required)"
-   :is="FormInput"
+    v-model="model"
+    :propOverrides="{rules: [x => Boolean(x) || 'Required!']}"
+    :gqlType="gqlType.ofType"
+    :types="types"
+    label="(required)"
+    :is="FormInput"
   >
     <template v-slot:append-outer>
       <!-- pass the "append-outer" slot onto the child component -->

--- a/src/components/graphqlFormGenerator/components/NonNull.vue
+++ b/src/components/graphqlFormGenerator/components/NonNull.vue
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <component
     v-model="model"
-    :propOverrides="{rules: [x => Boolean(x) || 'Required!']}"
+    :propOverrides="{rules: [nonNullRule]}"
     :gqlType="gqlType.ofType"
     :types="types"
     label="(required)"
@@ -37,6 +37,10 @@ import { formElement } from '@/components/graphqlFormGenerator/mixins'
 
 export default {
   name: 'g-non-null',
-  mixins: [formElement]
+  mixins: [formElement],
+  methods: {
+    nonNullRule: // disallow empty array/string or nullish
+      x => Boolean(x?.length ?? x != null) || 'Required'
+  }
 }
 </script>

--- a/src/components/graphqlFormGenerator/components/vuetify.js
+++ b/src/components/graphqlFormGenerator/components/vuetify.js
@@ -50,11 +50,16 @@ const VNumberField = Vue.component(
         }
       }
     }
-  })
+  }
+)
+
+const RE = {
+  cyclePoint: '\\d+(T\\d+(Z|[+-]\\d+)?)?'
+}
 
 const RULES = {
   integer:
-    x => (!x || Number.isInteger(x)) || 'Integer',
+    x => (!x || Number.isInteger(x)) || 'Must be integer',
   noSpaces:
     x => (!x || !x.includes(' ')) || 'Cannot contain spaces',
   cylcConfigItem:
@@ -118,7 +123,7 @@ export default {
       rules: [
         RULES.noSpaces,
         // character whitelist
-        x => Boolean(!x || x.match(/^[\dT]+(Z|[+-]\d+)?$/)) || 'Invalid Cycle Point'
+        x => Boolean(!x || x.match(`^${RE.cyclePoint}$`)) || 'Invalid Cycle Point'
       ]
     },
     CyclePointGlob: {
@@ -131,6 +136,12 @@ export default {
     },
     BroadcastSetting: {
       is: GBroadcastSetting
+    },
+    BroadcastCyclePoint: {
+      is: VTextField,
+      rules: [
+        x => Boolean(!x || x.match(`^(${RE.cyclePoint}|\\*)$`)) || 'Must be "*" or a valid cycle point'
+      ]
     },
     // TaskStatus
     // TaskState

--- a/src/components/graphqlFormGenerator/components/vuetify.js
+++ b/src/components/graphqlFormGenerator/components/vuetify.js
@@ -164,7 +164,10 @@ export default {
     TimePoint: {
       is: VTextField,
       placeholder: 'yyyy-mm-ddThh:mm:ss',
-      mask: '####-##-##T##:##:##'
+      mask: '####-##-##T##:##:##',
+      rules: [
+        x => Boolean(!x || x.match(/^\d{4}(-\d{2}(-\d{2}(T\d{2}(:\d{2}(:\d{2})?)?)?)?)?$/)) || 'Invalid'
+      ]
     },
     RuntimeConfiguration: {
       is: VTextField,

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -24,7 +24,9 @@ import Vuetify from 'vuetify/lib'
 Vue.use(Vuetify)
 
 export default new Vuetify({
-  theme: { disable: true },
+  theme: {
+    // dark: true
+  },
   icons: {
     iconfont: 'mdiSvg'
   }

--- a/src/styles/_util.scss
+++ b/src/styles/_util.scss
@@ -15,24 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-@import '~vuetify/src/styles/styles';
-@import '../util.scss';
-
-.c-header {
-  display: block;
-
-  @include theme-dependent(background-color, $grey, 3);
-
-  .layout {
-    .c-environment-info {
-      font-size: 1rem;
-      font-weight: map-get($font-weights, 'regular');
-
-      .v-chip {
-        font-size: 1rem;
-        @include theme-dependent(background-color, $grey, 5, !important);
-        @include theme-dependent(border-color, $grey, 1, !important);
-      }
+@mixin theme-dependent($prop, $color, $intensity, $important: null) {
+  // Set the specified color property in a way that just works regardless of
+  // whether the theme is light or dark.
+  // If light theme, lighten the specified color by the specified intensity;
+  // if dark, darken.
+  @each $theme in 'light', 'dark' {
+    .theme--#{$theme} & {
+      #{$prop}: map-get($color, '#{$theme}en-#{$intensity}') $important;
     }
   }
 }

--- a/src/styles/cylc/_drawer.scss
+++ b/src/styles/cylc/_drawer.scss
@@ -16,12 +16,14 @@
  */
 
 @import '~vuetify/src/styles/styles';
+@import '../util.scss';
 
 /* this is not in our styles/material-dashboard, so we need to force-override */
 .v-navigation-drawer {
-  background-color: map-get($grey, 'lighten-4') !important;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
+
+  @include theme-dependent(background-color, $grey, 4);
 
   .v-list__tile {
     border-radius: 4px;

--- a/src/styles/cylc/_toolbar.scss
+++ b/src/styles/cylc/_toolbar.scss
@@ -29,7 +29,6 @@
 }
 
 .c-toolbar {
-  background-color: map-get($grey, 'lighten-4') !important;
 
   .v-toolbar__title {
     // clear default padding (too much space on the left)

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -103,3 +103,9 @@ html {
 .mw-100 {
   max-width: 100%;
 }
+
+// Fix lack of margin for v-card-actions button with tooltip
+// https://github.com/vuetifyjs/vuetify/issues/9756
+.v-application--is-ltr .v-card__actions > .v-btn + .v-tooltip + .v-btn {
+  margin-left: 8px;
+}

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="h-100">
-    <div class="c-tree pa-2 h-100">
+    <div class="c-tree pa-2 h-100" data-cy="tree-view">
       <tree-component
         :workflows="workflows"
         :hoverable="false"

--- a/tests/e2e/specs/aotf.cy.js
+++ b/tests/e2e/specs/aotf.cy.js
@@ -232,7 +232,7 @@ describe('Api On The Fly', () => {
         .should('have.length', 1)
 
         // click the submit button
-        .find('.v-card__actions :nth-child(4)')
+        .find('[data-cy=submit]')
         .click()
         .then(() => {
           // this should execute one mutation...

--- a/tests/e2e/specs/mutation.cy.js
+++ b/tests/e2e/specs/mutation.cy.js
@@ -138,6 +138,11 @@ describe('Mutations component', () => {
     // Form should be valid initially
     cy.get('[data-cy=submit]').as('submit')
       .should('not.be.disabled')
+      .should('not.have.class', 'error--text')
+      // Indirect test for "form invalid" tooltip by checking aria-expanded attribute
+      // (not ideal but it's way too troublesome to test visibility of .v-tooltip__content)
+      .trigger('mouseenter')
+      .should('have.attr', 'aria-expanded', 'false') // should not be visible
     // Now type invalid input
     cy.get('.c-mutation-form')
       .find('.v-list-item__title')
@@ -149,6 +154,9 @@ describe('Mutations component', () => {
       .get('@textField')
       .should('have.class', 'error--text')
       .get('@submit')
-      .should('be.disabled')
+      .should('have.class', 'error--text')
+      .trigger('mouseenter')
+      .should('have.attr', 'aria-expanded', 'true') // tooltip should be visible
+      .should('not.be.disabled') // user can still submit if they really want to
   })
 })

--- a/tests/e2e/specs/mutation.cy.js
+++ b/tests/e2e/specs/mutation.cy.js
@@ -15,16 +15,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { upperFirst } from 'lodash'
 import {
   MUTATIONS
 } from '../support/graphql'
 
 describe('Mutations component', () => {
   beforeEach(() => {
+    // Patch graphql responses
     cy
       .intercept('/graphql', (req) => {
         const query = req.body.query
-        if (query.includes('__schema')) {
+        if (query.includes('__schema')) { // query that loads mutations
           req.reply({
             data: {
               __schema: {
@@ -35,13 +37,13 @@ describe('Mutations component', () => {
               }
             }
           })
-        } else {
+        } else { // mutation
           console.log(req)
           req.reply({
             data: {
               [req.body.operationName]: {
                 result: [true, {}],
-                __typename: req.body.operationName.charAt(0).toUpperCase() + req.body.operationName.slice(1)
+                __typename: upperFirst(req.body.operationName)
               }
             }
           })
@@ -49,23 +51,24 @@ describe('Mutations component', () => {
       })
       .as('HoldMutationQuery')
   })
+
   /**
    * @param {string} nodeName - the tree node name, to search for and open the mutations form
    */
   const openMutationsForm = (nodeName) => {
-    // check that the skeleton does not exist
-    cy.get('.lm-Widget')
-      .find('.v-skeleton-loader')
-      .then((loader) => {
-        const firstChild = loader.children('div').first()
-        // The skeleton may, or may not, still be displaying in the UI...
-        if (firstChild.attr('class') && firstChild.attr('class').includes('skeleton')) {
-          cy.wrap(firstChild)
-            .should('not.exist')
-        }
-      })
-    cy
-      .get('span')
+    cy.window().its('app.$workflowService').then(service => {
+      // mock the apollo client's mutate method to catch low-level calls
+      service.primaryMutations = {
+        workflow: ['workflowMutation']
+      }
+    })
+    cy.get('[data-cy=tree-view]').as('treeView')
+      .find('.treeitem')
+      .find('.c-task')
+      .should('be.visible')
+    // cy.wait(['@HoldMutationQuery'])
+    cy.get('@treeView')
+      .find('span')
       .contains(nodeName)
       .parent()
       .find('.c-task')
@@ -77,21 +80,10 @@ describe('Mutations component', () => {
       .should('be.visible')
       .click({ force: true })
   }
+
   const submitMutationForms = () => {
     cy.visit('/#/workflows/one')
-    cy.window().its('app.$workflowService').then(service => {
-      // mock the apollo client's mutate method to catch low-level calls
-      service.primaryMutations = {
-        workflow: ['workflowMutation']
-      }
-    })
-    cy
-      .get('.c-tree')
-      .get('.treeitem')
-      .get('.c-task')
-      .should('be.visible')
     openMutationsForm('BAD')
-    cy.wait(['@HoldMutationQuery'])
     // fill mocked mutation form with any data
     cy
       .get('.v-dialog')
@@ -115,9 +107,11 @@ describe('Mutations component', () => {
           .should('be.visible')
       })
   }
+
   it('should submit a mutation form', () => {
     submitMutationForms()
   })
+
   it('should not remember data after submitting a mutation form', () => {
     submitMutationForms()
     // close submit form (not clicking on cancel, as it appears to clear the form, but outside the dialog)
@@ -136,5 +130,25 @@ describe('Mutations component', () => {
             cy.wrap($el).should('not.contain.value', 'ABC')
           })
       })
+  })
+
+  it('should validate the form', () => {
+    cy.visit('/#/workflows/one')
+    openMutationsForm('checkpoint')
+    // Form should be valid initially
+    cy.get('[data-cy=submit]').as('submit')
+      .should('not.be.disabled')
+    // Now type invalid input
+    cy.get('.c-mutation-form')
+      .find('.v-list-item__title')
+      .contains('workflow')
+      .parent()
+      .find('.v-input.v-text-field:first').as('textField')
+      .find('input[type="text"]')
+      .type(' ') // (spaces should not be allowed)
+      .get('@textField')
+      .should('have.class', 'error--text')
+      .get('@submit')
+      .should('be.disabled')
   })
 })

--- a/tests/e2e/specs/workflow.cy.js
+++ b/tests/e2e/specs/workflow.cy.js
@@ -21,15 +21,30 @@ describe('Workflow view and component/widget', () => {
       .get('.v-alert')
       .should('not.exist')
   })
+
   it('Should display the Workflow component in the Workflow view, with a Tree widget', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabLabel').should('have.length', 1)
+
+    // The skeleton loader should stop existing
+    cy.get('.lm-Widget')
+      .find('.v-skeleton-loader')
+      .then((loader) => {
+        const firstChild = loader.children('div').first()
+        // The skeleton may, or may not, still be displaying in the UI...
+        if (firstChild.attr('class') && firstChild.attr('class').includes('skeleton')) {
+          cy.wrap(firstChild)
+            .should('not.exist')
+        }
+      })
   })
+
   it('Should remove the default widget and leave no more widgets', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabCloseIcon').click()
     cy.get('.lm-TabBar-tabLabel').should('not.exist')
   })
+
   it('Should be able to add two widgets of the same type', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabLabel').should('have.length', 1)
@@ -37,6 +52,7 @@ describe('Workflow view and component/widget', () => {
     cy.get('#toolbar-add-Tree-view').click()
     cy.get('.lm-TabBar-tabLabel').should('have.length', 2)
   })
+
   it('Should be able to add two widgets of different types', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabLabel').should('have.length', 1)
@@ -44,6 +60,7 @@ describe('Workflow view and component/widget', () => {
     cy.get('#toolbar-add-Table-view').click()
     cy.get('.lm-TabBar-tabLabel').should('have.length', 2)
   })
+
   it('Should remove widgets added successfully', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabLabel').should('have.length', 1)
@@ -57,6 +74,7 @@ describe('Workflow view and component/widget', () => {
     // ensure we have no widgets now
     cy.get('.lm-TabBar-tabLabel').should('not.exist')
   })
+
   it('Should remove widgets when leaving the Workflow view', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabLabel').should('have.length', 1)
@@ -69,6 +87,7 @@ describe('Workflow view and component/widget', () => {
     // ensure we have no widgets now
     cy.get('.lm-TabBar-tabLabel').should('not.exist')
   })
+
   it('Should remove widgets when updating the Workflow view', () => {
     cy.visit('/#/workflows/one')
     cy.get('.lm-TabBar-tabLabel').should('have.length', 1)


### PR DESCRIPTION
These changes partially address #885

Improve mutation form validation:
- Make validation errors more prominent with red colour
- Submit button turns red with warning tooltip if there are validation errors (do not disable completely because we leave control to the user)
- Improve/fix some of the validation rules for various inputs
  - The broadcast cycle point input validation needs https://github.com/cylc/cylc-flow/pull/5007 but this can be merged before that

![image](https://user-images.githubusercontent.com/61982285/180460207-536e2965-4c25-41b3-a9f6-7d7c2b4a3fd4.png)

It does not address having empty lists in the form, as mentioned in the issue #885

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included
- [x] Appropriate change log entry included.
- [x] No documentation update required.
