### PR TITLE
deps: remove unnecessary babel-loader dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@vue/cli-plugin-unit-mocha": "^5.0.1",
     "@vue/cli-service": "^4.5.18",
     "@vue/test-utils": "^1.2.2",
-    "babel-loader": "^8.2.3",
     "babel-plugin-istanbul": "^6.1.1",
     "bufferutil": "^4.0.6",
     "chai": "^4.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4298,7 +4298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^8.1.0, babel-loader@npm:^8.2.3":
+"babel-loader@npm:^8.1.0":
   version: 8.2.5
   resolution: "babel-loader@npm:8.2.5"
   dependencies:
@@ -6412,7 +6412,6 @@ __metadata:
     "@vue/cli-service": ^4.5.18
     "@vue/test-utils": ^1.2.2
     axios: ^0.27.0
-    babel-loader: ^8.2.3
     babel-plugin-istanbul: ^6.1.1
     bufferutil: ^4.0.6
     chai: ^4.3.6


### PR DESCRIPTION
Alternative to #1192

Doesn't look like we are using this dev dependency directly.