### PR TITLE
Fix family tasks discrepancy in tree view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,10 @@ Tree view: show mean run time in job details.
 
 ### Fixes
 
+[#1340](https://github.com/cylc/cylc-ui/pull/1340) -
+Fixed bug in tree view where tasks belonging to families would disappear
+and reappear eroneously.
+
 [#1312](https://github.com/cylc/cylc-ui/pull/1312) -
 Fixed incorrect latest job info in table view.
 

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -66,7 +66,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div class="mr-1">
                   <Job
                     v-cylc-object="item.value.task"
-                    :status="item.value.task.node.state"
+                    :status="item.value.latestJob?.node?.state"
                     :previous-state="item.value.previousJob?.node?.state"
                   />
                 </div>

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -81,6 +81,9 @@ fragment TaskProxyData on TaskProxy {
   task {
     meanElapsedTime
   }
+  firstParent {
+    id
+  }
 }
 `
 

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -270,28 +270,20 @@ function cleanParents (state, node) {
   }
 }
 
-/* Build / housekeep the familyTree based on the family information containined
+/**
+ * Build the familyTree based on the family information containined
  * in this node.
  */
 function applyInheritance (state, node) {
-  if (node.type === 'family') {
-    const childTasks = node.node.childTasks || []
-
+  if (node.type === 'family' && node.node.childTasks) {
     // add new tasks
-    for (const child of childTasks) {
+    for (const child of node.node.childTasks) {
       if (!hasChild(node, child.id)) {
         // child has been added to childTasks
         const childNode = getIndex(state, child.id)
         if (childNode) {
           addChild(node, childNode)
         }
-      }
-    }
-
-    // remove old tasks
-    for (const child of node.children.filter(child => child.type === 'task')) {
-      if (!childTasks.some(x => x.id === child.id)) {
-        removeChild(state, child, node)
       }
     }
   }
@@ -488,6 +480,11 @@ function remove (state, prunedID) {
     // remove family proxy node
     removeChild(state, treeNode, firstParent)
   } else {
+    if (treeNode.type === 'task') {
+      // remove task from its primary family
+      const familyNode = getIndex(state, treeNode.node.firstParent.id)
+      removeChild(state, treeNode, familyNode)
+    }
     // remove ~user[/path/to...]/workflow//cycle/task/job node
     removeTree(state, treeNode)
     cleanParents(state, parentNode)

--- a/tests/unit/store/workflows.spec.js
+++ b/tests/unit/store/workflows.spec.js
@@ -17,7 +17,6 @@
 
 import { createStore } from 'vuex'
 import storeOptions from '@/store/options'
-import { merge } from '@/store/workflows.module'
 
 function getTree (store) {
   const cylcTree = store.state.workflows.cylcTree
@@ -44,26 +43,6 @@ function getTree (store) {
   }
   return ret
 }
-
-describe('merge', () => {
-  it('should update the node', () => {
-    const data = { a: 1, b: 2 }
-    merge(data, { b: 3, c: 4 })
-    expect(data).to.deep.equal({ a: 1, b: 3, c: 4 })
-  })
-
-  it('should update Arrays', () => {
-    const data = { a: [1, 2] }
-    merge(data, { a: [2, 3] })
-    expect(data).to.deep.equal({ a: [2, 3] })
-  })
-
-  it('should update nested Objects', () => {
-    const data = { a: [{ x: 1 }, { x: 2 }] }
-    merge(data, { a: [{ x: 3 }] })
-    expect(data).to.deep.equal({ a: [{ x: 3 }] })
-  })
-})
 
 describe('cylc tree', () => {
   const store = createStore(storeOptions)

--- a/tests/unit/store/workflows.spec.js
+++ b/tests/unit/store/workflows.spec.js
@@ -277,6 +277,33 @@ describe('cylc tree', () => {
       expect(getTree(store)).to.deep.equal(expectedTree)
       expect(getIndex()).to.deep.equal(expectedIndex)
     })
+
+    it('removes a task from its first parent family', () => {
+      store.commit('workflows/UPDATE', {
+        id: '~u/w//1/a',
+        firstParent: { id: '~u/w//1/A' },
+        __typename: 'TaskProxy',
+      })
+      store.commit('workflows/UPDATE', {
+        id: '~u/w//1/A',
+        ancestors: [{ name: 'root' }],
+        childTasks: [{ id: '~u/w//1/a' }],
+        __typename: 'FamilyProxy',
+      })
+      expect(getTree(store).u.w).to.deep.equal({
+        1: {
+          a: {},
+        },
+      })
+      const A = () => store.state.workflows.cylcTree.$index['~u/w//1/A']
+      expect(A().children).toMatchObject([
+        { id: '~u/w//1/a' },
+      ])
+
+      store.commit('workflows/REMOVE', '~u/w//1/a')
+
+      expect(A().children).toStrictEqual([])
+    })
   })
 
   it('updates', () => {

--- a/tests/unit/store/workflows.spec.js
+++ b/tests/unit/store/workflows.spec.js
@@ -46,14 +46,11 @@ function getTree (store) {
 
 describe('cylc tree', () => {
   const store = createStore(storeOptions)
-  if (!global.localStorage) {
-    global.localStorage = {}
-  }
   const resetState = () => {
     store.state.workflows.cylcTree = undefined
   }
   beforeEach(resetState)
-  afterEach(resetState)
+
   function getNode (id) {
     return store.state.workflows.cylcTree.$index[id]
   }
@@ -170,9 +167,19 @@ describe('cylc tree', () => {
 
     // add some nodes to the tree
     function addNodes () {
-      store.commit('workflows/UPDATE', { id: '~a/b//c/d/e' })
-      store.commit('workflows/UPDATE', { id: '~a/b//c/d/f' })
-      store.commit('workflows/UPDATE', { id: '~a/b//g' })
+      store.commit('workflows/UPDATE', {
+        id: '~a/b//c/d',
+        firstParent: { id: '~a/b//c/root' },
+      })
+      store.commit('workflows/UPDATE', {
+        id: '~a/b//c/d/e',
+      })
+      store.commit('workflows/UPDATE', {
+        id: '~a/b//c/d/f',
+      })
+      store.commit('workflows/UPDATE', {
+        id: '~a/b//g',
+      })
       expect(getTree(store)).to.deep.equal({
         a: {
           b: {
@@ -520,10 +527,22 @@ describe('cylc tree', () => {
     expect(penguin.node.foo).to.equal(3)
 
     // test adding tasks
-    store.commit('workflows/UPDATE', { id: '~u/w//1/adelie' })
-    store.commit('workflows/UPDATE', { id: '~u/w//1/gentoo' })
-    store.commit('workflows/UPDATE', { id: '~u/w//1/jeffes' })
-    store.commit('workflows/UPDATE', { id: '~u/w//1/great-auk' })
+    store.commit('workflows/UPDATE', {
+      id: '~u/w//1/adelie',
+      firstParent: { id: '~u/w//1/PENGUIN' },
+    })
+    store.commit('workflows/UPDATE', {
+      id: '~u/w//1/gentoo',
+      firstParent: { id: '~u/w//1/PENGUIN' },
+    })
+    store.commit('workflows/UPDATE', {
+      id: '~u/w//1/jeffes',
+      firstParent: { id: '~u/w//1/PENGUIN' },
+    })
+    store.commit('workflows/UPDATE', {
+      id: '~u/w//1/great-auk',
+      firstParent: { id: '~u/w//1/ANIMAL' },
+    })
     store.commit(
       'workflows/UPDATE',
       {
@@ -561,17 +580,6 @@ describe('cylc tree', () => {
     ])
 
     // test removing task (1/adelie)
-    store.commit(
-      'workflows/UPDATE',
-      {
-        id: '~u/w//1/PENGUIN',
-        childTasks: [
-          // the childTasks should change triggering an update
-          { id: '~u/w//1/gentoo' },
-          { id: '~u/w//1/jeffes' }
-        ]
-      }
-    )
     store.commit('workflows/REMOVE', '~u/w//1/adelie')
 
     // 1/adelie should have been removed from both the regular and family trees

--- a/tests/unit/store/workflows.spec.js
+++ b/tests/unit/store/workflows.spec.js
@@ -161,12 +161,82 @@ describe('cylc tree', () => {
     ])
   })
 
-  it('removes', () => {
-    // it should remove nodes and housekeep the tree via the REMOVE interface
-    store.commit('workflows/CREATE')
+  /** it should remove nodes and housekeep the tree via the REMOVE interface */
+  describe('remove()', () => {
+    beforeEach(() => {
+      store.commit('workflows/CREATE')
+    })
 
-    // add some nodes to the tree
-    function addNodes () {
+    it.each([
+      {
+        type: 'user',
+        id: '~a',
+        expectedTree: {},
+        expectedIndex: [],
+      },
+      {
+        type: 'workflow',
+        id: '~a/b',
+        expectedTree: {},
+        expectedIndex: [],
+      },
+      {
+        type: 'cycle',
+        id: '~a/b//c',
+        expectedTree: {
+          a: {
+            b: {
+              g: {}
+            }
+          }
+        },
+        expectedIndex: [
+          '~a',
+          '~a/b',
+          '~a/b//g'
+        ],
+      },
+      {
+        type: 'task',
+        id: '~a/b//c/d',
+        expectedTree: {
+          a: {
+            b: {
+              g: {}
+            }
+          }
+        },
+        expectedIndex: [
+          '~a',
+          '~a/b',
+          '~a/b//g'
+        ],
+      },
+      {
+        type: 'job',
+        id: '~a/b//c/d/e',
+        expectedTree: {
+          a: {
+            b: {
+              c: {
+                d: {
+                  f: {}
+                }
+              },
+              g: {}
+            }
+          }
+        },
+        expectedIndex: [
+          '~a',
+          '~a/b',
+          '~a/b//c',
+          '~a/b//c/d',
+          '~a/b//c/d/f',
+          '~a/b//g'
+        ],
+      },
+    ])('removes a $type from the tree', ({ id, expectedTree, expectedIndex }) => {
       store.commit('workflows/UPDATE', {
         id: '~a/b//c/d',
         firstParent: { id: '~a/b//c/root' },
@@ -202,75 +272,11 @@ describe('cylc tree', () => {
         '~a/b//c/d/f',
         '~a/b//g'
       ])
-    }
 
-    // remove a user from the tree
-    addNodes()
-    store.commit('workflows/REMOVE', '~a')
-    expect(getTree(store)).to.deep.equal({})
-    expect(getIndex()).to.deep.equal([])
-
-    // remove a workflow from the tree
-    addNodes()
-    store.commit('workflows/REMOVE', '~a/b')
-    expect(getTree(store)).to.deep.equal({})
-    expect(getIndex()).to.deep.equal([])
-
-    // remove a cycle from the tree
-    addNodes()
-    store.commit('workflows/REMOVE', '~a/b//c')
-    expect(getTree(store)).to.deep.equal({
-      a: {
-        b: {
-          g: {}
-        }
-      }
+      store.commit('workflows/REMOVE', id)
+      expect(getTree(store)).to.deep.equal(expectedTree)
+      expect(getIndex()).to.deep.equal(expectedIndex)
     })
-    expect(getIndex()).to.deep.equal([
-      '~a',
-      '~a/b',
-      '~a/b//g'
-    ])
-
-    // remove a task from the tree
-    addNodes()
-    store.commit('workflows/REMOVE', '~a/b//c/d')
-    expect(getTree(store)).to.deep.equal({
-      a: {
-        b: {
-          g: {}
-        }
-      }
-    })
-    expect(getIndex()).to.deep.equal([
-      '~a',
-      '~a/b',
-      '~a/b//g'
-    ])
-
-    // remove a job from the tree
-    addNodes()
-    store.commit('workflows/REMOVE', '~a/b//c/d/e')
-    expect(getTree(store)).to.deep.equal({
-      a: {
-        b: {
-          c: {
-            d: {
-              f: {}
-            }
-          },
-          g: {}
-        }
-      }
-    })
-    expect(getIndex()).to.deep.equal([
-      '~a',
-      '~a/b',
-      '~a/b//c',
-      '~a/b//c/d',
-      '~a/b//c/d/f',
-      '~a/b//g'
-    ])
   })
 
   it('updates', () => {


### PR DESCRIPTION
Closes #1322.

Fixes a bug where tasks belonging to a family would sometimes disappear for a second only to reappear (typically when changing state), and would sometimes reappear permanently after having finished and moved out of the n=1 window.

There was an assumption the `childTasks` field of each updated-family delta always contained all current child tasks, but it only includes updated tasks (or maybe even arbitrary tasks?). Instead, use the pruned-task delta to remove the task from the family.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users

