### PR TITLE
Feature multiuser display

### DIFF
--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -37,8 +37,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </g>
       </svg>
     </div>
-    <div class="c-environment-info w-75 d-flex-col justify-center">
+    <div id="cylc-select-options" class="c-environment-info w-75 d-flex-col justify-center">
       <v-combobox
+        id="cylc-owner-combobox"
         :disabled = "store.state.user.user.mode !=='multi user'"
         bg-color="white"
         label="server owner"
@@ -50,6 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @keyup.enter="addOwner(owner)"
       ></v-combobox>
       <v-combobox
+        id="cylc-deployment-combobox"
         :disabled = "store.state.user.user.mode !=='multi user'"
         bg-color="white"
         label="deployment"

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -39,6 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div id="cylc-select-options" class="c-environment-info w-75 d-flex-col justify-center">
       <v-combobox
+        class="my-3"
         id="cylc-owner-combobox"
         :disabled = "store.state.user.user.mode !=='multi user'"
         bg-color="white"
@@ -51,6 +52,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         @keyup.enter="addOwner(owner)"
       ></v-combobox>
       <v-combobox
+        class="my-3"
         id="cylc-deployment-combobox"
         :disabled = "store.state.user.user.mode !=='multi user'"
         bg-color="white"
@@ -64,7 +66,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       ></v-combobox>
       <v-btn
         @click="route()"
-        class="mx-12"
+        class="mx-12 my-2"
         width="100"
         color="green"
         :hidden="isNewRoute == false"

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         class="mx-12 my-2"
         width="100"
         color="green"
-        :hidden="isNewRoute == false"
+        :hidden="isNewRoute == false || store.state.user.user.mode == 'single user'"
       >
         Go
       </v-btn>

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -37,27 +37,80 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </g>
       </svg>
     </div>
-    <div class="c-environment-info">
-      <v-chip id="username" class="text--secondary" variant="outlined">{{ user }}</v-chip>
-      <span class="at">@</span>
-      <v-chip id="host" class="text--secondary" variant="outlined">{{ environment }}</v-chip>
+    <div class="c-environment-info w-75 d-flex-col justify-center">
+      <v-combobox
+        :disabled = "store.state.user.user.mode !=='multi user'"
+        bg-color="white"
+        label="server owner"
+        placeholder="server owner"
+        :default="owner"
+        :items="owners"
+        variant="outlined"
+        v-model="owner"
+        @keyup.enter="addOwner(owner)"
+      ></v-combobox>
+      <v-combobox
+        :disabled = "store.state.user.user.mode !=='multi user'"
+        bg-color="white"
+        label="deployment"
+        placeholder="deployment"
+        :default="deployment"
+        :items="deployments"
+        variant="outlined"
+        v-model="deployment"
+        @keyup.enter="addDeployment(deployment)"
+      ></v-combobox>
+      <v-btn
+        @click="route()"
+        class="mx-12"
+        width="100"
+        color="green"
+        :hidden="isNewRoute == false"
+      >
+        Go
+      </v-btn>
     </div>
   </div>
 </template>
 
