### PR TITLE
Prepare release: 1.6.0 (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "wasm-loader": "^1.3.0",
     "webpack": "^4.46.0"
   },
+
   "bugs": {
     "url": "https://github.com/cylc/cylc-ui/issues"
   },


### PR DESCRIPTION
Follow-up to #1284, including a dummy commit to retrigger the 2nd stage of the release process now it's been fixed in #1286

