### PR TITLE
graph: increase max zoom by 5x

### DIFF
--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -365,7 +365,7 @@ export default {
           preventMouseEventsDefault: true,
           zoomScaleSensitivity: 0.2,
           minZoom: 0.01, // how zoomed out we can go
-          maxZoom: 10, // how zoomed in we can go
+          maxZoom: 50, // how zoomed in we can go
           fit: false,
           contain: false,
           center: true,


### PR DESCRIPTION
Define an upper and lower limit for zooming in the graph, but this doesn't scale with the size of the canvas due to the way zooming is implemented in svgpanzoom.

When graphs are transposed they get tall and thin, large graphs can get large enough that you can't zoom in on tasks close enough to read their names.

This bumps the max magnification by 5x. It's an arbitrary number, we could do 10x, but with smaller graphs that might allow you to zoom onto the dot of the letter i or whatever so keeping the value sensible has value.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.