### PR TITLE
GH Actions: fix upload release asset step

### DIFF
--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -69,19 +69,16 @@ jobs:
           body: |
             See [${{ env.CHANGELOG_FILE }}](https://github.com/${{ github.repository }}/blob/master/${{ env.CHANGELOG_FILE }}) for details.
 
-            sha256sum: ${{ env.SHA256SUM }}
+            sha256sum:
+            ```
+            ${{ env.SHA256SUM }}
+            ```
           # TODO: Get topmost changelog section somehow and use that as the body?
 
       - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./${{ env.ZIP_ARCHIVE }}
-          asset_name: ${{ env.ZIP_ARCHIVE }}
-          asset_content_type: application/zip
+        run: gh release upload "$VERSION" "$ZIP_ARCHIVE"
 
       - name: Comment on the release PR with the results & next steps
         if: always()


### PR DESCRIPTION
Replacing [actions/upload-release-asset](https://github.com/actions/upload-release-asset) because it's no longer maintained

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
