### PR TITLE
Ability to store & remove server owner & deployment entries in dropdowns

### DIFF
--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -102,12 +102,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </template>
         </v-combobox>
         <v-btn
-          v-if="store.state.user.user.mode !== 'single user' && isNewRoute"
+          v-if="store.state.user.user.mode !== 'single user' && isNewRoute && owner && deployment"
           data-cy="multiuser-go-btn"
           :href="url"
           variant="flat"
           class="px-8"
           color="green"
+          @click="addOwner(owner); addDeployment(deployment);"
         >
           Go
         </v-btn>

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -58,24 +58,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-model="owner"
           @keyup.enter="addOwner(owner)"
         >
-          <template v-slot:selection="data">
-            <!-- HTML that describe how select should render selected items -->
-            {{ data.item.title }}
-          </template>
           <template v-slot:item="{ item, props }">
             <!-- HTML that describe how select should render items when the select is open -->
             <div class="d-flex">
               <v-list-item
                 class="flex-grow-1"
                 :title="item.title"
-                @click="props.onClick"
+                v-bind="props"
                 >
+                <template v-slot:append v-if="item.title !== ownerOnLoad">
+                    <v-icon
+                      @click.stop="removeOwner(item.title)"
+                      color="pink-accent-4"
+                      :icon="mdiClose"
+                    />
+                </template>
               </v-list-item>
-              <button v-if="item.title != ownerOnLoad" @click="removeOwner(item.title)" class="mx-2">
-                <v-icon class="my-auto" color="pink-accent-4">
-                  {{ mdiCloseCircle }}
-                </v-icon>
-              </button>
             </div>
           </template>
         </v-combobox>
@@ -90,24 +88,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-model="deployment"
           @keyup.enter="addDeployment(deployment)"
         >
-          <template v-slot:selection="data">
-            <!-- HTML that describe how select should render selected items -->
-            {{ data.item.title }}
-          </template>
           <template v-slot:item="{ item, props }">
             <!-- HTML that describe how select should render items when the select is open -->
             <div class="d-flex">
               <v-list-item
                 class="flex-grow-1"
                 :title="item.title"
-                @click="props.onClick"
+                v-bind="props"
                 >
+                <template v-slot:append v-if="item.title !== deploymentOnLoad">
+                    <v-icon
+                      @click.stop="removeDeployment(item.title)"
+                      color="pink-accent-4"
+                      :icon="mdiClose"
+                    />
+                </template>
               </v-list-item>
-              <button v-if="item.title != deploymentOnLoad" @click="removeDeployment(item.title)" class="mx-2">
-                <v-icon class="my-auto" color="pink-accent-4">
-                  {{ mdiCloseCircle }}
-                </v-icon>
-              </button>
             </div>
           </template>
         </v-combobox>