-<script>
-export default {
-  // eslint-disable-next-line vue/no-reserved-component-names
-  name: 'Header',
-  props: {
-    user: {
-      type: String,
-      default: 'guest'
-    },
-    environment: {
-      type: String,
-      default: window.location.host
-    }
-  }
+<script setup>
+import { ref, computed } from 'vue'
+import { useStore } from 'vuex'
+
+const store = useStore()
+
+// owner logic
+const ownerOnLoad = store.state.user.user.owner
+const owner = ref(ownerOnLoad)
+const owners = ref([ownerOnLoad])
+const addOwner = (owner) => {
+  owners.value.indexOf(owner) === -1 ? owners.value.push(owner) : console.log('This owner already exists')
 }
+
+// deployment logic
+const deploymentOnLoad = window.location.host
+const deployment = ref(deploymentOnLoad)
+const deployments = ref([deploymentOnLoad])
+const addDeployment = (deployment) => {
+  deployments.value.indexOf(deployment) === -1 ? deployments.value.push(deployment) : console.log('This deployment already exists')
+}
+
+// route logic
+const url = computed(() => '//' + deployment.value + '/user/' + owner.value + 'cylc/#')
+
+const isNewRoute = computed(() => {
+  return !(deployment.value === window.location.host & owner.value === window.location.href.split('/')[4])
+})
+
+const route = () => {
+  window.location.href = url.value
+}
+
 </script>
+
+<style>
+/* work around bug with v-combobox overflow https://github.com/vuetifyjs/vuetify/issues/17596 */
+  .v-combobox__selection {
+    overflow-x: hidden;
+  }
+</style>

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -129,7 +129,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-avatar>
         </template>
         <div class="text-h5">{{this.user.username}}</div>
-        <div class="d-flex justify-space-between" ><span>Admin</span> <span>{{this.user.admin}}</span></div>
+        <div class="d-flex justify-space-between" ><span class="mr-4">Admin</span> <span>{{this.user.admin}}</span></div>
       </v-tooltip>
     </router-link>
     </template>

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -117,6 +117,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list>
         </v-menu>
       </v-btn>
+      <router-link
+          to="/user-profile"
+        >
+      <v-tooltip>
+        <template v-slot:activator="{ props }">
+          <v-avatar v-bind="props"
+          class="ma-8 pa-2"
+          color="blue">
+            {{userInitials}}
+          </v-avatar>
+        </template>
+        <div class="text-h5">{{this.user.username}}</div>
+        <div class="d-flex justify-space-between" ><span>Admin</span> <span>{{this.user.admin}}</span></div>
+      </v-tooltip>
+    </router-link>
     </template>
   </v-toolbar>
 </template>
@@ -233,6 +248,9 @@ export default {
           )
         )
       }
+    },
+    userInitials () {
+      return Array.from(this.user.username)[0].toUpperCase()
     }
   },
 

--- a/tests/e2e/specs/dashboard.cy.js
+++ b/tests/e2e/specs/dashboard.cy.js
@@ -63,5 +63,59 @@ describe('Dashboard', () => {
         // https://github.com/cylc/cylc-ui/issues/334
     })
   }
+
+  it('Displays server owner user input and is disabled in single-user mode', () => {
+    cy.visit('/#/')
+    cy
+      .get('#cylc-owner-combobox')
+      .should('be.disabled')
+  })
+
   // TODO: add test that verifies the dashboard content after we have reviewed how it should look like
+})
+
+describe('Dashboard multiuser', () => {
+  beforeEach(() => {
+    cy.intercept('/userprofile', {
+      body: {
+        name: 'userTest',
+        groups: [
+          'cylc',
+          'developer'
+        ],
+        created: '2021-03-23T23:26:23.606Z',
+        admin: true,
+        server: '/user/cylc/',
+        permissions: [
+        ],
+        mode: 'multi user',
+        owner: 'userTest'
+      }
+    }).as('test-data-server-owner-input')
+    cy.visit('/#/')
+  })
+
+  it('Displays server owner user input and is not disabled in multi-user mode', () => {
+    cy.wait('@test-data-server-owner-input')
+      .get('#cylc-owner-combobox')
+      .should('not.be.disabled')
+      .type('123{enter}')
+      .get('.v-combobox__content').contains('userTest')
+      .get('.v-combobox__content').contains('userTest123')
+  })
+
+  it('Displays deployment input and is not disabled in multi-user mode', () => {
+    cy.wait('@test-data-server-owner-input')
+      .get('#cylc-deployment-combobox')
+      .should('not.be.disabled')
+      .type('abc{enter}')
+      .get('.v-combobox__content').contains('localhost:5173')
+      .get('.v-combobox__content').contains('localhost:5173abc')
+  })
+
+  it('Displays go button', () => {
+    cy.wait('@test-data-server-owner-input')
+      .get('.v-btn')
+      .should('be.visible')
+  })
 })

--- a/tests/e2e/specs/toolbar.cy.js
+++ b/tests/e2e/specs/toolbar.cy.js
@@ -28,4 +28,11 @@ describe('Toolbar component', () => {
       .get('#core-app-bar')
       .should('not.exist')
   })
+  it('Contains an avatar displaying user initial', () => {
+    cy.visit('/#/workspace/one')
+    cy
+      .get('#core-app-bar')
+      .get('.v-avatar')
+      .should('have.text', 'U')
+  })
 })


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1393

Added combobox inputs for survey owner and deployment  
- these are disabled on single user user mode
- when user selects new path - 'Go' button appears
- clicking go button takes user to new web address 
- 'Go button' is hidden in single user mode
- - difficult to test routing as cant test multi-user mode

Added avatar to top right on workflow view
- avatar shows users full username and admin status

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
