### PR TITLE
aotf: ensure log mutation is listed when appropriate

### DIFF
--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -199,7 +199,7 @@ export default {
     ...mapState('user', ['user']),
 
     displayMutations () {
-      if (!this.mutations.length || this.user.permissions.length < 2) {
+      if (!this.mutations.length) {
         return []
       }
       const shortList = this.primaryMutations

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -304,7 +304,7 @@ export const dummyMutations = [
     name: 'log',
     description: 'View the logs.',
     args: [],
-    _appliesTo: [cylcObjects.Namespace, cylcObjects.Job],
+    _appliesTo: [cylcObjects.Workflow, cylcObjects.Namespace, cylcObjects.Job],
     _requiresInfo: true
   },
 ]

--- a/tests/e2e/specs/menu.cy.js
+++ b/tests/e2e/specs/menu.cy.js
@@ -16,8 +16,8 @@
  */
 
 describe('CylcObject Menu component', () => {
-  const collapsedWorkflowMenuLength = 7 // (6 mutations + "show more" btn)
-  const expandedWorkflowMenuLength = 21
+  const collapsedWorkflowMenuLength = 8 // (7 mutations + "show more" btn)
+  const expandedWorkflowMenuLength = 22
 
   beforeEach(() => {
     cy.visit('/#/workspace/one')


### PR DESCRIPTION
* Closes #1435
* Ensure the log mutation is listed, even when a user only has read permissions
* List the log mutation for workflows too.

The log mutation was getting filtered out when a user only had read permissions. The reason turned out to be this:

https://github.com/cylc/cylc-ui/commit/95f14f5fad6646fea683f3a11412125e069562f4#diff-ed0c1a902b9b47f63c1058d8ab66442fe9410209e762c70ddf15623b4b60dd1eR170

I expect this was a simple stopgap solution to hiding mutations for users who don't have write perms before we had the current solution implemented.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.