### PR TITLE
show mean times as iso durations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ ones in. -->
 
 ### Enhancements
 
+[#1184](https://github.com/cylc/cylc-ui/pull/1184) - Mean times for tasks
+in table changed to human readable ISO duration format.
+
 [#1144](https://github.com/cylc/cylc-ui/pull/1144) - Add "Edit Runtime"
 command, a more convenient way to perform broadcasts by viewing and editing a
 task/family's runtime configuration.

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -169,6 +169,7 @@ import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
 import { datetimeComparator } from '@/components/cylc/table/sort'
 import { matchNode } from '@/components/cylc/common/filter'
 import TaskFilter from '@/components/cylc/TaskFilter.vue'
+import { dtMean } from '@/utils/tasks'
 
 export default {
   name: 'TableComponent',
@@ -257,15 +258,7 @@ export default {
     }
   },
   methods: {
-    dtMean (taskNode) {
-      const ret = taskNode.node?.task?.meanElapsedTime
-      if (ret) {
-        return ret.toFixed()
-      }
-      // the meanElapsedTime can be undefined (e.g. task has not run before)
-      // return "undefined" rather than a number for these cases
-      return undefined
-    }
+    dtMean
   }
 }
 </script>

--- a/src/utils/tasks.js
+++ b/src/utils/tasks.js
@@ -105,3 +105,28 @@ export {
   latestJob,
   jobMessageOutputs
 }
+
+export function dtMean (taskNode) {
+  // Convert to an easily read duration format:
+  const dur = taskNode.node?.task?.meanElapsedTime
+  if (dur) {
+    const seconds = dur % 60
+    const minutes = ((dur - seconds) / 60) % 60
+    const hours = ((dur - minutes * 60 - seconds) / 3600) % 24
+    const days = (dur - hours * 3600 - minutes * 60 - seconds) / 86400
+
+    let dayss = ''
+    if (days > 0) {
+      dayss = days.toString() + 'd '
+    }
+
+    const ret = dayss +
+      hours.toString().padStart(2, '0') +
+      ':' + minutes.toString().padStart(2, '0') +
+      ':' + Math.round(seconds).toString().padStart(2, '0')
+    return ret
+  }
+  // the meanElapsedTime can be undefined (e.g. task has not run before)
+  // return "undefined" rather than a number for these cases
+  return undefined
+}

--- a/src/utils/tasks.js
+++ b/src/utils/tasks.js
@@ -120,11 +120,10 @@ export function dtMean (taskNode) {
       dayss = days.toString() + 'd '
     }
 
-    const ret = dayss +
+    return dayss +
       hours.toString().padStart(2, '0') +
       ':' + minutes.toString().padStart(2, '0') +
       ':' + Math.round(seconds).toString().padStart(2, '0')
-    return ret
   }
   // the meanElapsedTime can be 0/undefined (i.e. task has not run before)
   // return "undefined" rather than a number for these cases

--- a/src/utils/tasks.js
+++ b/src/utils/tasks.js
@@ -126,7 +126,7 @@ export function dtMean (taskNode) {
       ':' + Math.round(seconds).toString().padStart(2, '0')
     return ret
   }
-  // the meanElapsedTime can be undefined (e.g. task has not run before)
+  // the meanElapsedTime can be 0/undefined (i.e. task has not run before)
   // return "undefined" rather than a number for these cases
   return undefined
 }

--- a/tests/e2e/specs/table.cy.js
+++ b/tests/e2e/specs/table.cy.js
@@ -132,12 +132,12 @@ describe('Table view', () => {
 
         // sort ft-mean descending
         .get('.asc > .v-icon > .v-icon__svg > path')
-        .click()
+        .click({ force: true })
 
         // check 7 is at the top (1st row, 10th column)
         .get('tbody > :nth-child(1) > :nth-child(10)')
         .should(($ele) => {
-          expect($ele.text().trim()).equal('7')
+          expect($ele.text().trim()).equal('00:00:07')
         })
     })
   })

--- a/tests/unit/utils/tasks.spec.js
+++ b/tests/unit/utils/tasks.spec.js
@@ -17,7 +17,7 @@
 
 import { expect } from 'chai'
 import TaskState from '@/model/TaskState.model'
-import { extractGroupState, latestJob } from '@/utils/tasks'
+import { dtMean, extractGroupState, latestJob } from '@/utils/tasks'
 
 describe('tasks', () => {
   describe('extractGroupState', () => {
@@ -87,6 +87,59 @@ describe('tasks', () => {
       ]
       tests.forEach(test => {
         expect(latestJob(test.taskProxy)).to.equal(test.expected)
+      })
+    })
+  })
+  describe('dtMean', () => {
+    it('should format seconds to nice isodatetime format', () => {
+      const tests = [
+        {
+          taskNode: { node: null },
+          expected: undefined
+        },
+        {
+          taskNode: {
+            node: {
+              task: {
+                meanElapsedTime: 84
+              }
+            }
+          },
+          expected: '00:01:24'
+        },
+        {
+          taskNode: {
+            node: {
+              task: {
+                meanElapsedTime: 42
+              }
+            }
+          },
+          expected: '00:00:42'
+        },
+        {
+          taskNode: {
+            node: {
+              task: {
+                meanElapsedTime: 4242
+              }
+            }
+          },
+          expected: '01:10:42'
+        },
+        {
+          taskNode: {
+            node: {
+              task: {
+                meanElapsedTime: 1426332
+              }
+            }
+          },
+          expected: '16d 12:12:12'
+        }
+      ]
+      tests.forEach(test => {
+        expect(dtMean(test.taskNode)).to.equal(test.expected)
       })
     })
   })

--- a/tests/unit/utils/tasks.spec.js
+++ b/tests/unit/utils/tasks.spec.js
@@ -99,6 +99,14 @@ describe('tasks', () => {
         },
         {
           taskNode: {
+            task: {
+              meanElapsedTime: 0
+            }
+          },
+          expected: undefined
+        },
+        {
+          taskNode: {
             node: {
               task: {
                 meanElapsedTime: 84


### PR DESCRIPTION
These changes close #1180

In table view convert mean time from a number of seconds to an iso duration.

Question - do we want to make it mm:ss if duration < 3600?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
