### PR TITLE
made mutation edit button x-large to make it easier to click.

### DIFF
--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -74,13 +74,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-content>
             <v-list-item-action>
               <v-btn
+                icon
                 :disabled=!authorised
                 x-large
                 class="float-right"
                 @click.stop="openDialog(mutation)"
                 data-cy="mutation-edit"
-                outlined
-                width=80%
               >
                 <v-icon>{{ icons.pencil }}</v-icon>
               </v-btn>

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -73,14 +73,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <span class="c-description">{{ mutation._shortDescription }}</span>
             </v-list-item-content>
             <v-list-item-action>
-              <v-icon
+              <v-btn
+                icon
                 :disabled=!authorised
                 x-large
                 class="float-right"
                 @click.stop="openDialog(mutation)"
+                data-cy="mutation-edit"
               >
-                {{ icons.pencil }}
-              </v-icon>
+                <v-icon>{{ icons.pencil }}</v-icon>
+              </v-btn>
             </v-list-item-action>
           </v-list-item>
           <v-list-item

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -75,7 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <v-list-item-action>
               <v-icon
                 :disabled=!authorised
-                medium
+                x-large
                 class="float-right"
                 @click.stop="openDialog(mutation)"
               >

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -74,12 +74,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-content>
             <v-list-item-action>
               <v-btn
-                icon
                 :disabled=!authorised
                 x-large
                 class="float-right"
                 @click.stop="openDialog(mutation)"
                 data-cy="mutation-edit"
+                outlined
+                width=80%
               >
                 <v-icon>{{ icons.pencil }}</v-icon>
               </v-btn>

--- a/src/styles/cylc/_menu.scss
+++ b/src/styles/cylc/_menu.scss
@@ -38,7 +38,4 @@
       line-height: 1.35;
     }
   }
-  .pad-button {
-    padding: 30px;
-  }
 }

--- a/src/styles/cylc/_menu.scss
+++ b/src/styles/cylc/_menu.scss
@@ -38,4 +38,7 @@
       line-height: 1.35;
     }
   }
+  .pad-button {
+    padding: 30px;
+  }
 }

--- a/tests/e2e/specs/aotf.cy.js
+++ b/tests/e2e/specs/aotf.cy.js
@@ -220,10 +220,10 @@ describe('Api On The Fly', () => {
       // click on the first mutation
       cy
         .get('.c-mutation-menu-list:first')
-        .find('.v-list-item__action > .v-icon')
+        .find('[data-cy=mutation-edit]')
         .should('exist')
         .should('be.visible')
-        .click({ force: true })
+        .click()
 
       // this should open the mutation editor
       cy
@@ -316,8 +316,8 @@ describe('Api On The Fly', () => {
         .find('.v-list-item')
         .should('have.length', 2) // +1 because of the "see more" button
         // toggle the menu to "see more" items
-        .find('.v-btn:first')
-        .click({ force: true })
+        .find('#less-more-button')
+        .click()
         // it should now list the five workflow mutations
         .get('.c-mutation-menu-list:first')
         .find('.v-list-item')

--- a/tests/e2e/specs/mutation.cy.js
+++ b/tests/e2e/specs/mutation.cy.js
@@ -72,13 +72,13 @@ describe('Mutations component', () => {
       .contains(nodeName)
       .parent()
       .find('.c-task')
-      .click({ force: true })
+      .click()
     cy
       .get('.c-mutation-menu-list:first')
-      .find('.v-list-item__action > .v-icon')
+      .find('[data-cy=mutation-edit]')
       .should('exist')
       .should('be.visible')
-      .click({ force: true })
+      .click()
   }
 
   const submitMutationForms = () => {


### PR DESCRIPTION
May close #1096 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (v small change)
- [x] No documentation update required.
