### PR TITLE
Strip token from URL when app is first loaded

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,31 +33,45 @@ import { createVuetify } from 'vuetify'
 import mitt from 'mitt'
 import { createHead, VueHeadMixin } from '@unhead/vue'
 
-const app = createApp(App)
+if (location.search) {
+  /* Remove token from the querystring - we only need it on first load.
+  After the browser has sent the token as part of the URL in the first GET, the
+  server responds with a cookie that is stored in the browser so the token is
+  no longer needed. */
+  const params = new URLSearchParams(location.search)
+  params.delete('token')
+  const querystring = params.size ? `?${params.toString()}` : ''
+  // Move remaining querystring to after hash so vue-router has access to it
+  location.replace(location.pathname + location.hash + querystring)
+  // ^ redirects the page -> then the 'else' branch will run
+} else {
+  // Normal app start
+  const app = createApp(App)
 
-app.mixin(VueHeadMixin)
+  app.mixin(VueHeadMixin)
 
-app.use(store)
-app.use(router)
-app.use(createVuetify(vuetifyOptions))
-app.use(i18n)
-app.use(createHead())
-app.use(ServicesPlugin)
-app.use(CylcObjectPlugin)
+  app.use(store)
+  app.use(router)
+  app.use(createVuetify(vuetifyOptions))
+  app.use(i18n)
+  app.use(createHead())
+  app.use(ServicesPlugin)
+  app.use(CylcObjectPlugin)
 
-app.config.globalProperties.$eventBus = mitt()
+  app.config.globalProperties.$eventBus = mitt()
 
-app.component('default-layout', Default)
-app.component('empty-layout', Empty)
+  app.component('default-layout', Default)
+  app.component('empty-layout', Empty)
 
-// https://router.vuejs.org/guide/migration/#removal-of-router-app
-router.app = app
+  // https://router.vuejs.org/guide/migration/#removal-of-router-app
+  router.app = app
 
-router.isReady().then(() => app.mount('#app'))
+  router.isReady().then(() => app.mount('#app'))
 
-// e2e tests use the offline mode, so here we expose the Vue.js app so Cypress can access it programmatically
-// e.g. window.app.$store and window.app.$workflowService.
-// Ref: https://www.cypress.io/blog/2017/11/28/testing-vue-web-application-with-vuex-data-store-and-rest-backend/
-if (import.meta.env.MODE !== 'production') {
-  window.app = app.config.globalProperties
+  // e2e tests use the offline mode, so here we expose the Vue.js app so Cypress can access it programmatically
+  // e.g. window.app.$store and window.app.$workflowService.
+  // Ref: https://www.cypress.io/blog/2017/11/28/testing-vue-web-application-with-vuex-data-store-and-rest-backend/
+  if (import.meta.env.MODE !== 'production') {
+    window.app = app.config.globalProperties
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,8 @@ if (location.search) {
   no longer needed. */
   const params = new URLSearchParams(location.search)
   params.delete('token')
-  const querystring = params.size ? `?${params.toString()}` : ''
+  let querystring = params.toString()
+  querystring &&= `?${querystring}`
   // Move remaining querystring to after hash so vue-router has access to it
   location.replace(location.pathname + location.hash + querystring)
   // ^ redirects the page -> then the 'else' branch will run

--- a/tests/e2e/specs/url.cy.js
+++ b/tests/e2e/specs/url.cy.js
@@ -23,7 +23,10 @@ describe('URL handling', () => {
       .should('not.contain', '?')
       .should('not.contain', 'token')
       .should('not.contain', 'l0r3m1p5um')
-    // Other query params not stripped; moved to after hash so vue-router can access
+  })
+
+  it('preserves other params in the querystring', () => {
+    // Other query params moved to after hash so vue-router can access
     cy.visit('/?a=1&token=42&b=2#/')
       .get('#app')
     cy.url()

--- a/tests/e2e/specs/url.cy.js
+++ b/tests/e2e/specs/url.cy.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+describe('URL handling', () => {
+  it('strips token from querystring', () => {
+    cy.visit('/?token=l0r3m1p5um#/')
+      .get('#app')
+    cy.url()
+      .should('not.contain', '?')
+      .should('not.contain', 'token')
+      .should('not.contain', 'l0r3m1p5um')
+    // Other query params not stripped; moved to after hash so vue-router can access
+    cy.visit('/?a=1&token=42&b=2#/')
+      .get('#app')
+    cy.url()
+      .should('not.contain', 'token')
+      .then((url) => {
+        expect(url.endsWith('?a=1&b=2')).to.be.true
+      })
+  })
+})


### PR DESCRIPTION
Closes #1147, re-do of #1151

After the browser has sent the token as part of the URL in the first GET (e.g. `https://localhost:1234/cylc/?token=ab1c234de`) the server responds with a cookie that is stored in the browser so the token is no longer needed.

I have not encountered the race condition described in #1153 but reviewers should test carefully

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included
- [x] No changelog entry as fairly minor change
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
