### PR TITLE
Revert "router: strip the ?token when the app is first loaded"

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,16 +35,6 @@ Vue.prototype.$eventBus = mitt()
 
 Vue.config.productionTip = false
 
-if (location.search) {
-  // Vue Router puts the "hash" (#) after the "search" (?) for some reason.
-  // But the router fails to read the search parameters because of this?
-  // See this rather confusing issue for details:
-  //   https://github.com/vuejs/vue-router/issues/2125
-  // In the mean time we have to hack the path ourselves to reverse the order
-  // of the "?" and "#" parts so that the router can work with it.
-  location.replace(location.pathname + location.hash + location.search)
-}
-
 /* eslint-disable no-new */
 const app = new Vue({
   i18n,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,10 +69,6 @@ Vue.use(Meta)
 
 router.beforeResolve((to, from, next) => {
   NProgress.start()
-  if ('token' in to.query) {
-    // Remove ?token from the query, we only need it on load.
-    router.replace({ query: {} })
-  }
   if (to.name) {
     let title
     let workflowName


### PR DESCRIPTION
Reverts cylc/cylc-ui#1151

Sorry all, I think I've jiggered up here.

I've just tried launching `cylc gui`, but it just gave me the "Connection to server lost. You are offline." notice. The second time I opened the link it worked fine.

I think there's a race condition going on here where the token may, or may not still be present in the URL when it's required, dammit.