### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,16 @@
 {
   "extends": [
-    "config:base"
+    "config:js-app"
   ],
   "labels": ["dependencies", "javascript"],
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "rangeStrategy": "replace"
+      "matchPackagePatterns": ["^@lumino/"],
+      "groupName": "lumino packages"
+    },
+    {
+      "matchPackagePatterns": ["^eslint"],
+      "groupName": "eslint packages"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
We are not currently getting updates for dependencies when the new version falls within the semantic specifier. E.g. for `^1.2.3` we would only get a dependency PR if they released `2.0.0`, but not `1.3.0` or `1.2.4`.
- https://docs.renovatebot.com/configuration-options/#rangestrategy
- https://docs.renovatebot.com/presets-config/#configjs-app

If the dependency PRs get too noisy we can use a custom schedule to manage them.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
