### PR TITLE
aotf: prevent the "offset" field from being filled in

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -806,6 +806,14 @@ export function getMutationArgsFromTokens (mutation, tokens) {
     const alternate = alternateFields[arg._cylcType]
     for (let token in tokens) {
       if (arg._cylcObject && [token, alternate].includes(arg._cylcObject)) {
+        if (arg.name === 'cutoff') {
+          // Work around for a field we don't want filled in, see:
+          // * https://github.com/cylc/cylc-ui/issues/1222
+          // * https://github.com/cylc/cylc-ui/issues/1225
+          // TODO: Once #1225 is done the field type can be safely changed in
+          // the schema without creating a compatibility issue with the UIS.
+          continue
+        }
         if (arg._cylcObject === alternate) {
           token = alternate
         }


### PR DESCRIPTION
Fixes a small bug where the cutoff field is set in the broadcast form when opened from a task/family/cycle.

* Closes https://github.com/cylc/cylc-ui/issues/1222
* Note this solution is hardcoded in the UI and must stay that way until https://github.com/cylc/cylc-ui/issues/1225 is done.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.