### PR TITLE
Use dynamic async components for workspace view tabs + 1.6.x -> master (SimpleTree view)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
         objects: 'only-multiline',
         imports: 'only-multiline',
         exports: 'only-multiline',
-        functions: 'never',
+        functions: 'only-multiline',
       },
     ],
     'template-curly-spacing': [

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -89,6 +89,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <v-spacer class="mx-0" />
 
       <v-btn
+        v-if="$route.name === 'workspace'"
         class="add-view"
         color="primary"
         data-cy="add-view-btn"
@@ -101,20 +102,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-menu
           activator="parent"
           location="bottom"
-          v-if="$route.name === 'workspace'"
-        >
-          <v-list class="pa-0">
+          >
+          <v-list>
             <v-list-item
-              :id="`toolbar-add-${ view.name }-view`"
               v-for="view in views"
+              :id="`toolbar-add-${ view.name }-view`"
               :key="view.name"
               @click="$emit('add', { viewName: view.name })"
-              class="py-0 px-8 ma-0 c-add-view"
             >
               <template v-slot:prepend>
-                <v-icon>{{ view.data().widget.icon }}</v-icon>
+                <v-icon>{{ view.icon }}</v-icon>
               </template>
-              <v-list-item-title>{{ view.name }}</v-list-item-title>
+              <v-list-item-title>{{ startCase(view.name) }}</v-list-item-title>
             </v-list-item>
           </v-list>
         </v-menu>
@@ -148,6 +147,7 @@ import {
   mdiStop,
   mdiViewList
 } from '@mdi/js'
+import { startCase } from 'lodash'
 import toolbar from '@/mixins/toolbar'
 import WorkflowState from '@/model/WorkflowState.model'
 import graphql from '@/mixins/graphql'
@@ -158,20 +158,24 @@ import {
 
 export default {
   name: 'Toolbar',
+
   mixins: [
     toolbar,
     graphql
   ],
+
   props: {
     views: {
       type: Array,
       required: true
     }
+
   },
+
   emits: ['add'],
+
   data: () => ({
     extended: false,
-    // FIXME: remove local state once we have this data in the workflow - https://github.com/cylc/cylc-ui/issues/221
     svgPaths: {
       add: mdiPlusBoxMultiple,
       hold: mdiPause,
@@ -187,6 +191,7 @@ export default {
       stop: null
     }
   }),
+
   computed: {
     ...mapState('app', ['title']),
     ...mapState('user', ['user']),
@@ -253,6 +258,7 @@ export default {
       }
     }
   },
+
   watch: {
     isRunning () {
       this.expecting.play = null
@@ -264,6 +270,7 @@ export default {
       this.expecting.stop = null
     }
   },
+
   methods: {
     onClickPlay () {
       this.$workflowService.mutate(
@@ -285,7 +292,7 @@ export default {
         }
       })
     },
-    async onClickStop () {
+    onClickStop () {
       this.$workflowService.mutate(
         'stop',
         this.currentWorkflow.id
@@ -297,7 +304,8 @@ export default {
     },
     toggleExtended () {
       this.extended = !this.extended
-    }
+    },
+    startCase,
   }
 }
 </script>

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -88,7 +88,6 @@ import {
   platformOptions
 } from '@/components/cylc/analysis/filter'
 import {
-  mdiChartLine,
   mdiRefresh
 } from '@mdi/js'
 
@@ -185,10 +184,6 @@ export default {
   data () {
     const tasks = []
     return {
-      widget: {
-        title: 'analysis',
-        icon: mdiChartLine
-      },
       /** Defines controls which get added to the toolbar */
       groups: [
         {

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -108,7 +108,6 @@ import {
 import { Graphviz } from '@hpcc-js/wasm/graphviz'
 import svgPanZoom from 'svg-pan-zoom'
 import {
-  mdiGraph,
   mdiTimer,
   mdiImageFilterCenterFocus,
   mdiArrowCollapse,
@@ -219,10 +218,6 @@ export default {
 
   data () {
     return {
-      widget: {
-        title: 'graph',
-        icon: mdiGraph
-      },
       // the graph orientation
       orientation: 'TB',
       // the auto-refresh timer

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -141,7 +141,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import {
   mdiClockOutline,
-  mdiFileDocumentMultipleOutline,
   mdiFolderRefresh,
   mdiPowerPlugOff,
   mdiPowerPlug
@@ -253,11 +252,6 @@ export default {
 
   data () {
     return {
-      // metadata for the workspace view
-      widget: {
-        title: 'logs',
-        icon: mdiFileDocumentMultipleOutline
-      },
       // the log subscription query
       query: null,
       // list of log files for the selected workflow/task/job

--- a/src/views/SimpleTree.vue
+++ b/src/views/SimpleTree.vue
@@ -106,11 +106,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import gql from 'graphql-tag'
 import { mapState, mapGetters } from 'vuex'
-import pageMixin from '@/mixins/index'
+import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
-import { mdiTree } from '@mdi/js'
 
 // Any fields that our view will use (e.g. TaskProxy.status) must be requested
 // in the query.
@@ -176,30 +175,18 @@ fragment JobData on Job {
 `
 
 export default {
+  name: 'SimpleTree',
+
   // These mixins enable various functionalities.
   mixins: [
-    pageMixin,
     graphqlMixin,
     subscriptionComponentMixin
   ],
 
-  // This defines the component name, must be HTML safe.
-  name: 'SimpleTree',
-
   // This sets the page title.
-  metaInfo () {
+  head () {
     return {
-      title: this.getPageTitle('App.workflow', { name: this.workflowName })
-    }
-  },
-
-  // The view must provide a title and icon for display purposes.
-  data () {
-    return {
-      widget: {
-        title: 'simple tree',
-        icon: mdiTree
-      }
+      title: getPageTitle('App.workflow', { name: this.workflowName })
     }
   },
 
@@ -238,7 +225,10 @@ export default {
 
 <style lang="scss">
   .c-simple-tree {
-    .state:before {
+    ul, ol {
+      padding-left: 24px;
+    }
+    .state::before {
       content: ' ';
     }
     .state {

--- a/src/views/SimpleTree.vue
+++ b/src/views/SimpleTree.vue
@@ -153,7 +153,7 @@ fragment UpdatedDelta on Updated {
 }
 
 # We must list all of the types we request data for here to enable automatic
-# hosekeeping.
+# housekeeping.
 fragment PrunedDelta on Pruned {
   workflow
   taskProxies

--- a/src/views/Table.vue
+++ b/src/views/Table.vue
@@ -27,7 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script>
 import { mapState, mapGetters } from 'vuex'
-import { mdiTable } from '@mdi/js'
 import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
@@ -54,13 +53,6 @@ export default {
       title: getPageTitle('App.workflow', { name: this.workflowName })
     }
   },
-
-  data: () => ({
-    widget: {
-      title: 'table',
-      icon: mdiTable
-    }
-  }),
 
   computed: {
     ...mapState('workflows', ['cylcTree']),

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -35,7 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script>
 import { mapState, mapGetters } from 'vuex'
-import { mdiFileTree } from '@mdi/js'
 import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
@@ -58,15 +57,6 @@ export default {
   head () {
     return {
       title: getPageTitle('App.workflow', { name: this.workflowName })
-    }
-  },
-
-  data () {
-    return {
-      widget: {
-        title: 'tree',
-        icon: mdiFileTree
-      }
     }
   },
 

--- a/src/views/Workspace.vue
+++ b/src/views/Workspace.vue
@@ -28,7 +28,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         ref="lumino"
         @lumino:deleted="onWidgetDeletedEvent"
         :views="widgets"
-        tab-title-prop="tab-title"
         :workflow-name="workflowName"
         :allViews="$options.allViews"
       />
@@ -37,19 +36,45 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
 import { uniqueId } from 'lodash'
 import { toArray } from '@lumino/algorithm'
+import {
+  mdiChartLine,
+  mdiFileDocumentMultipleOutline,
+  mdiFileTree,
+  mdiGraph,
+  mdiTable,
+  mdiTree,
+} from '@mdi/js'
 import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
 import subscriptionMixin from '@/mixins/subscription'
 import ViewState from '@/model/ViewState.model'
 import Lumino from '@/components/cylc/workflow/Lumino.vue'
 import Toolbar from '@/components/cylc/workflow/Toolbar.vue'
-import TableView from '@/views/Table.vue'
-import TreeView from '@/views/Tree.vue'
-import GraphView from '@/views/Graph.vue'
-import LogView from '@/views/Log.vue'
-import AnalysisView from '@/views/Analysis.vue'
+
+// Use dynamic async components for lazy loading:
+const TreeView = defineAsyncComponent(() => import('@/views/Tree.vue'))
+const TableView = defineAsyncComponent(() => import('@/views/Table.vue'))
+const GraphView = defineAsyncComponent(() => import('@/views/Graph.vue'))
+const LogView = defineAsyncComponent(() => import('@/views/Log.vue'))
+const AnalysisView = defineAsyncComponent(() => import('@/views/Analysis.vue'))
+const SimpleTreeView = defineAsyncComponent(() => import('@/views/SimpleTree.vue'))
+
+const allViews = [
+  { name: 'Tree', component: TreeView, icon: mdiFileTree },
+  { name: 'Table', component: TableView, icon: mdiTable },
+  { name: 'Graph', component: GraphView, icon: mdiGraph },
+  { name: 'Log', component: LogView, icon: mdiFileDocumentMultipleOutline },
+  { name: 'Analysis', component: AnalysisView, icon: mdiChartLine },
+]
+// Development views that we don't want in production:
+if (import.meta.env.MODE !== 'production') {
+  allViews.push(
+    { name: 'SimpleTree', component: SimpleTreeView, icon: mdiTree },
+  )
+}
 
 export default {
   name: 'Workspace',
@@ -86,20 +111,12 @@ export default {
      */
     widgets: {}
   }),
-  created () {
-    if (import.meta.env.MODE !== 'production') {
-      // dynamically load development views that we don't want in production
-      import('@/views/SimpleTree.vue').then((SimpleTreeView) => {
-        this.$options.allViews.push(SimpleTreeView.default)
-      })
-    }
-  },
 
   beforeRouteEnter (to, from, next) {
     next(vm => {
       vm.$workflowService.startSubscriptions()
       vm.$nextTick(() => {
-        vm.addView({ viewName: TreeView.name })
+        vm.addView({ viewName: 'Tree' })
       })
     })
   },
@@ -110,7 +127,7 @@ export default {
     // and in the next tick as otherwise we would get stale/old variables for the graphql query
     this.$nextTick(() => {
       // Create a Tree View for the current workflow by default
-      this.addView({ viewName: TreeView.name })
+      this.addView({ viewName: 'Tree' })
     })
   },
 
@@ -133,7 +150,7 @@ export default {
      * viewName - the name of the view to be added (Vue component name).
      */
     addView ({ viewName, initialOptions = {} }) {
-      this.widgets[uniqueId()] = { view: viewName, initialOptions }
+      this.widgets[uniqueId('widget_')] = { view: viewName, initialOptions }
     },
     /**
      * Remove all the widgets present in the DockPanel.
@@ -178,12 +195,6 @@ export default {
    *
    * @type {Object[]}
    */
-  allViews: [
-    TreeView,
-    TableView,
-    GraphView,
-    LogView,
-    AnalysisView,
-  ]
+  allViews,
 }
 </script>


### PR DESCRIPTION
In order to incorporate the dynamically imported SimpleTree view it seemed necessary to make all the views dynamically imported in Vue 3. Closes #1221.

I also took this opportunity to use [`<Teleport>`](https://vuejs.org/api/built-in-components.html#teleport) instead of the hacky solution for displaying these views in the Lumino tabs. (Hat tip to @kinow for the suggestion, it is rather nice!). Closes #1273.

Sync:
- #1139

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are not needed.
- [x] No changelog entry needed.
