### PR TITLE
Remove dev dependency `vue-cli-plugin-eslint-config-vuetify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "standard": "^17.0.0",
     "subscriptions-transport-ws": "^0.11.0",
     "utf-8-validate": "^5.0.9",
-    "vue-cli-plugin-eslint-config-vuetify": "0.0.3",
     "vue-cli-plugin-vuetify": "^2.4.2",
     "vue-cli-plugin-vuetify-essentials": "^0.8.3",
     "vue-template-compiler": "^2.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6289,7 +6289,6 @@ __metadata:
     subscriptions-transport-ws: ^0.11.0
     utf-8-validate: ^5.0.9
     vue: ^2.6.14
-    vue-cli-plugin-eslint-config-vuetify: 0.0.3
     vue-cli-plugin-vuetify: ^2.4.2
     vue-cli-plugin-vuetify-essentials: ^0.8.3
     vue-i18n: ^8.27.0
@@ -16999,13 +16998,6 @@ __metadata:
   version: 3.17.1
   resolution: "vscode-languageserver-types@npm:3.17.1"
   checksum: ceb4145dfd840e026a51a6059af6ca2ced606763d945ab24851b1871bf8614f12e7f6fdb1f865ba6ea26f62db066ef188b183b1c830e0f38f28e08b584136464
-  languageName: node
-  linkType: hard
-
-"vue-cli-plugin-eslint-config-vuetify@npm:0.0.3":
-  version: 0.0.3
-  resolution: "vue-cli-plugin-eslint-config-vuetify@npm:0.0.3"
-  checksum: f54aad3dfc6fc15efccc4d8f9b7e427b4f916f1087e085616194dbe75e9ddeec47ea68642c904641956163d3dad80a65becb1789de0b91803a8ae1f217a2caf4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a small change with no associated Issue.

I cannot tell that this is doing anything? There is zero information about this package at https://www.npmjs.com/package/vue-cli-plugin-eslint-config-vuetify

Note that `eslint-config-vuetify` is not a dependency since #692

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests 
- [x] No change log entry required 
- [x] No documentation update required.
