### PR TITLE
router: strip the ?token when the app is first loaded

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,16 @@ Vue.prototype.$eventBus = mitt()
 
 Vue.config.productionTip = false
 
+if (location.search) {
+  // Vue Router puts the "hash" (#) after the "search" (?) for some reason.
+  // But the router fails to read the search parameters because of this?
+  // See this rather confusing issue for details:
+  //   https://github.com/vuejs/vue-router/issues/2125
+  // In the mean time we have to hack the path ourselves to reverse the order
+  // of the "?" and "#" parts so that the router can work with it.
+  location.replace(location.pathname + location.hash + location.search)
+}
+
 /* eslint-disable no-new */
 const app = new Vue({
   i18n,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,6 +69,10 @@ Vue.use(Meta)
 
 router.beforeResolve((to, from, next) => {
   NProgress.start()
+  if ('token' in to.query) {
+    // Remove ?token from the query, we only need it on load.
+    router.replace({ query: {} })
+  }
   if (to.name) {
     let title
     let workflowName


### PR DESCRIPTION
* Closes #1147.
* The token is used to set a secure cookie.
* We don't need it after that so we may as well remove it from the URL.
* This is cleaner and reduces the temptation for users to copy it with the URL.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.