### PR TITLE
store: fix ancestor order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ cycle point and family in tree & table views.
 
 ### Fixes
 
+[#1230](https://github.com/cylc/cylc-ui/pull/1230) -
+Fixes an issue where tasks were missing from the GUI in workflows which
+use multi-level family inheritance.
+
 [#1182](https://github.com/cylc/cylc-ui/pull/1182) - Fixes bug in filtering
 by task name.
 

--- a/src/services/mock/json/App.json
+++ b/src/services/mock/json/App.json
@@ -100,8 +100,8 @@
             {"id": "~user/one//20000102T0000Z/succeeded"}
           ],
           "ancestors": [
-            {"name": "root"},
-            {"name": "GOOD"}
+            {"name": "GOOD"},
+            {"name": "root"}
           ]
         }
       ],

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -358,7 +358,7 @@ function getFamilyTree (tokens, node) {
   }
 
   // add family levels below the cycle point
-  for (const ancestor of node.ancestors || []) {
+  for (const ancestor of node.ancestors.slice().reverse() || []) {
     ret.push([
       'family',
       ancestor.name,

--- a/tests/unit/store/workflows.spec.js
+++ b/tests/unit/store/workflows.spec.js
@@ -493,8 +493,8 @@ describe('cylc tree', () => {
         id: '~u/w//1/PENGUIN',
         name: 'PENGUIN',
         ancestors: [
-          { name: 'root' },
-          { name: 'ANIMAL' }
+          { name: 'ANIMAL' },
+          { name: 'root' }
         ],
         __typename: 'FamilyProxy'
       }
@@ -661,6 +661,7 @@ describe('cylc tree', () => {
       'workflows/UPDATE',
       {
         id: '~u/w//1/root',
+        ancestors: [],
         __typename: 'FamilyProxy'
       }
     )


### PR DESCRIPTION
> Sibling https://github.com/cylc/cylc-flow/pull/5368

* Due to a bug in cylc-flow the ancestor order came out reversed more often than not.
* https://github.com/cylc/cylc-flow/pull/5368 fixes this bug.
* Now the ancestors should always come out the right way around so we need to reverse the iteration of this list.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No documentation update required.
