### PR TITLE
Fix duplicate blank tab bug

### DIFF
--- a/src/components/cylc/workflow/Lumino.vue
+++ b/src/components/cylc/workflow/Lumino.vue
@@ -110,8 +110,6 @@ export default {
     this.$nextTick(() => {
       // Attach box panel to DOM:
       Widget.attach(this.box, this.$refs.main)
-      // Add widget(s):
-      this.syncWidgets(this.views, {})
       // Watch for resize of the main element to trigger relayout:
       resizeObserver.observe(this.$refs.main)
     })

--- a/tests/e2e/specs/graphiql.cy.js
+++ b/tests/e2e/specs/graphiql.cy.js
@@ -48,7 +48,7 @@ describe('GraphiQL', () => {
     cy.get('.graphiql-execute-button')
       .click()
     cy.wait('@GraphQLQuery')
-    cy.get('.result-window')
+    cy.get('.graphiql-response')
       .find('.graphiql-spinner')
       .should('not.exist')
     cy.get('.CodeMirror')


### PR DESCRIPTION
When navigating back from e.g. GraphiQL, there would be a duplicate but blank tree view tab in the workspace view. This was because `syncWidgets()` was being called twice for the same widget - once in the `created` lifecycle hook and once for the `_views` watcher.

Also fixed GraphiQL e2e test flakiness.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No tests included as minor bug
- [x] No changelog entry as minor bug
