### PR TITLE
Remove deprecated Vue & Vuetify syntax

### DIFF
--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <v-list
         class="pa-0 ma-0 flex-grow-0 d-flex flex-column"
       >
-        <c-header class="pb-5" :user="user.username" />
+        <c-header :user="user.username" />
         <v-list-item
           v-if="responsive"
         >

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -16,35 +16,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <v-list-item-action-text class="pt-3 pb-3 c-header">
-    <v-layout align-center justify-center row wrap fill-height>
-      <div class="mb-2 px-8">
-        <svg version="1.1" preserveAspectRatio="xMinYMin meet" width="100%" height="100%" viewBox="0 0 655 260" xmlns="http://www.w3.org/2000/svg">
-          <g transform="translate(292.53,-49.505)">
+  <div class="c-header d-flex flex-column align-center pt-3 pb-5">
+    <div class="mb-2 px-6">
+      <svg version="1.1" preserveAspectRatio="xMinYMin meet" width="100%" height="100%" viewBox="0 0 655 260" xmlns="http://www.w3.org/2000/svg">
+        <g transform="translate(292.53,-49.505)">
+          <g>
             <g>
               <g>
-                <g>
-                  <circle r="27.743086" cy="248.39331" cx="-135.70163" transform="scale(-1,1)" style="fill:#ff5966;fill-opacity:1;stroke:none;stroke-width:1.29467726;stroke-opacity:1"/>
-                  <circle r="72.85714" cy="216.6479" cx="201.04846" style="fill:#0dc66e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-opacity:1"/>
-                  <circle r="37.37936" cy="136.32114" cx="167.3486" style="fill:#ffcc00;fill-opacity:1;stroke:none;stroke-width:1.18934333;stroke-opacity:1"/>
-                  <circle r="49.79998" cy="121.63028" cx="292.31558" style="fill:#00b4fd;fill-opacity:1;stroke:none;stroke-width:0.91736811;stroke-opacity:1"/>
-                  <path d="m -239.15268,150.44225 q 5.28,0 17.92,1.92 l 3.84,0.48 -0.48,9.76 q -12.8,-1.44 -18.88,-1.44 -13.6,0 -18.56,6.56 -4.8,6.4 -4.8,24 0,17.44 4.48,24.32 4.64,6.88 19.04,6.88 l 18.88,-1.44 0.48,9.92 q -14.88,2.24 -22.24,2.24 -18.72,0 -25.92,-9.6 -7.04,-9.6 -7.04,-32.32 0,-22.88 7.68,-32 7.68,-9.28 25.6,-9.28 z" style="fill:#ff5966;fill-opacity:1;stroke:none"/>
-                  <path d="m -175.59268,152.04225 h 12 l 20,69.6 h 5.28 l 20.16,-69.6 h 12 l -33.28,115.52 h -12 l 10.4,-35.52 h -11.84 z" style="fill:#ffcc00;fill-opacity:1;stroke:none"/>
-                  <path d="m -58.612682,232.04225 v -114.88 h 12 v 114.88 z" style="fill:#0dc66e;fill-opacity:1;stroke:none"/>
-                  <path d="m 34.534818,150.44225 q 5.28,0 17.92,1.92 l 3.84,0.48 -0.48,9.76 q -12.8,-1.44 -18.88,-1.44 -13.6,0 -18.56,6.56 -4.8,6.4 -4.8,24 0,17.44 4.48,24.32 4.64,6.88 19.04,6.88 l 18.88,-1.44 0.48,9.92 q -14.88,2.24 -22.24,2.24 -18.72,0 -25.9199999,-9.6 -7.04,-9.6 -7.04,-32.32 0,-22.88 7.68,-32 7.6799999,-9.28 25.5999999,-9.28 z" style="fill:#00b4fd;fill-opacity:1;stroke:none"/>
-                </g>
+                <circle r="27.743086" cy="248.39331" cx="-135.70163" transform="scale(-1,1)" style="fill:#ff5966;fill-opacity:1;stroke:none;stroke-width:1.29467726;stroke-opacity:1"/>
+                <circle r="72.85714" cy="216.6479" cx="201.04846" style="fill:#0dc66e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-opacity:1"/>
+                <circle r="37.37936" cy="136.32114" cx="167.3486" style="fill:#ffcc00;fill-opacity:1;stroke:none;stroke-width:1.18934333;stroke-opacity:1"/>
+                <circle r="49.79998" cy="121.63028" cx="292.31558" style="fill:#00b4fd;fill-opacity:1;stroke:none;stroke-width:0.91736811;stroke-opacity:1"/>
+                <path d="m -239.15268,150.44225 q 5.28,0 17.92,1.92 l 3.84,0.48 -0.48,9.76 q -12.8,-1.44 -18.88,-1.44 -13.6,0 -18.56,6.56 -4.8,6.4 -4.8,24 0,17.44 4.48,24.32 4.64,6.88 19.04,6.88 l 18.88,-1.44 0.48,9.92 q -14.88,2.24 -22.24,2.24 -18.72,0 -25.92,-9.6 -7.04,-9.6 -7.04,-32.32 0,-22.88 7.68,-32 7.68,-9.28 25.6,-9.28 z" style="fill:#ff5966;fill-opacity:1;stroke:none"/>
+                <path d="m -175.59268,152.04225 h 12 l 20,69.6 h 5.28 l 20.16,-69.6 h 12 l -33.28,115.52 h -12 l 10.4,-35.52 h -11.84 z" style="fill:#ffcc00;fill-opacity:1;stroke:none"/>
+                <path d="m -58.612682,232.04225 v -114.88 h 12 v 114.88 z" style="fill:#0dc66e;fill-opacity:1;stroke:none"/>
+                <path d="m 34.534818,150.44225 q 5.28,0 17.92,1.92 l 3.84,0.48 -0.48,9.76 q -12.8,-1.44 -18.88,-1.44 -13.6,0 -18.56,6.56 -4.8,6.4 -4.8,24 0,17.44 4.48,24.32 4.64,6.88 19.04,6.88 l 18.88,-1.44 0.48,9.92 q -14.88,2.24 -22.24,2.24 -18.72,0 -25.9199999,-9.6 -7.04,-9.6 -7.04,-32.32 0,-22.88 7.68,-32 7.6799999,-9.28 25.5999999,-9.28 z" style="fill:#00b4fd;fill-opacity:1;stroke:none"/>
               </g>
             </g>
           </g>
