### PR TITLE
gscan: fix searching for hierarchical workflows

### DIFF
--- a/src/components/cylc/gscan/filters.js
+++ b/src/components/cylc/gscan/filters.js
@@ -23,7 +23,7 @@ import JobState from '@/model/JobState.model'
  * @returns {boolean}
  */
 export function filterByName (workflow, name) {
-  return workflow.name.toLowerCase().includes(name.toLowerCase())
+  return workflow.tokens.workflow.toLowerCase().includes(name.toLowerCase())
 }
 
 /**

--- a/tests/unit/components/cylc/gscan/utils.js
+++ b/tests/unit/components/cylc/gscan/utils.js
@@ -31,22 +31,37 @@ export const TEST_TREE = {
     {
       id: '~u',
       type: 'user',
+      tokens: {
+        user: 'u'
+      },
       children: [
         {
           id: '~u/a',
           name: 'a',
           type: 'workflow-part',
+          tokens: {
+            user: 'u',
+            workflow: 'a'
+          },
           children: [
             {
               id: '~u/a/x1',
               name: 'x1',
               type: 'workflow',
+              tokens: {
+                user: 'u',
+                workflow: 'a/x1'
+              },
               node: { status: WorkflowState.STOPPED.name }
             },
             {
               id: '~u/a/x2',
               name: 'x2',
               type: 'workflow',
+              tokens: {
+                user: 'u',
+                workflow: 'a/x2'
+              },
               node: { status: WorkflowState.STOPPED.name }
             }
           ]
@@ -55,6 +70,10 @@ export const TEST_TREE = {
           id: '~u/b',
           name: 'b',
           type: 'workflow',
+          tokens: {
+            user: 'u',
+            workflow: 'b'
+          },
           node: {
             status: WorkflowState.STOPPING.name,
             stateTotals: RUNNING_STATE_TOTALS
@@ -64,6 +83,10 @@ export const TEST_TREE = {
           id: '~u/c',
           name: 'c',
           type: 'workflow',
+          tokens: {
+            user: 'u',
+            workflow: 'c'
+          },
           node: {
             status: WorkflowState.RUNNING.name,
             stateTotals: SUBMITTED_STATE_TOTALS


### PR DESCRIPTION
* Closes #1173
* Search by the whole workflow part of the ID (e.g. a/b/c) rather than just the "name" part (e.g. c).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? unreleased bug)
- [x] No documentation update required.
