### PR TITLE
Attempt 2 collapsing gscan

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -139,8 +139,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   </v-col>
                   <!-- We check the latestStateTasks below as offline workflows won't have a latestStateTasks property -->
                   <v-col
-                    v-if="!branchingLineage && (lastDescendent.type === 'workflow' && lastDescendent.node.latestStateTasks)"
-                    class="text-right c-gscan-workflow-states flex-grow-0"
+                    v-if="!branchingLineage && (lastDescendent.type === 'workflow' && lastDescendent.node.latestStateTasks) && !expansionStatus"
+                    class="text-right c-gscan-workflow-states"
                   >
                     <!-- task summary tooltips -->
                     <span

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -111,7 +111,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <template v-slot:node="{node, latestDescendantTasks, lastDescendent, descendentLabel, branchingLineage, expansionStatus}">
             <workflow-icon
               class="mr-2"
-              v-if="lastDescendent.type === 'workflow' && !branchingLineage"
+              v-if="!branchingLineage && lastDescendent.type === 'workflow'"
               :status="lastDescendent.node.status"
               v-cylc-object="lastDescendent"
             />
@@ -139,7 +139,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   </v-col>
                   <!-- We check the latestStateTasks below as offline workflows won't have a latestStateTasks property -->
                   <v-col
-                    v-if="(!branchingLineage && (lastDescendent.type === 'workflow' && lastDescendent.node.latestStateTasks) && !expansionStatus) || (!expansionStatus && branchingLineage)"
+                    v-if="!expansionStatus || node.type === 'workflow'"
                     class="text-right c-gscan-workflow-states"
                   >
                     <!-- task summary tooltips -->

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -361,13 +361,10 @@ export default {
       }
       return ''
     },
-    // we need to do this here because the computed property in treeitem loses reactivity if you create a new object based on computed properties
-    extractLatestTaskStates (statesArray) {
-      return Object.assign({}, ...statesArray)
-    },
     /**
      * Get number of tasks we have in a given state. The states are retrieved
-     * the `stateTotals`
+     * from `latestStateTasks`, and the number of tasks in each state is from
+     * the `stateTotals`. (`latestStateTasks` includes old tasks).
      *
      * @param taskTotals
      * @param {string} state - a workflow state

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -101,51 +101,52 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <tree
           :filterable="false"
           :expand-collapse-toggle="false"
+          :auto-collapse="true"
           :workflows="workflows"
           :stopOn="['workflow']"
           :autoExpandTypes="['workflow-part', 'workflow']"
           class="c-gscan-workflow ma-0 pa-0"
           ref="tree"
         >
-          <template v-slot:node="scope">
+          <template v-slot:node="{node, latestDescendantTasks, lastDescendent, descendentLabel, branchingLineage, expansionStatus}">
             <workflow-icon
               class="mr-2"
-              v-if="scope.node.type === 'workflow'"
-              :status="scope.node.node.status"
-              v-cylc-object="scope.node"
+              v-if="lastDescendent.type === 'workflow' && !branchingLineage"
+              :status="lastDescendent.node.status"
+              v-cylc-object="lastDescendent"
             />
             <v-list-item
-              :to="workflowLink(scope.node)"
+              :to="workflowLink(node)"
             >
               <v-list-item-title>
                 <v-row class="align-center align-content-center flex-nowrap">
                   <v-col
-                    v-if="scope.node.type === 'workflow-part'"
+                    v-if="node.type === 'workflow-part'"
                     class="c-gscan-workflow-name"
                   >
-                    <span>{{ scope.node.name || scope.node.id }}</span>
+                    <span>{{ !expansionStatus ? descendentLabel : (node.name || node.id) }}</span>
                   </v-col>
                   <v-col
-                    v-else-if="scope.node.type === 'workflow'"
+                    v-else-if="node.type === 'workflow'"
                     class="c-gscan-workflow-name"
                   >
                     <v-tooltip top>
                       <template v-slot:activator="{ on }">
-                        <span v-on="on">{{ scope.node.name }}</span>
+                        <span v-on="on">{{ node.name }}</span>
                       </template>
-                      <span>{{ scope.node.id }}</span>
+                      <span>{{ node.id }}</span>
                     </v-tooltip>
                   </v-col>
                   <!-- We check the latestStateTasks below as offline workflows won't have a latestStateTasks property -->
                   <v-col
-                    v-if="scope.node.type === 'workflow' && scope.node.node.latestStateTasks"
+                    v-if="!branchingLineage && (lastDescendent.type === 'workflow' && lastDescendent.node.latestStateTasks)"
                     class="text-right c-gscan-workflow-states flex-grow-0"
                   >
                     <!-- task summary tooltips -->
                     <span
-                      v-for="[state, tasks] in getLatestStateTasks(Object.entries(scope.node.node.latestStateTasks))"
-                      :key="`${scope.node.id}-summary-${state}`"
-                      :class="getTaskStateClasses(scope.node.node, state)"
+                      v-for="[state, tasks] in getLatestStateTasks(Object.entries(latestDescendantTasks))"
+                      :key="`${lastDescendent.node.id}-summary-${state}`"
+                      :class="getTaskStateClasses(lastDescendent.node, state)"
                     >
                     <v-tooltip color="black" top>
                       <template v-slot:activator="{ on }">

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -362,7 +362,7 @@ export default {
       return ''
     },
     // we need to do this here because the computed property in treeitem loses reactivity if you create a new object based on computed properties
-    extractLatestTaskStates(statesArray) {
+    extractLatestTaskStates (statesArray) {
       return Object.assign({}, ...statesArray)
     },
     /**

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -139,7 +139,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   </v-col>
                   <!-- We check the latestStateTasks below as offline workflows won't have a latestStateTasks property -->
                   <v-col
-                    v-if="!branchingLineage && (lastDescendent.type === 'workflow' && lastDescendent.node.latestStateTasks) && !expansionStatus"
+                    v-if="(!branchingLineage && (lastDescendent.type === 'workflow' && lastDescendent.node.latestStateTasks) && !expansionStatus) || (!expansionStatus && branchingLineage)"
                     class="text-right c-gscan-workflow-states"
                   >
                     <!-- task summary tooltips -->

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -145,8 +145,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <!-- task summary tooltips -->
                     <span
                       v-for="[state, tasks] in getLatestStateTasks(Object.entries(latestDescendantTasks))"
-                      :key="`${lastDescendent.node.id}-summary-${state}`"
-                      :class="getTaskStateClasses(lastDescendent.node, state)"
+                      :key="`${node.id}-summary-${state}`"
+                      :class="getTaskStateClasses(latestDescendantTasks, state)"
                     >
                     <v-tooltip color="black" top>
                       <template v-slot:activator="{ on }">
@@ -167,7 +167,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       </template>
                       <!-- tooltip text -->
                       <span>
-                        <span class="grey--text">{{ countTasksInState(lastDescendent.node, state) }} {{ state }}. Recent {{ state }} tasks:</span>
+                        <span class="grey--text">{{ countTasksInState(latestDescendantTasks, state) }} {{ state }}. Recent {{ state }} tasks:</span>
                         <br/>
                         <span v-for="(task, index) in tasks.slice(0, maximumTasksDisplayed)" :key="index">
                           {{ task }}<br v-if="index !== tasks.length -1" />
@@ -371,15 +371,15 @@ export default {
      * @param {string} state - a workflow state
      * @returns {number|*} - the number of tasks in the given state
      */
