### PR TITLE
aotf: Make set-outputs a primary mutation for namespaces.

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -183,7 +183,8 @@ export const primaryMutations = {
     'release',
     'trigger',
     'kill',
-    'log'
+    'log',
+    'set-outputs'
   ]
 }
 

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -184,7 +184,7 @@ export const primaryMutations = {
     'trigger',
     'kill',
     'log',
-    'set-outputs'
+    'setOutputs'
   ]
 }
 


### PR DESCRIPTION
* Partially addresses #1364
* The `set-outputs` command is used reasonably often and current discussions could see its importance grow in the near future.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.