### PR TITLE
GraphNode: nude the cycle point down a little

### DIFF
--- a/src/components/cylc/GraphNode.vue
+++ b/src/components/cylc/GraphNode.vue
@@ -54,7 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <!-- the cycle point -->
       <text
-        x="180" y="105"
+        x="180" y="115"
         font-size="30"
       >
         {{ task.tokens.cycle }}
@@ -174,7 +174,7 @@ export default {
       if (this.jobs.length) {
         return ''
       }
-      return 'translate(0, 15)'
+      return 'translate(0, 14)'
     },
     previousJobOffset () {
       // the most recent job is larger so all subsequent jobs need to be bumped


### PR DESCRIPTION
Add a little extra vertical separation between the task name and cycle point to better allow for characters which extend below the baseline

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.