@@ -130,7 +126,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { ref, computed, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import {
-  mdiCloseCircle
+  mdiClose
 } from '@mdi/js'
 
 const store = useStore()
@@ -148,36 +144,36 @@ const deployments = ref(new Set([deploymentOnLoad]))
 onMounted(() => {
   // Set load state for owners
   if (!localStorage.owners) {
-    localStorage.setItem('owners', Array.from(owners.value))
+    localStorage.setItem('owners', JSON.stringify(Array.from(owners.value)))
   } else {
-    owners.value = new Set(localStorage.owners.split(','))
+    owners.value = new Set(JSON.parse(localStorage.owners))
   }
   // Set load state for deployments
   if (!localStorage.deployments) {
-    localStorage.setItem('deployments', Array.from(deployments.value))
+    localStorage.setItem('deployments', JSON.stringify(Array.from(deployments.value)))
   } else {
-    deployments.value = new Set(localStorage.deployments.split(','))
+    deployments.value = new Set(JSON.parse(localStorage.deployments))
   }
 })
 
 function addDeployment (deployment) {
   deployments.value.add(deployment)
-  localStorage.setItem('deployments', Array.from(deployments.value))
+  localStorage.setItem('deployments', JSON.stringify(Array.from(deployments.value)))
 }
 
 function removeDeployment (deployment) {
   deployments.value.delete(deployment)
-  localStorage.setItem('deployments', Array.from(deployments.value))
+  localStorage.setItem('deployments', JSON.stringify(Array.from(deployments.value)))
 }
 
 function addOwner (owner) {
   owners.value.add(owner)
-  localStorage.setItem('owners', Array.from(owners.value))
+  localStorage.setItem('owners', JSON.stringify(Array.from(owners.value)))
 }
 
 function removeOwner (owner) {
   owners.value.delete(owner)
-  localStorage.setItem('owners', Array.from(owners.value))
+  localStorage.setItem('owners', JSON.stringify(Array.from(owners.value)))
 }
 
 const url = computed(() => `//${deployment.value}/user/${owner.value}/cylc/#`)

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -123,23 +123,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import {
   mdiClose
 } from '@mdi/js'
 
+import useLocalStorage from '@/composables/useLocalStorage.js'
+
 const store = useStore()
+const {
+  itemOnLoad: ownerOnLoad,
+  item: owner,
+  items: owners,
+  addToLocalStorage: addOwner,
+  removeFromLocalStorage: removeOwner
+} = useLocalStorage('owners', store.state.user.user.owner)
 
-// owner logic
-const ownerOnLoad = store.state.user.user.owner
-const owner = ref(ownerOnLoad)
-const owners = ref(new Set([ownerOnLoad]))
-
-// deployment logic
-const deploymentOnLoad = window.location.host
-const deployment = ref(deploymentOnLoad)
-const deployments = ref(new Set([deploymentOnLoad]))
+const {
+  itemOnLoad: deploymentOnLoad,
+  item: deployment,
+  items: deployments,
+  addToLocalStorage: addDeployment,
+  removeFromLocalStorage: removeDeployment
+} = useLocalStorage('deployments', window.location.host)
 
 onMounted(() => {
   // Set load state for owners
@@ -155,26 +162,6 @@ onMounted(() => {
     deployments.value = new Set(JSON.parse(localStorage.deployments))
   }
 })
-
-function addDeployment (deployment) {
-  deployments.value.add(deployment)
-  localStorage.setItem('deployments', JSON.stringify(Array.from(deployments.value)))
-}
-
-function removeDeployment (deployment) {
-  deployments.value.delete(deployment)
-  localStorage.setItem('deployments', JSON.stringify(Array.from(deployments.value)))
-}
-
-function addOwner (owner) {
-  owners.value.add(owner)
-  localStorage.setItem('owners', JSON.stringify(Array.from(owners.value)))
-}
-
-function removeOwner (owner) {
-  owners.value.delete(owner)
-  localStorage.setItem('owners', JSON.stringify(Array.from(owners.value)))
-}
 
 const url = computed(() => `//${deployment.value}/user/${owner.value}/cylc/#`)
 

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -54,7 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :disabled="store.state.user.user.mode !== 'multi user'"
           label="server owner"
           :default="owner"
-          :items="owners"
+          :items="Array.from(owners)"
           v-model="owner"
           @keyup.enter="addOwner(owner)"
         >
@@ -84,7 +84,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :disabled="store.state.user.user.mode !== 'multi user'"
           label="deployment"
           :default="deployment"
-          :items="deployments"
+          :items="Array.from(deployments)"
           v-model="deployment"
           @keyup.enter="addDeployment(deployment)"
         >

--- a/src/components/cylc/Header.vue
+++ b/src/components/cylc/Header.vue
@@ -60,21 +60,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         >
           <template v-slot:item="{ item, props }">
             <!-- HTML that describe how select should render items when the select is open -->
-            <div class="d-flex">
-              <v-list-item
-                class="flex-grow-1"
-                :title="item.title"
-                v-bind="props"
-                >
-                <template v-slot:append v-if="item.title !== ownerOnLoad">
-                    <v-icon
-                      @click.stop="removeOwner(item.title)"
-                      color="pink-accent-4"
-                      :icon="mdiClose"
-                    />
-                </template>
-              </v-list-item>
-            </div>
+            <v-list-item
+              :title="item.title"
+              v-bind="props"
+              >
+              <template v-slot:append v-if="item.title !== ownerOnLoad">
+                  <v-icon
+                    @click.stop="removeOwner(item.title)"
+                    color="pink-accent-4"
+                    :icon="mdiClose"
+                  />
+              </template>
+            </v-list-item>
           </template>
         </v-combobox>
         <!-- Deployment combobox -->
@@ -90,21 +87,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         >
           <template v-slot:item="{ item, props }">
             <!-- HTML that describe how select should render items when the select is open -->
-            <div class="d-flex">
-              <v-list-item
-                class="flex-grow-1"
-                :title="item.title"
-                v-bind="props"
-                >
-                <template v-slot:append v-if="item.title !== deploymentOnLoad">
-                    <v-icon
-                      @click.stop="removeDeployment(item.title)"
-                      color="pink-accent-4"
-                      :icon="mdiClose"
-                    />
-                </template>
-              </v-list-item>
-            </div>
+            <v-list-item
+              :title="item.title"
+              v-bind="props"
+              >
+              <template v-slot:append v-if="item.title !== deploymentOnLoad">
+                  <v-icon
+                    @click.stop="removeDeployment(item.title)"
+                    color="pink-accent-4"
+                    :icon="mdiClose"
+                  />
+              </template>
+            </v-list-item>
           </template>
         </v-combobox>
         <v-btn

--- a/src/composables/useLocalStorage.js
+++ b/src/composables/useLocalStorage.js
@@ -40,12 +40,16 @@ export default function useLocalStorage (key, initialValue) {
   const items = ref(new Set([itemOnLoad]))
 
   function addToLocalStorage (item) {
-    items.value.add(item)
-    localStorage.setItem(key, JSON.stringify(Array.from(items.value)))
+    if (item) {
+      items.value.add(item)
+      localStorage.setItem(key, JSON.stringify(Array.from(items.value)))
+    }
   }
   function removeFromLocalStorage (item) {
-    items.value.delete(item)
-    localStorage.setItem(key, JSON.stringify(Array.from(items.value)))
+    if (item) {
+      items.value.delete(item)
+      localStorage.setItem(key, JSON.stringify(Array.from(items.value)))
+    }
   }
 
   return {

--- a/src/composables/useLocalStorage.js
+++ b/src/composables/useLocalStorage.js
@@ -1,5 +1,18 @@
 import { ref } from 'vue'
 
+/**
+ * Function for initialising, adding to and removing from local storage.
+ * Values are stored in arrays with and can be accessed
+ * via a key which specified by the 'key' parameter.
+ * The local storage array is initialized with a value
+ * specified by the 'initialValue' parameter.
+ * Note: this could be replaced by a VueUse composable in the future
+ * https://vueuse.org/core/useLocalStorage/
+ *
+ * @param {string} key
+ * @param {*} initialValue
+ * @returns {function}
+ */
 export default function useLocalStorage (key, initialValue) {
   const itemOnLoad = initialValue
   const item = ref(itemOnLoad)

--- a/src/composables/useLocalStorage.js
+++ b/src/composables/useLocalStorage.js
@@ -1,6 +1,27 @@
 import { ref } from 'vue'
 
 /**
+ * @name addToLocalStorage
+ * @function
+ * @param {String} item Item to add to local storage
+*/
+
+/**
+ * @name removeFromLocalStorage
+ * @function
+ * @param {String} item Item to remove from local storage
+*/
+
+/**
+ * @typedef {Object} LocalStorage
+ * @property {string} itemOnLoad - The default item on load
+ * @property {ref} item - The selected item
+ * @property {ref} items - The array of items in local storage
+ * @property {addToLocalStorage} addToLocalStorage - Adds a value to local storage
+ * @property {removeFromLocalStorage} removeFromLocalStorage - Removes a value from local storage
+ */
+
+/**
  * Function for initialising, adding to and removing from local storage.
  * Values are stored in arrays with and can be accessed
  * via a key which specified by the 'key' parameter.
@@ -11,7 +32,7 @@ import { ref } from 'vue'
  *
  * @param {string} key
  * @param {*} initialValue
- * @returns {function}
+ * @return {LocalStorage}
  */
 export default function useLocalStorage (key, initialValue) {
   const itemOnLoad = initialValue

--- a/src/composables/useLocalStorage.js
+++ b/src/composables/useLocalStorage.js
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+
+export default function useLocalStorage (key, initialValue) {
+  const itemOnLoad = initialValue
+  const item = ref(itemOnLoad)
+  const items = ref(new Set([itemOnLoad]))
+
+  function addToLocalStorage (item) {
+    items.value.add(item)
+    localStorage.setItem(key, JSON.stringify(Array.from(items.value)))
+  }
+  function removeFromLocalStorage (item) {
+    items.value.delete(item)
+    localStorage.setItem(key, JSON.stringify(Array.from(items.value)))
+  }
+
+  return {
+    itemOnLoad,
+    item,
+    items,
+    addToLocalStorage,
+    removeFromLocalStorage
+  }
+}

--- a/tests/e2e/specs/header.cy.js
+++ b/tests/e2e/specs/header.cy.js
@@ -63,7 +63,7 @@ describe('Header Component multiuser', () => {
 
       // Test to see if values are in local storage
       cy.getAllLocalStorage().then((result) => {
-        expect(JSON.parse(result['http://localhost:5173'].owners)).to.deep.equal(['userTest', 'userTest123'])
+        expect(JSON.parse(result[window.location.origin].owners)).to.deep.equal(['userTest', 'userTest123'])
       })
 
       cy.get('body').type('{esc}') // Closes combobox

--- a/tests/e2e/specs/header.cy.js
+++ b/tests/e2e/specs/header.cy.js
@@ -61,6 +61,11 @@ describe('Header Component multiuser', () => {
         .get('.v-combobox__content').contains('userTest')
         .get('.v-combobox__content').contains('userTest123')
 
+      // Test to see if values are in local storage
+      cy.getAllLocalStorage().then((result) => {
+        expect(JSON.parse(result['http://localhost:5173'].owners)).to.deep.equal(['userTest', 'userTest123'])
+      })
+
       cy.get('body').type('{esc}') // Closes combobox
         .get('[data-cy=multiuser-go-btn]')
         .should('be.visible')

--- a/tests/unit/composables/useLocalStorage.spec.js
+++ b/tests/unit/composables/useLocalStorage.spec.js
@@ -14,6 +14,11 @@ describe('useLocalStorage composable', () => {
     expect(Array.from(items.value)).toStrictEqual(['test initial item', 'test item'])
   })
 
+  it('should not add more than one of the same value to the local store', () => {
+    addToLocalStorage('test item')
+    expect(Array.from(items.value)).toStrictEqual(['test initial item', 'test item'])
+  })
+
   it('should remove a value to the local store', () => {
     removeFromLocalStorage('test item')
     expect(Array.from(items.value)).toStrictEqual(['test initial item'])

--- a/tests/unit/composables/useLocalStorage.spec.js
+++ b/tests/unit/composables/useLocalStorage.spec.js
@@ -1,0 +1,21 @@
+import useLocalStorage from '@/composables/useLocalStorage.js'
+
+describe('useLocalStorage composable', () => {
+  const {
+    items,
+    addToLocalStorage,
+    removeFromLocalStorage
+  } = useLocalStorage('itemsLocalStoreKey', 'test initial item')
+
+  localStorage.setItem('itemsLocalStoreKey', JSON.stringify(Array.from(items.value)))
+
+  it('should add a value to the local store', () => {
+    addToLocalStorage('test item')
+    expect(Array.from(items.value)).toStrictEqual(['test initial item', 'test item'])
+  })
+
+  it('should remove a value to the local store', () => {
+    removeFromLocalStorage('test item')
+    expect(Array.from(items.value)).toStrictEqual(['test initial item'])
+  })
+})


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1457

- Added functionality for storing server owner and deployment in local storage.
- The state of the reactive array for deployments or owners is copied to a local storage variable each time it is changed.
- User can also remove values that have been stored.
- User cannot remove the initial values `onLoad` values.


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