-        </svg>
-      </div>
-      <div class="c-environment-info">
-        <v-chip id="username" class="text--secondary" outlined>{{ user }}</v-chip>
-        <span class="at">@</span>
-        <v-chip id="host" class="text--secondary" outlined>{{ environment }}</v-chip>
-      </div>
-    </v-layout>
-  </v-list-item-action-text>
+        </g>
+      </svg>
+    </div>
+    <div class="c-environment-info">
+      <v-chip id="username" class="text--secondary" outlined>{{ user }}</v-chip>
+      <span class="at">@</span>
+      <v-chip id="host" class="text--secondary" outlined>{{ environment }}</v-chip>
+    </div>
+  </div>
 </template>
 
 <script>

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -126,14 +126,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :to="workflowLink(scope.node)"
             >
               <v-list-item-title>
-                <v-layout align-center align-content-center d-flex flex-nowrap>
-                  <v-flex
+                <v-row class="align-center align-content-center flex-nowrap">
+                  <v-col
                     v-if="scope.node.type === 'workflow-part'"
                     class="c-gscan-workflow-name"
                   >
                     <span>{{ scope.node.name || scope.node.id }}</span>
-                  </v-flex>
-                  <v-flex
+                  </v-col>
+                  <v-col
                     v-else-if="scope.node.type === 'workflow'"
                     class="c-gscan-workflow-name"
                   >
@@ -143,11 +143,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       </template>
                       <span>{{ scope.node.id }}</span>
                     </v-tooltip>
-                  </v-flex>
+                  </v-col>
                   <!-- We check the latestStateTasks below as offline workflows won't have a latestStateTasks property -->
-                  <v-flex
+                  <v-col
                     v-if="scope.node.type === 'workflow' && scope.node.node.latestStateTasks"
-                    class="text-right c-gscan-workflow-states"
+                    class="text-right c-gscan-workflow-states flex-grow-0"
                   >
                     <!-- task summary tooltips -->
                     <span
@@ -182,8 +182,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       </span>
                     </v-tooltip>
                   </span>
-                  </v-flex>
-                </v-layout>
+                  </v-col>
+                </v-row>
               </v-list-item-title>
             </v-list-item>
           </template>

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="treeitem" v-show="filtered">
-    <v-flex
+    <div
       class="node d-flex align-center"
       :class="nodeClass"
       :style="nodeStyle"
@@ -187,7 +187,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </slot>
       <slot></slot>
-    </v-flex>
+    </div>
     <span
       v-show="isExpanded"
       v-if="!stopOn.includes(node.type)"

