### PR TITLE
more items per page options in table view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ ones in. -->
 
 ## __cylc-ui-1.4.0 (<span actions:bind='release-date'>Pending</span>)__
 
+### Enhancements
+
+[#1124](https://github.com/cylc/cylc-ui/pull/1075) - Table view: More options
+for number of tasks per page.
+
 ### Fixes
 
 [#1075](https://github.com/cylc/cylc-ui/pull/1075) - Reverse default sort order

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -114,6 +114,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               itemsPerPageOptions: [10, 20, 50, 100, 200, -1],
               showFirstLastPage: true
             }"
+            :options="{ itemsPerPage: 50 }"
           >
             <template
               v-slot:item="{ item }"

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -109,6 +109,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :sort-desc.sync="sortDesc"
             item-key="id"
             show-expand
+            dense
+            :footer-props="{
+              itemsPerPageOptions: [10, 20, 50, 100, 200, -1],
+              showFirstLastPage: true
+            }"
           >
             <template
               v-slot:item="{ item }"


### PR DESCRIPTION
These changes close #1121 

### Comments on changes

As well as modifying the numbers of tasks per page I turned on the table [dense mode](https://vuetifyjs.com/en/components/data-tables/#slots) - I don't think it loses owt, and gains more space:

![dense](https://user-images.githubusercontent.com/26465611/197808133-6ca3a844-b614-4af4-871f-a13e2072301c.png)

I've provided 20, 50, 100 and 200 - I couldn't find any way of defaulting to 20 but having 10 available - It's fine even on a small screen:

![Screen Shot 2022-10-25 at 15 40 11](https://user-images.githubusercontent.com/26465611/197808335-857f314e-cf7b-49ff-a092-5296d924976e.png)

Additionally I tried it with a workflow with 600 tasks per cycle and it seemed to be as performant as one might reasonably expect (200 took under a second, 2400 took about 5).

Finally, since it's a simple change I added a first and last page icon to the table.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests - manually tested
- [x] Appropriate change log entry included.
- [x] No documentation update required.
