### PR TITLE
Log view: update file list when opening file select

### DIFF
--- a/src/services/mock/json/logData.cjs
+++ b/src/services/mock/json/logData.cjs
@@ -31,6 +31,7 @@ const workflowLogLines = [
   '2023-05-25T10:48:01+01:00 INFO - Workflow: one\n',
   '2023-05-25T10:48:01+01:00 INFO - LOADING workflow parameters\n',
   '2023-05-25T10:48:01+01:00 INFO - + cycle point time zone = Z\n',
+  '2023-08-17T14:10:51+01:00 INFO - What about emojis? ✨ 🍰 ✨\n',
   '2038-01-19T04:14:07+01:00 CRITICAL - It\'s the Epochalypse!\n',
 ]
 
@@ -49,7 +50,7 @@ const LogData = ({ id, file }) => {
     logs: {
       connected: file !== deletedFile,
       error: file === deletedFile
-        ? `tail: ${path}: No such file or directory\ntail: no files remaining`
+        ? `${path}: No such file or directory`
         : undefined,
       path: `my-host:${path}`,
       lines: isJob ? jobLogLines : workflowLogLines,

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -405,6 +405,11 @@ export default {
     async updateLogFileList (reset = true) {
       // if reset===true then the this.file will be reset
       // otherwise it will be left alone
+      if (!this.id) {
+        this.fileInputLabel = 'Enter an ID first'
+        this.fileInputDisabled = true
+        return
+      }
 
       // update the list of log files
       this.fileInputLoading = true

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -418,49 +418,40 @@ export default {
           query: LOG_FILE_QUERY,
           variables: { id: this.id }
         })
-      } catch {
+      } catch (err) {
         // the query failed
+        console.warn(err)
         this.fileInputLabel = `No log files for ${this.id}`
         this.fileInputDisabled = true
         this.fileInputLoading = false
         return
       }
-      let logFiles
-      if (result.data.logFiles) {
-        logFiles = result.data.logFiles.files
-      } else {
-        logFiles = []
-      }
+      const logFiles = result.data.logFiles?.files ?? []
 
       // reset the file if it is not present in the new selection
       if (reset) {
-        if (this.file && !(this.file in logFiles)) {
+        if (this.file && !logFiles.includes(this.file)) {
           this.file = null
         }
 
         // set the default log file if appropriate
-        if (!this.file && logFiles) {
+        if (!this.file && logFiles.length) {
           for (const filePattern of LOG_FILE_DEFAULTS) {
-            for (const fileName of logFiles) {
-              if (filePattern.exec(fileName)) {
-                this.file = fileName
-                break
-              }
-            }
+            this.file = logFiles.find((fileName) => filePattern.exec(fileName))
+            if (this.file) break
           }
         }
       }
 
       // update the file input
       this.fileInputLoading = false
+      this.logFiles = logFiles
       if (logFiles.length) {
         this.fileInputLabel = 'Select File'
         this.fileInputDisabled = false
-        this.logFiles = logFiles
       } else {
         this.fileInputLabel = `No log files for ${this.id}`
         this.fileInputDisabled = true
-        this.logFiles = []
       }
     }
   },


### PR DESCRIPTION
A small usability enhancement: update the list of log files when you open the input, instead of having to click the refresh button beforehand.

![demo12](https://github.com/cylc/cylc-ui/assets/61982285/0e5e7b8a-c9e0-4dc8-8042-df60b0b082a6)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Existing tests should be fine
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
