### PR TITLE
Reversed the default sort order of jobs in the table view.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+
+## __cylc-ui-1.4.0 (<span actions:bind='release-date'>Pending</span>)__
+
+### Fixes
+
+[#1075](https://github.com/cylc/cylc-ui/pull/1075) - Reverse default sort order
+of the table view so it matches the tree view.
 -------------------------------------------------------------------------------
 ## __cylc-ui-1.3.0 (<span actions:bind='release-date'>Released 2022-07-27</span>)__
 
@@ -17,13 +24,6 @@ ones in. -->
 
 [#1073](https://github.com/cylc/cylc-ui/pull/1073) - Improve validation of the
 command edit form.
-
-## __cylc-ui-1.2.2 (<span actions:bind='release-date'>Pending</span>)__
-
-### Fixes
-
-[#1075](https://github.com/cylc/cylc-ui/pull/1075) - Reverse default sort order
-of the table view so it matches the tree view.
 
 -------------------------------------------------------------------------------
 ## __cylc-ui-1.2.1 (<span actions:bind='release-date'>Released 2022-05-30</span>)__

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,13 @@ ones in. -->
 [#1073](https://github.com/cylc/cylc-ui/pull/1073) - Improve validation of the
 command edit form.
 
+## __cylc-ui-1.2.2 (<span actions:bind='release-date'>Pending</span>)__
+
+### Fixes
+
+[#1075](https://github.com/cylc/cylc-ui/pull/1075) - Reverse default sort order
+of the table view so it matches the tree view.
+
 -------------------------------------------------------------------------------
 ## __cylc-ui-1.2.1 (<span actions:bind='release-date'>Released 2022-05-30</span>)__
 

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -240,8 +240,8 @@ export default {
         mdiChevronDown,
         mdiArrowDown
       },
-      sortBy: [],
-      sortDesc: [],
+      sortBy: ['Cycle Point'],
+      sortDesc: [true],
       expanded: [],
       headers: [
         {

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -99,6 +99,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           fluid
           class="ma-0 pa-0 w-100 h-100 left-0 top-0 position-absolute"
         >
+          {{  }}
           <v-data-table
             :headers.sync="headers"
             :items.sync="filteredTasks"
@@ -241,7 +242,7 @@ export default {
         mdiArrowDown
       },
       sortBy: ['Cycle Point'],
-      sortDesc: [true],
+      sortDesc: [localStorage.cyclePointsOrderDesc ? JSON.parse(localStorage.cyclePointsOrderDesc) : true],
       expanded: [],
       headers: [
         {

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -99,7 +99,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           fluid
           class="ma-0 pa-0 w-100 h-100 left-0 top-0 position-absolute"
         >
-          {{  }}
           <v-data-table
             :headers.sync="headers"
             :items.sync="filteredTasks"

--- a/tests/unit/components/cylc/table/table.data.js
+++ b/tests/unit/components/cylc/table/table.data.js
@@ -27,7 +27,8 @@ const simpleTableTasks = [
       id: BASE_TOKENS.clone({ task: 'taskA' }).id,
       state: TaskState.RUNNING.name,
       name: 'taskA',
-      meanElapsedTime: 2000
+      meanElapsedTime: 2000,
+      cyclePoint: '20000101T0000Z'
     },
     latestJob: {
       platform: 'localhost',
@@ -45,7 +46,8 @@ const simpleTableTasks = [
     node: {
       id: BASE_TOKENS.clone({ task: 'taskB' }).id,
       state: TaskState.WAITING.name,
-      name: 'taskB'
+      name: 'taskB',
+      cyclePoint: '20000102T0000Z'
     },
     latestJob: {},
     jobs: []
@@ -55,7 +57,8 @@ const simpleTableTasks = [
     node: {
       id: BASE_TOKENS.clone({ task: 'taskC' }).id,
       state: TaskState.SUBMITTED.name,
-      name: 'taskC'
+      name: 'taskC',
+      cyclePoint: '20000103T0000Z'
     },
     latestJob: {},
     jobs: []

--- a/tests/unit/components/cylc/table/table.vue.spec.js
+++ b/tests/unit/components/cylc/table/table.vue.spec.js
@@ -74,6 +74,26 @@ describe('Table component', () => {
     })
   }
   global.requestAnimationFrame = cb => cb()
+  it('should enforce the newest job first policy', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        tasks: simpleTableTasks
+      }
+    })
+
+    // check the the raw task data has the cycle points from lowest to highest
+    expect(wrapper.vm.tasks[wrapper.vm.filteredTasks.length - 1].node.cyclePoint).to.equal('20000103T0000Z')
+    expect(wrapper.vm.tasks[0].node.cyclePoint).to.equal('20000101T0000Z')
+
+    // check the filtered tasks  have the cycle points from high to low
+    expect(wrapper.vm.filteredTasks[wrapper.vm.filteredTasks.length - 1].node.cyclePoint).to.equal('20000101T0000Z')
+    expect(wrapper.vm.filteredTasks[0].node.cyclePoint).to.equal('20000103T0000Z')
+
+    // check that the actual html markup is also correct
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('table > tbody > tr:nth-child(1) > td:nth-child(3)').element.innerHTML).to.equal('20000103T0000Z')
+    expect(wrapper.find('table > tbody > tr:nth-child(' + String(wrapper.vm.filteredTasks.length) + ') > td:nth-child(3)').element.innerHTML).to.equal('20000101T0000Z')
+  })
   it('should display the table with valid data', () => {
     const wrapper = mountFunction({
       propsData: {


### PR DESCRIPTION
These changes close #1002 

Make the default sort order of the table view match the the tree view. It should respect the "Latest cycle point on top" setting in the UI settings.

I'd appreciate some help with testing this. Going to try and work it out myself as an excercise in getting used to JS & Cypress.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