-    countTasksInState (workflow, state) {
-      if (Object.hasOwnProperty.call(workflow.stateTotals, state)) {
-        return workflow.stateTotals[state]
+    countTasksInState (latestStateTasks, state) {
+      if (Object.hasOwnProperty.call(latestStateTasks, state)) {
+        return latestStateTasks[state].length
       }
       return 0
     },
 
-    getTaskStateClasses (workflow, state) {
-      const tasksInState = this.countTasksInState(workflow, state)
+    getTaskStateClasses (latestStateTasks, state) {
+      const tasksInState = this.countTasksInState(latestStateTasks, state)
       return tasksInState === 0 ? ['empty-state'] : []
     },
 

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -167,7 +167,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       </template>
                       <!-- tooltip text -->
                       <span>
-                        <span class="grey--text">{{ countTasksInState(scope.node.node, state) }} {{ state }}. Recent {{ state }} tasks:</span>
+                        <span class="grey--text">{{ countTasksInState(lastDescendent.node, state) }} {{ state }}. Recent {{ state }} tasks:</span>
                         <br/>
                         <span v-for="(task, index) in tasks.slice(0, maximumTasksDisplayed)" :key="index">
                           {{ task }}<br v-if="index !== tasks.length -1" />

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -85,6 +85,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :node="child"
             :stopOn="stopOn"
             :hoverable="hoverable"
+            :auto-collapse="autoCollapse"
             :autoExpandTypes="autoExpandTypes"
             :cyclePointsOrderDesc="cyclePointsOrderDesc"
             v-on:tree-item-created="onTreeItemCreated"
@@ -122,6 +123,10 @@ export default {
       type: Array,
       required: false,
       default: () => []
+    },
+    autoCollapse: {
+      type: Boolean,
+      default: false
     },
     hoverable: Boolean,
     activable: Boolean,

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -339,14 +339,6 @@ export default {
       expandedStateOverridden: false
     }
   },
-  // watch: {
-  //   expansionStatus () {
-  //     // only called when autoExpand changes
-  //     if (!this.expandedStateOverridden) {
-  //       this.emitExpandCollapseEvent(this.isExpanded)
-  //     }
-  //   }
-  // },
   computed: {
     expansionStatus () {
       return this.autoCollapse && !this.expandedStateOverridden ? this.branchingLineage && this.autoExpandTypes.includes(this.node.type) : this.isExpanded
@@ -364,8 +356,13 @@ export default {
       const tasks = {}
       const traverseChildren = (currentNode) => {
         // if we aren't at the end of the node tree, continue
-        if (currentNode.children && currentNode.children.length > 0 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
-          traverseChildren(currentNode.children[0])
+        if (currentNode.type === 'workflow-part' && currentNode.children) {
+          // we want to compute the latest tasks for every child at every level
+          for (let i = 0; i < currentNode.children.length; i++) {
+            // if (['workflow', 'workflow-part'].includes(currentNode.children[i].type)) {
+            traverseChildren(currentNode.children[i])
+            // }
+          }
         } else {
           // if we are at the end of the tree, and the end of the tree is of type workflow, fetch the states from the latestStateTasks property
           if (currentNode.type === 'workflow') {
@@ -455,7 +452,7 @@ export default {
       return {
         'node--hoverable': this.hoverable,
         'node--active': this.active,
-        'c-workflow-stopped': this.lastDescendent?.node?.status === WorkflowState.STOPPED.name,
+        'c-workflow-stopped': !this.branchingLineage && this.lastDescendent?.node?.status === WorkflowState.STOPPED.name,
         expanded: this.autoCollapse ? this.expansionStatus : this.isExpanded
       }
     },

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -401,7 +401,7 @@ export default {
       const labelArr = []
       const traverseChildren = (currentNode) => {
         labelArr.push(currentNode.name || currentNode.id)
-        if (currentNode.children && currentNode.children.length > 0 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
+        if (currentNode.children && currentNode.children.length === 1 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
           traverseChildren(currentNode.children[0])
         }
       }

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -408,8 +408,9 @@ export default {
                 if (!tasks[key]) {
                   tasks[key] = []
                 }
+                console.log('should show up twice', currentNode.node.latestStateTasks[key]);
                 // sort the tasks in decending order
-                tasks[key] = [].concat(tasks[key], currentNode.node.latestStateTasks[key].filter(newTask => tasks[key].includes(newTask))).sort((item1, item2) => (new Date(item2.split('/')[0]).getTime() - (new Date(item1.split('/')[0]).getTime())));
+                tasks[key] = [].concat(tasks[key], currentNode.node.latestStateTasks[key]).sort((item1, item2) => (new Date(item2.split('/')[0]).getTime() - (new Date(item1.split('/')[0]).getTime())));
               })
           }
         }

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -343,8 +343,8 @@ export default {
     expansionStatus () {
       return this.autoCollapse && !this.expandedStateOverridden ? this.branchingLineage && this.autoExpandTypes.includes(this.node.type) : this.isExpanded
     },
-    descendantTaskTotals() {
-      const tasks = {};
+    descendantTaskTotals () {
+      const tasks = {}
       const validValues = [
         TaskState.SUBMITTED.name,
         TaskState.SUBMIT_FAILED.name,
@@ -359,7 +359,6 @@ export default {
           // at every branch, recurse all child nodes
           currentNode.children.forEach(child => traverseChildren(child))
         } else {
-          // console.log(JSON.parse(JSON.stringify(currentNode)))
           // if we are at the end of a node (or at least, hit a workflow node), stop and merge the latest state tasks from this node with all the others from the tree
           if (currentNode.type === 'workflow') {
             // in some test data we dont include the latestStateTasks, so include a fallback
@@ -372,7 +371,7 @@ export default {
                   tasks[key] = []
                 }
                 // cast as numbers so they dont get concatenated as strings
-                tasks[key] = Math.abs(tasks[key]) + Math.abs(currentNode.node.stateTotals[key]);
+                tasks[key] = Math.abs(tasks[key]) + Math.abs(currentNode.node.stateTotals[key])
               })
           }
         }
@@ -380,8 +379,8 @@ export default {
       traverseChildren(this.node)
       return tasks
     },
-    latestDescendantTasks() {
-      const tasks = {};
+    latestDescendantTasks () {
+      const tasks = {}
       const validValues = [
         TaskState.SUBMITTED.name,
         TaskState.SUBMIT_FAILED.name,
@@ -396,7 +395,6 @@ export default {
           // at every branch, recurse all child nodes
           currentNode.children.forEach(child => traverseChildren(child))
         } else {
-          // console.log(JSON.parse(JSON.stringify(currentNode)))
           // if we are at the end of a node (or at least, hit a workflow node), stop and merge the latest state tasks from this node with all the others from the tree
           if (currentNode.type === 'workflow') {
             // in some test data we dont include the latestStateTasks, so include a fallback
@@ -408,9 +406,8 @@ export default {
                 if (!tasks[key]) {
                   tasks[key] = []
                 }
-                console.log('should show up twice', currentNode.node.latestStateTasks[key]);
                 // sort the tasks in decending order
-                tasks[key] = [].concat(tasks[key], currentNode.node.latestStateTasks[key]).sort((item1, item2) => (new Date(item2.split('/')[0]).getTime() - (new Date(item1.split('/')[0]).getTime())));
+                tasks[key] = [].concat(tasks[key], currentNode.node.latestStateTasks[key]).sort((item1, item2) => (new Date(item2.split('/')[0]).getTime() - (new Date(item1.split('/')[0]).getTime())))
               })
           }
         }

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -364,7 +364,7 @@ export default {
       const tasks = {}
       const traverseChildren = (currentNode) => {
         // if we aren't at the end of the node tree, continue
-        if (currentNode.children && currentNode.children.length > 0) {
+        if (currentNode.children && currentNode.children.length > 0 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
           traverseChildren(currentNode.children[0])
         } else {
           // if we are at the end of the tree, and the end of the tree is of type workflow, fetch the states from the latestStateTasks property
@@ -388,7 +388,7 @@ export default {
     lastDescendent () {
       let lastDescendent = this.node
       const traverseChildren = (currentNode) => {
-        if (currentNode.children && currentNode.children.length > 0) {
+        if (currentNode.children && currentNode.children.length > 0 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
           traverseChildren(currentNode.children[0])
         } else {
           lastDescendent = currentNode
@@ -401,7 +401,7 @@ export default {
       const labelArr = []
       const traverseChildren = (currentNode) => {
         labelArr.push(currentNode.name || currentNode.id)
-        if (currentNode.children && currentNode.children.length > 0) {
+        if (currentNode.children && currentNode.children.length > 0 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
           traverseChildren(currentNode.children[0])
         }
       }
@@ -411,7 +411,7 @@ export default {
     branchingLineage () {
       let moreThenTwoChildren = false
       const traverseChildren = (currentNode) => {
-        if (moreThenTwoChildren === false && currentNode.children && currentNode.children.length > 0) {
+        if (moreThenTwoChildren === false && currentNode.children && currentNode.children.length > 0 && ['workflow', 'workflow-part'].includes(currentNode.children[0].type)) {
           if (currentNode.children.length === 1) {
             traverseChildren(currentNode.children[0])
           } else {
@@ -455,7 +455,7 @@ export default {
       return {
         'node--hoverable': this.hoverable,
         'node--active': this.active,
-        'c-workflow-stopped': this.node?.node?.status === WorkflowState.STOPPED.name,
+        'c-workflow-stopped': this.lastDescendent?.node?.status === WorkflowState.STOPPED.name,
         expanded: this.autoCollapse ? this.expansionStatus : this.isExpanded
       }
     },

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -84,7 +84,7 @@ const stateTotalsTestWorkflowNodes = {
                 status: 'running',
                 statusMsg: 'running',
                 owner: 'cylc',
-                host: 'aarons-mbp-2.niwa.local',
+                host: 'localhost',
                 port: 43055,
                 stateTotals: {
                   waiting: 7,
@@ -162,7 +162,7 @@ const stateTotalsTestWorkflowNodes = {
                 status: 'running',
                 statusMsg: 'running',
                 owner: 'cylc',
-                host: 'aarons-mbp-2.niwa.local',
+                host: 'localhost',
                 port: 43038,
                 stateTotals: {
                   waiting: 7,

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -19,6 +19,199 @@
  * Test data for Tree component tests.
  */
 
+const stateTotalsTestWorkflowNodes = {
+  "id": "~cylc/double",
+  "name": "double",
+  "node": {
+    "id": "~cylc/double"
+  },
+  "parent": "~cylc",
+  "tokens": {
+    "user": "cylc",
+    "workflow": "double",
+    "id": "~cylc/double",
+    "workflow_id": "~cylc/double",
+    "relative_id": ""
+  },
+  "type": "workflow-part",
+  "children": [
+    {
+      "id": "~cylc/double/mid",
+      "name": "mid",
+      "node": {
+        "id": "~cylc/double/mid"
+      },
+      "parent": "~cylc/double",
+      "tokens": {
+        "user": "cylc",
+        "workflow": "double/mid",
+        "id": "~cylc/double/mid",
+        "workflow_id": "~cylc/double/mid",
+        "relative_id": ""
+      },
+      "type": "workflow-part",
+      "children": [
+        {
+          "id": "~cylc/double/mid/first",
+          "name": "first",
+          "node": {
+            "id": "~cylc/double/mid/first"
+          },
+          "parent": "~cylc/double/mid",
+          "tokens": {
+            "user": "cylc",
+            "workflow": "double/mid/first",
+            "id": "~cylc/double/mid/first",
+            "workflow_id": "~cylc/double/mid/first",
+            "relative_id": ""
+          },
+          "type": "workflow-part",
+          "children": [
+            {
+              "id": "~cylc/double/mid/first/run1",
+              "tokens": {
+                "user": "cylc",
+                "workflow": "double/mid/first/run1",
+                "id": "~cylc/double/mid/first/run1",
+                "workflow_id": "~cylc/double/mid/first/run1",
+                "relative_id": ""
+              },
+              "name": "run1",
+              "type": "workflow",
+              "parent": "~cylc/double/mid/first",
+              "node": {
+                "id": "~cylc/double/mid/first/run1",
+                "status": "running",
+                "statusMsg": "running",
+                "owner": "cylc",
+                "host": "aarons-mbp-2.niwa.local",
+                "port": 43055,
+                "stateTotals": {
+                  "waiting": 7,
+                  "expired": 0,
+                  "preparing": 0,
+                  "submit-failed": 0,
+                  "submitted": 0,
+                  "running": 6,
+                  "failed": 0,
+                  "succeeded": 0
+                },
+                "latestStateTasks": {
+                  "failed": [],
+                  "preparing": [
+                    "2022-03-19/get-data",
+                    "2022-03-15/prep",
+                    "2022-03-15/get-data",
+                    "2022-03-16/get-data",
+                    "2022-03-17/get-data"
+                  ],
+                  "submit-failed": [],
+                  "submitted": [
+                    "2022-03-19/get-data",
+                    "2022-03-18/get-data",
+                    "2022-03-17/get-data",
+                    "2022-03-16/get-data",
+                    "2022-03-15/prep"
+                  ],
+                  "running": [
+                    "2022-03-17/get-data",
+                    "2022-03-19/get-data",
+                    "2022-03-18/get-data",
+                    "2022-03-16/get-data",
+                    "2022-03-15/get-data"
+                  ]
+                },
+                "__typename": "Workflow"
+              },
+              "children": [],
+              "$edges": [],
+              "$namespaces": []
+            }
+          ]
+        },
+        {
+          "id": "~cylc/double/mid/second",
+          "name": "second",
+          "node": {
+            "id": "~cylc/double/mid/second"
+          },
+          "parent": "~cylc/double/mid",
+          "tokens": {
+            "user": "cylc",
+            "workflow": "double/mid/second",
+            "id": "~cylc/double/mid/second",
+            "workflow_id": "~cylc/double/mid/second",
+            "relative_id": ""
+          },
+          "type": "workflow-part",
+          "children": [
+            {
+              "id": "~cylc/double/mid/second/run1",
+              "tokens": {
+                "user": "cylc",
+                "workflow": "double/mid/second/run1",
+                "id": "~cylc/double/mid/second/run1",
+                "workflow_id": "~cylc/double/mid/second/run1",
+                "relative_id": ""
+              },
+              "name": "run1",
+              "type": "workflow",
+              "parent": "~cylc/double/mid/second",
+              "node": {
+                "id": "~cylc/double/mid/second/run1",
+                "status": "running",
+                "statusMsg": "running",
+                "owner": "cylc",
+                "host": "aarons-mbp-2.niwa.local",
+                "port": 43038,
+                "stateTotals": {
+                  "waiting": 7,
+                  "expired": 0,
+                  "preparing": 0,
+                  "submit-failed": 0,
+                  "submitted": 0,
+                  "running": 6,
+                  "failed": 0,
+                  "succeeded": 0
+                },
+                "latestStateTasks": {
+                  "failed": [],
+                  "preparing": [
+                    "2022-01-19/get-data",
+                    "2022-01-15/prep",
+                    "2022-01-15/get-data",
+                    "2022-01-16/get-data",
+                    "2022-01-17/get-data"
+                  ],
+                  "submit-failed": [],
+                  "submitted": [
+                    "2022-01-19/get-data",
+                    "2022-01-18/get-data",
+                    "2022-01-17/get-data",
+                    "2022-01-16/get-data",
+                    "2022-01-15/prep"
+                  ],
+                  "running": [
+                    "2022-01-19/get-data",
+                    "2022-01-18/get-data",
+                    "2022-01-17/get-data",
+                    "2022-01-15/prep",
+                    "2022-01-16/get-data"
+                  ]
+                },
+                "__typename": "Workflow"
+              },
+              "children": [],
+              "$edges": [],
+              "$namespaces": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
 const simpleWorkflowTree4Nodes = [
   {
     id: '~user/workflow1',
@@ -1118,6 +1311,7 @@ const simpleTaskNode = simpleCyclepointNode.familyTree[0].children[0]
 const simpleJobNode = simpleTaskNode.children[0]
 
 export {
+  stateTotalsTestWorkflowNodes,
   simpleWorkflowTree4Nodes,
   simpleWorkflowNode,
   simpleCyclepointNode,

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -91,7 +91,7 @@ const stateTotalsTestWorkflowNodes = {
                   expired: 0,
                   preparing: 0,
                   'submit-failed': 0,
-                  submitted: 0,
+                  submitted: 3,
                   running: 6,
                   failed: 0,
                   succeeded: 0
@@ -169,7 +169,7 @@ const stateTotalsTestWorkflowNodes = {
                   expired: 0,
                   preparing: 0,
                   'submit-failed': 0,
-                  submitted: 0,
+                  submitted: 2,
                   running: 6,
                   failed: 0,
                   succeeded: 0

--- a/tests/unit/components/cylc/tree/tree.data.js
+++ b/tests/unit/components/cylc/tree/tree.data.js
@@ -20,190 +20,190 @@
  */
 
 const stateTotalsTestWorkflowNodes = {
-  "id": "~cylc/double",
-  "name": "double",
-  "node": {
-    "id": "~cylc/double"
+  id: '~cylc/double',
+  name: 'double',
+  node: {
+    id: '~cylc/double'
   },
-  "parent": "~cylc",
-  "tokens": {
-    "user": "cylc",
-    "workflow": "double",
-    "id": "~cylc/double",
-    "workflow_id": "~cylc/double",
-    "relative_id": ""
+  parent: '~cylc',
+  tokens: {
+    user: 'cylc',
+    workflow: 'double',
+    id: '~cylc/double',
+    workflow_id: '~cylc/double',
+    relative_id: ''
   },
-  "type": "workflow-part",
-  "children": [
+  type: 'workflow-part',
+  children: [
     {
-      "id": "~cylc/double/mid",
-      "name": "mid",
-      "node": {
-        "id": "~cylc/double/mid"
+      id: '~cylc/double/mid',
+      name: 'mid',
+      node: {
+        id: '~cylc/double/mid'
       },
-      "parent": "~cylc/double",
-      "tokens": {
-        "user": "cylc",
-        "workflow": "double/mid",
-        "id": "~cylc/double/mid",
-        "workflow_id": "~cylc/double/mid",
-        "relative_id": ""
+      parent: '~cylc/double',
+      tokens: {
+        user: 'cylc',
+        workflow: 'double/mid',
+        id: '~cylc/double/mid',
+        workflow_id: '~cylc/double/mid',
+        relative_id: ''
       },
-      "type": "workflow-part",
-      "children": [
+      type: 'workflow-part',
+      children: [
         {
-          "id": "~cylc/double/mid/first",
-          "name": "first",
-          "node": {
-            "id": "~cylc/double/mid/first"
+          id: '~cylc/double/mid/first',
+          name: 'first',
+          node: {
+            id: '~cylc/double/mid/first'
           },
-          "parent": "~cylc/double/mid",
-          "tokens": {
-            "user": "cylc",
-            "workflow": "double/mid/first",
-            "id": "~cylc/double/mid/first",
-            "workflow_id": "~cylc/double/mid/first",
-            "relative_id": ""
+          parent: '~cylc/double/mid',
+          tokens: {
+            user: 'cylc',
+            workflow: 'double/mid/first',
+            id: '~cylc/double/mid/first',
+            workflow_id: '~cylc/double/mid/first',
+            relative_id: ''
           },
-          "type": "workflow-part",
-          "children": [
+          type: 'workflow-part',
+          children: [
             {
-              "id": "~cylc/double/mid/first/run1",
-              "tokens": {
-                "user": "cylc",
-                "workflow": "double/mid/first/run1",
-                "id": "~cylc/double/mid/first/run1",
-                "workflow_id": "~cylc/double/mid/first/run1",
-                "relative_id": ""
+              id: '~cylc/double/mid/first/run1',
+              tokens: {
+                user: 'cylc',
+                workflow: 'double/mid/first/run1',
+                id: '~cylc/double/mid/first/run1',
+                workflow_id: '~cylc/double/mid/first/run1',
+                relative_id: ''
               },
-              "name": "run1",
-              "type": "workflow",
-              "parent": "~cylc/double/mid/first",
-              "node": {
-                "id": "~cylc/double/mid/first/run1",
-                "status": "running",
-                "statusMsg": "running",
-                "owner": "cylc",
-                "host": "aarons-mbp-2.niwa.local",
-                "port": 43055,
-                "stateTotals": {
-                  "waiting": 7,
-                  "expired": 0,
-                  "preparing": 0,
-                  "submit-failed": 0,
-                  "submitted": 0,
-                  "running": 6,
-                  "failed": 0,
-                  "succeeded": 0
+              name: 'run1',
+              type: 'workflow',
+              parent: '~cylc/double/mid/first',
+              node: {
+                id: '~cylc/double/mid/first/run1',
+                status: 'running',
+                statusMsg: 'running',
+                owner: 'cylc',
+                host: 'aarons-mbp-2.niwa.local',
+                port: 43055,
+                stateTotals: {
+                  waiting: 7,
+                  expired: 0,
+                  preparing: 0,
+                  'submit-failed': 0,
+                  submitted: 0,
+                  running: 6,
+                  failed: 0,
+                  succeeded: 0
                 },
-                "latestStateTasks": {
-                  "failed": [],
-                  "preparing": [
-                    "2022-03-19/get-data",
-                    "2022-03-15/prep",
-                    "2022-03-15/get-data",
-                    "2022-03-16/get-data",
-                    "2022-03-17/get-data"
+                latestStateTasks: {
+                  failed: [],
+                  preparing: [
+                    '2022-03-19/get-data',
+                    '2022-03-15/prep',
+                    '2022-03-15/get-data',
+                    '2022-03-16/get-data',
+                    '2022-03-17/get-data'
                   ],
-                  "submit-failed": [],
-                  "submitted": [
-                    "2022-03-19/get-data",
-                    "2022-03-18/get-data",
-                    "2022-03-17/get-data",
-                    "2022-03-16/get-data",
-                    "2022-03-15/prep"
+                  'submit-failed': [],
+                  submitted: [
+                    '2022-03-19/get-data',
+                    '2022-03-18/get-data',
+                    '2022-03-17/get-data',
+                    '2022-03-16/get-data',
+                    '2022-03-15/prep'
                   ],
-                  "running": [
-                    "2022-03-17/get-data",
-                    "2022-03-19/get-data",
-                    "2022-03-18/get-data",
-                    "2022-03-16/get-data",
-                    "2022-03-15/get-data"
+                  running: [
+                    '2022-03-17/get-data',
+                    '2022-03-19/get-data',
+                    '2022-03-18/get-data',
+                    '2022-03-16/get-data',
+                    '2022-03-15/get-data'
                   ]
                 },
-                "__typename": "Workflow"
+                __typename: 'Workflow'
               },
-              "children": [],
-              "$edges": [],
-              "$namespaces": []
+              children: [],
+              $edges: [],
+              $namespaces: []
             }
           ]
         },
         {
-          "id": "~cylc/double/mid/second",
-          "name": "second",
-          "node": {
-            "id": "~cylc/double/mid/second"
+          id: '~cylc/double/mid/second',
+          name: 'second',
+          node: {
+            id: '~cylc/double/mid/second'
           },
-          "parent": "~cylc/double/mid",
-          "tokens": {
-            "user": "cylc",
-            "workflow": "double/mid/second",
-            "id": "~cylc/double/mid/second",
-            "workflow_id": "~cylc/double/mid/second",
-            "relative_id": ""
+          parent: '~cylc/double/mid',
+          tokens: {
+            user: 'cylc',
+            workflow: 'double/mid/second',
+            id: '~cylc/double/mid/second',
+            workflow_id: '~cylc/double/mid/second',
+            relative_id: ''
           },
-          "type": "workflow-part",
-          "children": [
+          type: 'workflow-part',
+          children: [
             {
-              "id": "~cylc/double/mid/second/run1",
-              "tokens": {
-                "user": "cylc",
-                "workflow": "double/mid/second/run1",
-                "id": "~cylc/double/mid/second/run1",
-                "workflow_id": "~cylc/double/mid/second/run1",
-                "relative_id": ""
+              id: '~cylc/double/mid/second/run1',
+              tokens: {
+                user: 'cylc',
+                workflow: 'double/mid/second/run1',
+                id: '~cylc/double/mid/second/run1',
+                workflow_id: '~cylc/double/mid/second/run1',
+                relative_id: ''
               },
-              "name": "run1",
-              "type": "workflow",
-              "parent": "~cylc/double/mid/second",
-              "node": {
-                "id": "~cylc/double/mid/second/run1",
-                "status": "running",
-                "statusMsg": "running",
-                "owner": "cylc",
-                "host": "aarons-mbp-2.niwa.local",
-                "port": 43038,
-                "stateTotals": {
-                  "waiting": 7,
-                  "expired": 0,
-                  "preparing": 0,
-                  "submit-failed": 0,
-                  "submitted": 0,
-                  "running": 6,
-                  "failed": 0,
-                  "succeeded": 0
+              name: 'run1',
+              type: 'workflow',
+              parent: '~cylc/double/mid/second',
+              node: {
+                id: '~cylc/double/mid/second/run1',
+                status: 'running',
+                statusMsg: 'running',
+                owner: 'cylc',
+                host: 'aarons-mbp-2.niwa.local',
+                port: 43038,
+                stateTotals: {
+                  waiting: 7,
+                  expired: 0,
+                  preparing: 0,
+                  'submit-failed': 0,
+                  submitted: 0,
+                  running: 6,
+                  failed: 0,
+                  succeeded: 0
                 },
-                "latestStateTasks": {
-                  "failed": [],
-                  "preparing": [
-                    "2022-01-19/get-data",
-                    "2022-01-15/prep",
-                    "2022-01-15/get-data",
-                    "2022-01-16/get-data",
-                    "2022-01-17/get-data"
+                latestStateTasks: {
+                  failed: [],
+                  preparing: [
+                    '2022-01-19/get-data',
+                    '2022-01-15/prep',
+                    '2022-01-15/get-data',
+                    '2022-01-16/get-data',
+                    '2022-01-17/get-data'
                   ],
-                  "submit-failed": [],
-                  "submitted": [
-                    "2022-01-19/get-data",
-                    "2022-01-18/get-data",
-                    "2022-01-17/get-data",
-                    "2022-01-16/get-data",
-                    "2022-01-15/prep"
+                  'submit-failed': [],
+                  submitted: [
+                    '2022-01-19/get-data',
+                    '2022-01-18/get-data',
+                    '2022-01-17/get-data',
+                    '2022-01-16/get-data',
+                    '2022-01-15/prep'
                   ],
-                  "running": [
-                    "2022-01-19/get-data",
-                    "2022-01-18/get-data",
-                    "2022-01-17/get-data",
-                    "2022-01-15/prep",
-                    "2022-01-16/get-data"
+                  running: [
+                    '2022-01-19/get-data',
+                    '2022-01-18/get-data',
+                    '2022-01-17/get-data',
+                    '2022-01-15/prep',
+                    '2022-01-16/get-data'
                   ]
                 },
-                "__typename": "Workflow"
+                __typename: 'Workflow'
               },
-              "children": [],
-              "$edges": [],
-              "$namespaces": []
+              children: [],
+              $edges: [],
+              $namespaces: []
             }
           ]
         }

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -131,7 +131,7 @@ describe('TreeItem component', () => {
     })
   })
   describe('computed properties', () => {
-    let wrapper = mountFunction({
+    const wrapper = mountFunction({
       propsData: {
         node: stateTotalsTestWorkflowNodes,
         initialExpanded: false,
@@ -158,15 +158,15 @@ describe('TreeItem component', () => {
       expect(wrapper.vm.expansionStatus).to.equal(true)
     })
   })
-    describe('computed properties as workflow', () => {
-    let wrapper = mountFunction({
-        propsData: {
-          node: stateTotalsTestWorkflowNodes.children[0].children[0],
-          initialExpanded: false,
-          autoCollapse: true,
-          autoExpandTypes: ['workflow-part', 'workflow']
-        }
-      })
+  describe('computed properties as workflow', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        node: stateTotalsTestWorkflowNodes.children[0].children[0],
+        initialExpanded: false,
+        autoCollapse: true,
+        autoExpandTypes: ['workflow-part', 'workflow']
+      }
+    })
     it('should get the correct label as a child', () => {
       expect(wrapper.vm.descendentLabel).to.equal('first/run1')
     })

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -143,6 +143,10 @@ describe('TreeItem component', () => {
       expect(wrapper.vm.latestDescendantTasks.submitted.length).to.equal(10)
       expect(wrapper.vm.latestDescendantTasks.running.length).to.equal(10)
     })
+    it('should combine all descendant task totals', () => {
+      expect(wrapper.vm.descendantTaskTotals.submitted).to.equal(5)
+      expect(wrapper.vm.descendantTaskTotals.running).to.equal(12)
+    })
     // note while this test tests a valid scenario, the last child properly should always be used in association with the branching lineage check
     it('should get the (first) last child', () => {
       expect(wrapper.vm.lastDescendent.id).to.equal('~cylc/double/mid/first/run1')

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -24,6 +24,7 @@ import Vuetify from 'vuetify/lib'
 import * as vuetify from '@/plugins/vuetify'
 import TreeItem from '@/components/cylc/tree/TreeItem'
 import {
+  stateTotalsTestWorkflowNodes,
   simpleWorkflowNode,
   simpleCyclepointNode,
   simpleTaskNode
@@ -129,7 +130,53 @@ describe('TreeItem component', () => {
       expect(wrapper).to.not.be.expanded()
     })
   })
-
+  describe('computed properties', () => {
+    let wrapper = mountFunction({
+      propsData: {
+        node: stateTotalsTestWorkflowNodes,
+        initialExpanded: false,
+        autoCollapse: true,
+        autoExpandTypes: ['workflow-part', 'workflow']
+      }
+    })
+    it('should combine all descendant tasks', () => {
+      expect(wrapper.vm.latestDescendantTasks.submitted.length).to.equal(10)
+      expect(wrapper.vm.latestDescendantTasks.running.length).to.equal(10)
+    })
+    // note while this test tests a valid scenario, the last child properly should always be used in association with the branching lineage check
+    it('should get the (first) last child', () => {
+      expect(wrapper.vm.lastDescendent.id).to.equal('~cylc/double/mid/first/run1')
+    })
+    // note this only generates a label until the first branch it encounters when recursing
+    it('should get the correct label as a parent', () => {
+      expect(wrapper.vm.descendentLabel).to.equal('double/mid')
+    })
+    it('should return true if the children branch at any point', () => {
+      expect(wrapper.vm.branchingLineage).to.equal(true)
+    })
+    it('should be initially expanded', () => {
+      expect(wrapper.vm.expansionStatus).to.equal(true)
+    })
+  })
+    describe('computed properties as workflow', () => {
+    let wrapper = mountFunction({
+        propsData: {
+          node: stateTotalsTestWorkflowNodes.children[0].children[0],
+          initialExpanded: false,
+          autoCollapse: true,
+          autoExpandTypes: ['workflow-part', 'workflow']
+        }
+      })
+    it('should get the correct label as a child', () => {
+      expect(wrapper.vm.descendentLabel).to.equal('first/run1')
+    })
+    it('should return false if the children do not branch', () => {
+      expect(wrapper.vm.branchingLineage).to.equal(false)
+    })
+    it('should be initially collapsed as its non-branching', () => {
+      expect(wrapper.vm.expansionStatus).to.equal(false)
+    })
+  })
   describe('children', () => {
     it('should recursively include other TreeItem components for its children', () => {
       const wrapper = mountFunction({


### PR DESCRIPTION
Attempt number 3 at the auto collapse workflows, this may not work flawlessly yet but would be good to get some review on based on the feedback from Oliver on the previous pull request (https://github.com/cylc/cylc-ui/pull/1037).

This is a ground up rewrite of the original feature request, based on the latest changes on developer (including the most recent changes from Oliver), with (hopefully) a lot of code quality improvements and general readability updates (since I found the structure of the g-scan element incredible hard to follow / change in a recursive fashion (as suggested in Olivers comments on the previous MR, listed above).

Tests will be broken, but an initial review would be helpful (even if just a sighting pass), then Ill make final adjustments and then fix the tests.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [x] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No documentation update required.
