### PR TITLE
Renovate: automerge Vite dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,23 @@
   ],
   "labels": ["dependencies", "javascript"],
   "platformAutomerge": true,
+  "automergeStrategy": "squash",
   "packageRules": [
     {
       "matchPackageNames": ["yarn"],
+      "automerge": true
+    },
+    {
+      "groupName": "vite packages",
+      "matchPackageNames": [
+        "vite",
+        "vite-plugin-vuetify"
+      ],
+      "matchPackagePatterns": [
+        "^@vitejs/"
+      ],
       "automerge": true,
-      "automergeStrategy": "squash"
+      "schedule": ["at 18:00 on saturday"]
     },
     {
       "groupName": "dev server packages",
@@ -21,7 +33,6 @@
         "nodemon"
       ],
       "automerge": true,
-      "automergeStrategy": "squash",
       "schedule": ["on the 5th and 20th day of the month"]
     },
     {
@@ -33,7 +44,6 @@
       "matchPackageNames": ["standard"],
       "matchPackagePatterns": ["^eslint"],
       "automerge": true,
-      "automergeStrategy": "squash",
       "schedule": ["on the first day of the month"]
     },
     {
@@ -51,7 +61,6 @@
         "istanbul"
       ],
       "automerge": true,
-      "automergeStrategy": "squash",
       "schedule": ["at 18:00 on sunday"]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
         "^@vitejs/"
       ],
       "automerge": true,
-      "schedule": ["at 18:00 on saturday"]
+      "schedule": ["on saturday"]
     },
     {
       "groupName": "dev server packages",
@@ -61,7 +61,7 @@
         "istanbul"
       ],
       "automerge": true,
-      "schedule": ["at 18:00 on sunday"]
+      "schedule": ["on sunday"]
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,7 @@
     {
       "groupName": "tests packages",
       "matchPackageNames": [
+        "@vue/test-utils",
         "cross-fetch",
         "jsdom",
         "nyc",


### PR DESCRIPTION
I think these should be fine to automerge as the CI is extremely likely to fail if there's any issue

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
