### PR TITLE
Make mutations menu more compact

### DIFF
--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -78,7 +78,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <template v-slot:prepend>
               <v-icon
                 :icon="mutation._icon"
-                size="x-large"
+                size="large"
               />
             </template>
             <template v-slot:append>
@@ -86,9 +86,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 icon
                 variant="text"
                 :disabled="isEditable(authorised, mutation)"
-                size="large"
                 @click.stop="openDialog(mutation)"
                 data-cy="mutation-edit"
+                class="ml-2"
               >
                 <v-icon>{{ icons.pencil }}</v-icon>
               </v-btn>
@@ -204,10 +204,7 @@ export default {
       const shortList = this.primaryMutations
       if (!this.expanded && shortList.length) {
         return this.mutations
-          // filter for shortlisted mutations
-          .filter(x => shortList.includes(x.mutation.name))
-          // filter out mutations which aren't relevant to the workflow state
-          .filter(x => !this.isDisabled(x.mutation, true))
+          .filter(x => shortList.includes(x.mutation.name) && !this.isDisabled(x.mutation, true))
           // sort by definition order
           .sort(
             (x, y) => shortList.indexOf(x.mutation.name) - shortList.indexOf(y.mutation.name)


### PR DESCRIPTION
Partially addresses #1364 

Make command menu items take up a bit less height so less mouse movement and less scrolling required.

#### Before & after

<p float="left">
<img src="https://github.com/cylc/cylc-ui/assets/61982285/c30419de-6a64-49a1-a05d-e85389d8eee1" width="48%" />
<img src="https://github.com/cylc/cylc-ui/assets/61982285/35b007d4-4213-4e94-ba34-184ae6632292" width="48%" />
</p>

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No tests needed
- [x] No changelog entry required