--- a/src/mixins/subscriptionView.js
+++ b/src/mixins/subscriptionView.js
@@ -36,10 +36,5 @@ export default {
     next(vm => {
       vm.$workflowService.startSubscriptions()
     })
-  },
-  beforeRouteUpdate (to, from, next) {
-    next(vm => {
-      vm.$workflowService.startSubscriptions()
-    })
   }
 }

--- a/src/styles/cylc/_dashboard.scss
+++ b/src/styles/cylc/_dashboard.scss
@@ -26,10 +26,6 @@
     width: auto;
     height: auto;
   }
-  .v-list__tile__action, .v-list__tile__avatar {
-    min-width: auto;
-    margin-left: -10px;
-  }
 
   /* otherwise avatar does not left align with component above,
      !important as the attributes are set in the tag element */
@@ -41,11 +37,6 @@
   /* otherwise responsive UI ends up with extra space between vertical menu items */
   .v-list {
     padding: 0 0;
-  }
-
-  /* to left align items in the dashboard */
-  .v-list__tile {
-    padding: 10px 0;
   }
 
   table {

--- a/src/styles/cylc/_drawer.scss
+++ b/src/styles/cylc/_drawer.scss
@@ -25,17 +25,6 @@
 
   @include theme-dependent(background-color, $grey, 4);
 
-  .v-list__tile {
-    border-radius: 4px;
-    margin-top: 5px;
-  }
-
-  .v-image__image--contain {
-    top: 30px;
-    bottom: 30px;
-    height: 60%;
-  }
-
   .search-input {
     margin-bottom: 30px !important;
     padding-left: 15px;

--- a/src/styles/cylc/_header.scss
+++ b/src/styles/cylc/_header.scss
@@ -23,16 +23,14 @@
 
   @include theme-dependent(background-color, $grey, 3);
 
-  .layout {
-    .c-environment-info {
-      font-size: 1rem;
-      font-weight: map-get($font-weights, 'regular');
+  .c-environment-info {
+    font-size: 1rem;
+    font-weight: map-get($font-weights, 'regular');
 
-      .v-chip {
-        font-size: 1rem;
-        @include theme-dependent(background-color, $grey, 5, !important);
-        @include theme-dependent(border-color, $grey, 1, !important);
-      }
+    .v-chip {
+      font-size: 1rem;
+      @include theme-dependent(background-color, $grey, 5, !important);
+      @include theme-dependent(border-color, $grey, 1, !important);
     }
   }
 }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     grid-list
     class="c-dashboard mt-4"
   >
-    <v-layout wrap>
-      <v-flex xs12 md6 lg6>
+    <v-row wrap>
+      <v-col md="6" lg="6">
         <p class="display-1">Workflows</p>
         <v-data-table
           :headers="workflowsHeader"
@@ -32,7 +32,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           hide-default-header
           id="dashboard-workflows"
         >
-          <v-progress-linear slot="progress" color="grey" indeterminate></v-progress-linear>
           <template v-slot:item.count="{ item }">
             <v-skeleton-loader
               :loading="isLoading"
@@ -47,8 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <span class="title font-weight-light">{{ item.text }}</span>
           </template>
         </v-data-table>
-      </v-flex>
-      <v-flex xs12 md6 lg6>
+      </v-col>
+      <v-col md="6" lg="6">
         <p class="display-1">Events</p>
         <v-data-table
           :headers="eventsHeader"
@@ -66,11 +65,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <td class="title">No events</td>
           </template>
         </v-data-table>
-      </v-flex>
-    </v-layout>
+      </v-col>
+    </v-row>
     <v-divider />
-    <v-layout wrap>
-      <v-flex xs12 md6 lg6>
+    <v-row wrap>
+      <v-col md="6" lg="6">
         <v-list three-line>
           <v-list-item to="/workflow-table" data-cy="workflow-table-link">
             <v-list-item-avatar size="60" style="font-size: 2em;">
@@ -117,8 +116,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <span>You are not running Cylc UI via Cylc Hub.</span>
           </v-tooltip>
         </v-list>
-      </v-flex>
-      <v-flex xs12 md6 lg6>
+      </v-col>
+      <v-col md="6" lg="6">
         <v-list three-line>
           <v-list-item to="/guide" data-cy="quickstart-link">
             <v-list-item-avatar size="60" style="font-size: 2em;">
@@ -160,8 +159,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </v-list-item-content>
           </v-list-item>
         </v-list>
-      </v-flex>
-    </v-layout>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -30,10 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <div class="card-grid">
 
-      <v-flex
-        md5
-        xs12
-      >
+      <v-col>
         <v-card outlined>
           <v-card-title primary-title>
             <p class="display-1 text--primary">Tasks &amp; Jobs</p>
@@ -89,12 +86,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </p>
           </v-card-text>
         </v-card>
-      </v-flex>
+      </v-col>
 
-      <v-flex
-        md5
-        xs12
-      >
+      <v-col>
         <v-card outlined>
           <v-card-title primary-title>
             <p class="display-1 text--primary">Why Are We Waiting?</p>
@@ -187,7 +181,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
              </p>
           </v-card-text>
         </v-card>
-      </v-flex>
+      </v-col>
     </div>
 
   </v-container>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -16,33 +16,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <v-container
-      fill-height
-      fluid>
-    <v-layout
-        align-center
-        justify-center>
-      <v-flex
-          xs12
-          sm8
-          md4>
-        <v-card>
-          <v-card-title primary-title>
-            <div>
-              <h3 class="headline mb-0">{{ $t('NotFound.title') }}</h3>
-            </div>
-          </v-card-title>
-          <v-card-text>
-            {{ $t('NotFound.message') }}
-          </v-card-text>
-          <v-card-actions>
-            <button @click="$router.go(-1)" class="v-btn success">{{ $t('NotFound.goBack') }}</button>
-            <router-link to="/" tag="button" class="white--text success v-btn">{{ $t('NotFound.toHomepage') }}</router-link>
-          </v-card-actions>
-        </v-card>
-      </v-flex>
-    </v-layout>
-  </v-container>
+  <div class="d-flex fill-height align-items-center justify-content-center">
+    <v-card class="pa-4">
+      <v-card-title primary-title>
+        <div>
+          <h3 class="headline mb-0">{{ $t('NotFound.title') }}</h3>
+        </div>
+      </v-card-title>
+      <v-card-text>
+        {{ $t('NotFound.message') }}
+      </v-card-text>
+      <v-card-actions>
+        <button @click="$router.go(-1)" class="v-btn success">{{ $t('NotFound.goBack') }}</button>
+        <router-link to="/" tag="button" class="white--text success v-btn">{{ $t('NotFound.toHomepage') }}</router-link>
+      </v-card-actions>
+    </v-card>
+  </div>
 </template>
 
 <script>

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -17,8 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <v-container class="c-user-profile">
-    <v-layout wrap>
-      <v-flex xs12 md12>
+    <v-row class="wrap">
+      <v-col cols="12">
         <v-alert
           :icon="svgPaths.settings"
           prominent
@@ -29,11 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </v-alert>
         <v-form v-if="user !== null">
           <v-container py-0>
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>{{ $t('UserProfile.username') }}</span>
-              </v-flex>
-              <v-flex xs9>
+              </v-col>
+              <v-col cols="9">
                 <v-text-field
                     :value="user.username"
                     disabled
@@ -41,14 +41,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     aria-disabled="true"
                     class="body-1"
                 />
-              </v-flex>
-            </v-layout>
+              </v-col>
+            </v-row>
 
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>{{ $t('UserProfile.administrator') }}</span>
-              </v-flex>
-              <v-flex xs9>
+              </v-col>
+              <v-col cols="9">
                 <v-checkbox
                     v-model="user.admin"
                     disabled
@@ -56,14 +56,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     aria-disabled="true"
                     class="body-1"
                 />
-              </v-flex>
-            </v-layout>
+              </v-col>
+            </v-row>
 
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>{{ $t('UserProfile.groups') }}</span>
-              </v-flex>
-              <v-flex xs9>
+              </v-col>
+              <v-col cols="9">
                 <v-select
                     :items="user.groups"
                     v-model="user.groups"
@@ -74,14 +74,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     aria-disabled="true"
                     class="body-1"
                 />
-              </v-flex>
-            </v-layout>
+              </v-col>
+            </v-row>
 
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>{{ $t('UserProfile.created') }}</span>
-              </v-flex>
-              <v-flex xs9>
+              </v-col>
+              <v-col cols="9">
                 <v-text-field
                     :value="user.created"
                     disabled
@@ -89,13 +89,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     aria-disabled="true"
                     class="body-1"
                 />
-              </v-flex>
-            </v-layout>
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+              </v-col>
+            </v-row>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>{{ $t('UserProfile.permissions') }}</span>
-              </v-flex>
-              <v-flex xs9>
+              </v-col>
+              <v-col cols="9">
                 <v-select
                     :items="user.permissions"
                     v-model="user.permissions"
@@ -106,19 +106,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     aria-disabled="true"
                     class="body-1"
                 />
-              </v-flex>
-            </v-layout>
-            <v-row mt-4>
-              <v-flex xs12>
+              </v-col>
+            </v-row>
+            <v-row no-gutters class="mt-4">
+              <v-col cols="12">
                 <p class="title">Preferences</p>
-              </v-flex>
+              </v-col>
             </v-row>
 
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>Font size</span>
-              </v-flex>
-              <v-flex xs9>
+              </v-col>
+              <v-col cols="9">
                 <v-btn
                   depressed
                   id="font-size-reset-button"
@@ -140,13 +140,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   @click="increaseFontSize()">
                   <v-icon>{{ svgPaths.increase }}</v-icon>
                 </v-btn>
-              </v-flex>
-            </v-layout>
+              </v-col>
+            </v-row>
 
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>Colour Theme</span>
-              </v-flex>
+              </v-col>
               <v-radio-group v-model="jobTheme" column>
                 <table class="c-job-state-table">
                   <tr>
@@ -186,25 +186,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   </tr>
                 </table>
               </v-radio-group>
-              <v-flex xs9>
-              </v-flex>
-            </v-layout>
+              <v-col cols="9">
+              </v-col>
+            </v-row>
 
-            <v-layout row align-center wrap>
-              <v-flex xs3>
+            <v-row no-gutters class="align-center wrap">
+              <v-col cols="3">
                 <span>Latest cycle point at top</span>
-              </v-flex>
+              </v-col>
               <v-checkbox
                 v-model="cyclePointsOrderDesc"
                 id="input-cyclepoints-order"
               >
               </v-checkbox>
-            </v-layout>
+            </v-row>
           </v-container>
         </v-form>
         <v-progress-linear v-else :indeterminate="true" />
-      </v-flex>
-    </v-layout>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 

--- a/src/views/WorkflowsTable.vue
+++ b/src/views/WorkflowsTable.vue
@@ -21,48 +21,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     fluid
     grid-list-xl
   >
-    <v-layout
-      justify-center
-      wrap
-    >
-      <v-flex
-        md12
-      >
-          <v-alert
-            :icon="svgPath.table"
-            prominent
-            color="grey lighten-3"
-          >
-            <h3 class="headline">{{ $t('Workflows.tableHeader') }}</h3>
-          </v-alert>
+    <v-row class="align-self-start">
+      <v-col>
+        <!-- TODO: this is not really an alert, it's a heading -->
+        <v-alert
+          :icon="svgPath.table"
+          prominent
+          color="grey lighten-3"
+        >
+          <h3 class="headline">{{ $t('Workflows.tableHeader') }}</h3>
+        </v-alert>
         <v-data-table
           :headers="headers"
           :items="workflowsTable"
-          :loading="isLoading"
           data-cy="workflows-table"
         >
-          <template slot="no-data" v-if="!isLoading">
-            <v-alert
-              :value="true"
-              color="error"
-              icon="warning">
-              <p class="body-1">No workflows found for the current user</p>
-            </v-alert>
-          </template>
-          <template
-            slot="headerCell"
-            slot-scope="{ header }"
-          >
-            <span
-              class="subheading font-weight-light text-success text--darken-3"
-              v-text="header.text"
-            />
-          </template>
-          <v-progress-linear slot="progress" color="green" indeterminate></v-progress-linear>
-          <template
-            slot="item"
-            slot-scope="{ item }"
-          >
+          <template v-slot:item="{ item }">
             <tr>
               <td width="1em">
                 <WorkflowIcon
@@ -88,8 +62,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </tr>
           </template>
         </v-data-table>
-      </v-flex>
-    </v-layout>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 

--- a/tests/unit/mixins/subscriptionView.spec.js
+++ b/tests/unit/mixins/subscriptionView.spec.js
@@ -41,14 +41,4 @@ describe('Subscription View mixin', () => {
     })
     expect(workflowService.startSubscriptions.calledOnce).to.equal(true)
   })
-  it('should provide a navigation guard for when the view is updated', () => {
-    const component = Object.assign(subscriptionViewMixin)
-    const vm = {
-      $workflowService: workflowService
-    }
-    component.beforeRouteUpdate(null, null, (callback) => {
-      callback(vm)
-    })
-    expect(workflowService.startSubscriptions.calledOnce).to.equal(true)
-  })
 })


### PR DESCRIPTION
Remove stuff that is already deprecated as of Vue 2 / Vuetify 2

Vue:
- Deprecated slot syntax

Vuetify:
- Old grid/layout components
  - `v-layout` -> `v-row` or `div`
  - `v-flex` -> `v-col` or `div`

Vue-Router:
- Remove broken navigation guard that was not doing anything since first being added in #543

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
