### PR TITLE
GH Actions: use ubuntu-latest for e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,22 +55,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-20.04
-            browser: firefox
-            type: 'e2e'
-          - os: ubuntu-20.04
-            browser: firefox
-            type: 'component'
-          - os: ubuntu-latest
-            browser: chrome
-            type: 'e2e'
-          - os: ubuntu-latest
-            browser: chrome
-            type: 'component'
+        os: [ubuntu-latest]
+        browser: [firefox, chrome]
+        type: [e2e, component]
 # TODO: re-enable once macos build is stable #590
-#          - os: macos-latest
-#            browser: edge
+#         include:
+#           - os: macos-latest
+#             browser: edge
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Follow-up to #1140, it now has Firefox