### PR TITLE
Table view: use natural sort order for cycle point column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ ones in. -->
 
 [#1075](https://github.com/cylc/cylc-ui/pull/1075) - Reverse default sort order
 of the table view so it matches the tree view.
+
+[#1107](https://github.com/cylc/cylc-ui/pull/1107) - Use natural sort for table
+view cycle point column.
+
 -------------------------------------------------------------------------------
 ## __cylc-ui-1.3.0 (<span actions:bind='release-date'>Released 2022-07-27</span>)__
 

--- a/cypress/component/cylc-icons.cy.js
+++ b/cypress/component/cylc-icons.cy.js
@@ -36,7 +36,7 @@ const TaskComponent = {
   data: () => ({
     // set the progress indicator for running tasks to ~33%
     // 33% of the 100s duration in milliseconds (0.33 * 100s * 1000ms/s)
-    startTime: String(new Date(Date.now() - 33333).toISOString())
+    startTime: new Date(Date.now() - 33333).toISOString()
   })
 }
 

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -203,7 +203,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import { taskStartTime, taskEstimatedDuration } from '@/utils/tasks'
 import { mdiChevronDown, mdiArrowDown } from '@mdi/js'
 import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
-import { datetimeSort } from '@/components/cylc/table/sort'
+import { datetimeComparator } from '@/components/cylc/table/sort'
 
 export default {
   name: 'TableComponent',
@@ -259,27 +259,27 @@ export default {
         {
           text: 'Job ID',
           value: 'latestJob.jobId',
-          sort: (a, b) => a ?? 0 - b ?? 0
+          sort: (a, b) => parseInt(a ?? 0) - parseInt(b ?? 0)
         },
         {
           text: 'T-submit',
           value: 'latestJob.submittedTime',
-          sort: datetimeSort
+          sort: datetimeComparator
         },
         {
           text: 'T-start',
           value: 'latestJob.startedTime',
-          sort: datetimeSort
+          sort: datetimeComparator
         },
         {
           text: 'T-finish',
           value: 'latestJob.finishedTime',
-          sort: datetimeSort
+          sort: datetimeComparator
         },
         {
           text: 'dT-mean',
           value: 'meanElapsedTime',
-          sort: (a, b) => a ?? 0 - b ?? 0
+          sort: (a, b) => parseInt(a ?? 0) - parseInt(b ?? 0)
         }
       ],
       tasksFilter: {

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -320,28 +320,28 @@ export default {
           const sortDesc = this.sortDesc[this.sortBy.indexOf(sortByProperty)]
           switch (sortByProperty) {
           case 'Task':
-            valueA = typeof taskA.node.name !== 'undefined' ? taskA.node.name : ''
-            valueB = typeof taskB.node.name !== 'undefined' ? taskB.node.name : ''
+            valueA = taskA.node.name ?? ''
+            valueB = taskB.node.name ?? ''
             return sortDesc ? DEFAULT_COMPARATOR(valueB, valueA) : DEFAULT_COMPARATOR(valueA, valueB)
           case 'Cycle Point':
             valueA = taskA.node.cyclePoint !== '' && typeof taskA.node.cyclePoint !== 'undefined' ? String(taskA.node.cyclePoint) : ''
             valueB = taskB.node.cyclePoint !== '' && typeof taskB.node.cyclePoint !== 'undefined' ? String(taskB.node.cyclePoint) : ''
             return sortDesc ? DEFAULT_COMPARATOR(valueB, valueA) : DEFAULT_COMPARATOR(valueA, valueB)
           case 'Jobs':
-            valueA = typeof taskA.jobs !== 'undefined' ? taskA.jobs.length : 0
-            valueB = typeof taskB.jobs !== 'undefined' ? taskB.jobs.length : 0
+            valueA = taskA.jobs?.length ?? 0
+            valueB = taskB.jobs?.length ?? 0
             return sortDesc ? valueB - valueA : valueA - valueB
           case 'Host':
-            valueA = typeof taskA.latestJob.platform !== 'undefined' ? taskA.latestJob.platform : ''
-            valueB = typeof taskB.latestJob.platform !== 'undefined' ? taskB.latestJob.platform : ''
+            valueA = taskA.latestJob.platform ?? ''
+            valueB = taskB.latestJob.platform ?? ''
             return sortDesc ? DEFAULT_COMPARATOR(valueB, valueA) : DEFAULT_COMPARATOR(valueA, valueB)
           case 'Job System':
-            valueA = typeof taskA.latestJob.jobRunnerName !== 'undefined' ? taskA.latestJob.jobRunnerName : ''
-            valueB = typeof taskB.latestJob.jobRunnerName !== 'undefined' ? taskB.latestJob.jobRunnerName : ''
+            valueA = taskA.latestJob.jobRunnerName ?? ''
+            valueB = taskB.latestJob.jobRunnerName ?? ''
             return sortDesc ? valueB.localeCompare(valueA) : valueA.localeCompare(valueB)
           case 'Job ID':
-            valueA = typeof taskA.latestJob.jobId !== 'undefined' ? taskA.latestJob.jobId : 0
-            valueB = typeof taskB.latestJob.jobId !== 'undefined' ? taskB.latestJob.jobId : 0
+            valueA = taskA.latestJob.jobId ?? 0
+            valueB = taskB.latestJob.jobId ?? 0
             return sortDesc ? valueB - valueA : valueA - valueB
           case 'T-submit':
             valueA = taskA.latestJob.submittedTime !== '' && typeof taskA.latestJob.submittedTime !== 'undefined' ? (new Date(taskA.latestJob.submittedTime)).getTime() : 0
@@ -356,8 +356,8 @@ export default {
             valueB = taskB.latestJob.finishedTime !== '' && typeof taskB.latestJob.finishedTime !== 'undefined' ? (new Date(taskB.latestJob.finishedTime)).getTime() : 0
             return sortDesc ? valueB - valueA : valueA - valueB
           case 'dT-mean':
-            valueA = typeof taskA.meanElapsedTime !== 'undefined' ? taskA.meanElapsedTime : 0
-            valueB = typeof taskB.meanElapsedTime !== 'undefined' ? taskB.meanElapsedTime : 0
+            valueA = taskA.meanElapsedTime ?? 0
+            valueB = taskB.meanElapsedTime ?? 0
             return sortDesc ? valueB - valueA : valueA - valueB
           default:
             return 0

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -217,6 +217,7 @@ import Job from '@/components/cylc/Job'
 import cloneDeep from 'lodash/cloneDeep'
 import { taskStartTime, taskEstimatedDuration } from '@/utils/tasks'
 import { mdiChevronDown, mdiArrowDown } from '@mdi/js'
+import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
 
 export default {
   name: 'TableComponent',
@@ -321,11 +322,11 @@ export default {
           case 'Task':
             valueA = typeof taskA.node.name !== 'undefined' ? taskA.node.name : ''
             valueB = typeof taskB.node.name !== 'undefined' ? taskB.node.name : ''
-            return sortDesc ? valueB.localeCompare(valueA) : valueA.localeCompare(valueB)
+            return sortDesc ? DEFAULT_COMPARATOR(valueB, valueA) : DEFAULT_COMPARATOR(valueA, valueB)
           case 'Cycle Point':
             valueA = taskA.node.cyclePoint !== '' && typeof taskA.node.cyclePoint !== 'undefined' ? String(taskA.node.cyclePoint) : ''
             valueB = taskB.node.cyclePoint !== '' && typeof taskB.node.cyclePoint !== 'undefined' ? String(taskB.node.cyclePoint) : ''
-            return sortDesc ? valueB.localeCompare(valueA) : valueA.localeCompare(valueB)
+            return sortDesc ? DEFAULT_COMPARATOR(valueB, valueA) : DEFAULT_COMPARATOR(valueA, valueB)
           case 'Jobs':
             valueA = typeof taskA.jobs !== 'undefined' ? taskA.jobs.length : 0
             valueB = typeof taskB.jobs !== 'undefined' ? taskB.jobs.length : 0
@@ -333,7 +334,7 @@ export default {
           case 'Host':
             valueA = typeof taskA.latestJob.platform !== 'undefined' ? taskA.latestJob.platform : ''
             valueB = typeof taskB.latestJob.platform !== 'undefined' ? taskB.latestJob.platform : ''
-            return sortDesc ? valueB.localeCompare(valueA) : valueA.localeCompare(valueB)
+            return sortDesc ? DEFAULT_COMPARATOR(valueB, valueA) : DEFAULT_COMPARATOR(valueA, valueB)
           case 'Job System':
             valueA = typeof taskA.latestJob.jobRunnerName !== 'undefined' ? taskA.latestJob.jobRunnerName : ''
             valueB = typeof taskB.latestJob.jobRunnerName !== 'undefined' ? taskB.latestJob.jobRunnerName : ''

--- a/src/components/cylc/table/sort.js
+++ b/src/components/cylc/table/sort.js
@@ -16,16 +16,17 @@
  */
 
 /**
- * Compare function for sorting datetime strings, that might possibly be
- * nullish or empty strings.
+ * Comparator function for sorting datetime strings. Note: nullish or empty
+ * strings are treated as infinity.
  *
  * @export
  * @param {*} a - The first element for comparison.
  * @param {*} b - The second element for comparison.
  * @return {number} A number > 0 if a > b, or < 0 if a < b, or 0 if a === b
  */
-export function datetimeSort (a, b) {
-  const valueA = a !== '' && typeof a !== 'undefined' ? (new Date(a)).getTime() : 0
-  const valueB = b !== '' && typeof b !== 'undefined' ? (new Date(b)).getTime() : 0
-  return valueA - valueB
+export function datetimeComparator (a, b) {
+  a = (a ?? '') === '' ? Infinity : new Date(a).getTime()
+  b = (b ?? '') === '' ? Infinity : new Date(b).getTime()
+  // Avoid return NaN for a === b === Infinity
+  return a === b ? 0 : a - b
 }

--- a/src/components/cylc/table/sort.js
+++ b/src/components/cylc/table/sort.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Compare function for sorting datetime strings, that might possibly be
+ * nullish or empty strings.
+ *
+ * @export
+ * @param {*} a - The first element for comparison.
+ * @param {*} b - The second element for comparison.
+ * @return {number} A number > 0 if a > b, or < 0 if a < b, or 0 if a === b
+ */
+export function datetimeSort (a, b) {
+  const valueA = a !== '' && typeof a !== 'undefined' ? (new Date(a)).getTime() : 0
+  const valueB = b !== '' && typeof b !== 'undefined' ? (new Date(b)).getTime() : 0
+  return valueA - valueB
+}

--- a/tests/unit/components/cylc/table/sort.spec.js
+++ b/tests/unit/components/cylc/table/sort.spec.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai'
+import { datetimeComparator } from '@/components/cylc/table/sort'
+
+describe('datetimeComparator()', () => {
+  it('should rank datetime strings appropriately', () => {
+    expect(datetimeComparator('2022-09-26T12:30:00Z', '2022-09-26T12:30:01Z')).to.be.lessThan(0)
+    expect(datetimeComparator('2022-09-26T12:30:01Z', '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
+    expect(datetimeComparator('2022-09-26T12:30:00Z', '2022-09-26T12:30:00Z')).to.equal(0)
+  })
+  it('should rank nullish as higher than proper datetimes', () => {
+    expect(datetimeComparator('', '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
+    expect(datetimeComparator(undefined, '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
+    expect(datetimeComparator(undefined, '')).to.equal(0)
+  })
+})

--- a/tests/unit/components/cylc/table/table.data.js
+++ b/tests/unit/components/cylc/table/table.data.js
@@ -34,8 +34,8 @@ const simpleTableTasks = [
       platform: 'localhost',
       jobRunnerName: 'background',
       jobId: '1',
-      submittedTime: new Date(),
-      startedTime: new Date(),
+      submittedTime: new Date().toISOString(),
+      startedTime: new Date().toISOString(),
       finishedTime: null,
       state: JobState.RUNNING.name
     },

--- a/tests/unit/components/cylc/table/table.vue.spec.js
+++ b/tests/unit/components/cylc/table/table.vue.spec.js
@@ -74,7 +74,7 @@ describe('Table component', () => {
     })
   }
   global.requestAnimationFrame = cb => cb()
-  it('should enforce the newest job first policy', async () => {
+  it('should sort cycle point column descending by default', async () => {
     const wrapper = mountFunction({
       propsData: {
         tasks: simpleTableTasks
@@ -85,14 +85,10 @@ describe('Table component', () => {
     expect(wrapper.vm.tasks[wrapper.vm.filteredTasks.length - 1].node.cyclePoint).to.equal('20000103T0000Z')
     expect(wrapper.vm.tasks[0].node.cyclePoint).to.equal('20000101T0000Z')
 
-    // check the filtered tasks  have the cycle points from high to low
-    expect(wrapper.vm.filteredTasks[wrapper.vm.filteredTasks.length - 1].node.cyclePoint).to.equal('20000101T0000Z')
-    expect(wrapper.vm.filteredTasks[0].node.cyclePoint).to.equal('20000103T0000Z')
-
-    // check that the actual html markup is also correct
+    // check that the html have the cycle points from high to low
     await wrapper.vm.$nextTick()
     expect(wrapper.find('table > tbody > tr:nth-child(1) > td:nth-child(3)').element.innerHTML).to.equal('20000103T0000Z')
-    expect(wrapper.find('table > tbody > tr:nth-child(' + String(wrapper.vm.filteredTasks.length) + ') > td:nth-child(3)').element.innerHTML).to.equal('20000101T0000Z')
+    expect(wrapper.find(`table > tbody > tr:nth-child(${wrapper.vm.filteredTasks.length}) > td:nth-child(3)`).element.innerHTML).to.equal('20000101T0000Z')
   })
   it('should display the table with valid data', () => {
     const wrapper = mountFunction({


### PR DESCRIPTION
These changes close #1086

Table view column sorting changes:
- Use natural sort for cycle points column (so that e.g. 9 appears before 10 in ascending order for integer cycling mode).
- Sort datetimes (e.g. "start time", "submitted time") so that blanks come after actual datetimes in ascending order
- Simplify to use Vuetify's `v-data-table` built-in sorting.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
