### PR TITLE
Prepare release: 1.6.0 (3rd time's the charm)

### DIFF
--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -69,19 +69,16 @@ jobs:
           body: |
             See [${{ env.CHANGELOG_FILE }}](https://github.com/${{ github.repository }}/blob/master/${{ env.CHANGELOG_FILE }}) for details.
 
-            sha256sum: ${{ env.SHA256SUM }}
+            sha256sum:
+            ```
+            ${{ env.SHA256SUM }}
+            ```
           # TODO: Get topmost changelog section somehow and use that as the body?
 
       - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./${{ env.ZIP_ARCHIVE }}
-          asset_name: ${{ env.ZIP_ARCHIVE }}
-          asset_content_type: application/zip
+        run: gh release upload "$VERSION" "$ZIP_ARCHIVE"
 
       - name: Comment on the release PR with the results & next steps
         if: always()

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "wasm-loader": "^1.3.0",
     "webpack": "^4.46.0"
   },
-
   "bugs": {
     "url": "https://github.com/cylc/cylc-ui/issues"
   },


### PR DESCRIPTION
Follow-up to #1284 & #1287, cherry-picking https://github.com/cylc/cylc-ui/pull/1286 to fix the release stage 2 failure

