### PR TITLE
Fetch user initials from UIServer

### DIFF
--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -93,7 +93,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         color="primary"
         data-cy="add-view-btn"
       >
-        <v-icon class="icon">{{ $options.icons.add }}</v-icon>
+        <v-icon class="icon">
+          {{ $options.icons.add }}
+        </v-icon>
         <span class="label">
           {{ $t('Toolbar.addView') }}
         </span>
@@ -101,7 +103,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-menu
           activator="parent"
           location="bottom"
-          >
+        >
           <v-list>
             <v-list-item
               v-for="view in views"
@@ -109,7 +111,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               :key="view.name"
               @click="$emit('add', { viewName: view.name })"
             >
-              <template v-slot:prepend>
+              <template #prepend>
                 <v-icon>{{ view.icon }}</v-icon>
               </template>
               <v-list-item-title>{{ startCase(view.name) }}</v-list-item-title>
@@ -117,10 +119,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-list>
         </v-menu>
       </v-btn>
-      <v-btn icon size="small">
-        <v-avatar color="primary" size="small">
-          <v-icon v-if="!user.initials" :icon="$options.icons.mdiAccountEdit"></v-icon>
-          <div v-else>{{ user.initials }}</div>
+      <v-btn
+        icon
+        size="small"
+      >
+        <v-avatar
+          color="primary"
+          size="small"
+        >
+          <div v-if="user.initials">
+            {{ user.initials }}
+          </div>
+          <v-icon
+            v-else
+            :icon="$options.icons.mdiAccount"
+          />
         </v-avatar>
         <v-menu activator="parent">
           <v-card :title="user.username">
@@ -153,7 +166,7 @@ import {
   mdiPlusBoxMultiple,
   mdiStop,
   mdiViewList,
-  mdiAccountEdit
+  mdiAccount
 } from '@mdi/js'
 import { startCase } from 'lodash'
 import { useToolbar, toolbarHeight } from '@/utils/toolbar'
@@ -314,7 +327,7 @@ export default {
     run: mdiPlay,
     stop: mdiStop,
     mdiCog,
-    mdiAccountEdit
+    mdiAccount
   },
 }
 </script>

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -188,7 +188,8 @@ export default {
       play: null,
       paused: null,
       stop: null
-    }
+    },
+    userProfile: {}
   }),
 
   computed: {
@@ -257,8 +258,26 @@ export default {
       }
     },
     userInitials () {
-      return this.user.username[0].toUpperCase()
+      return this.userProfile.initials ? this.userProfile.initials : this.user.username[0].toUpperCase()
     }
+  },
+  created () {
+    console.log('running on created')
+    // GET userProfile using fetch with error handling
+    fetch('http://localhost:5173/userprofile')
+      .then(async response => {
+        const data = await response.json()
+
+        if (!response.ok) {
+          const error = (data && data.message) || response.statusText
+          throw new Error(error)
+        }
+        this.userProfile = data
+      })
+      .catch(error => {
+        this.errorMessage = error
+        console.error('Error fetching user profile:', error)
+      })
   },
 
   watch: {

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -119,8 +119,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </v-btn>
       <v-btn icon size="small">
         <v-avatar color="primary" size="small">
-          <v-icon v-if="!this.userProfile.initials" :icon="$options.icons.mdiAccountEdit"></v-icon>
-          <div v-else>{{ this.userProfile.initials }}</div>
+          <v-icon v-if="!user.initials" :icon="$options.icons.mdiAccountEdit"></v-icon>
+          <div v-else>{{ user.initials }}</div>
         </v-avatar>
         <v-menu activator="parent">
           <v-card :title="user.username">
@@ -190,8 +190,7 @@ export default {
       play: null,
       paused: null,
       stop: null
-    },
-    userProfile: {}
+    }
   }),
 
   computed: {
@@ -259,24 +258,6 @@ export default {
         )
       }
     }
-  },
-  created () {
-    console.log('running on created')
-    // GET userProfile using fetch with error handling
-    fetch('http://localhost:5173/userprofile')
-      .then(async response => {
-        const data = await response.json()
-
-        if (!response.ok) {
-          const error = (data && data.message) || response.statusText
-          throw new Error(error)
-        }
-        this.userProfile = data
-      })
-      .catch(error => {
-        this.errorMessage = error
-        console.error('Error fetching user profile:', error)
-      })
   },
 
   watch: {

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -119,7 +119,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </v-btn>
       <v-btn icon size="small">
         <v-avatar color="primary" size="small">
-          {{ userInitials }}
+          <v-icon v-if="!this.userProfile.initials" :icon="$options.icons.mdiAccountEdit"></v-icon>
+          <div v-else>{{ this.userProfile.initials }}</div>
         </v-avatar>
         <v-menu activator="parent">
           <v-card :title="user.username">
@@ -151,7 +152,8 @@ import {
   mdiPlay,
   mdiPlusBoxMultiple,
   mdiStop,
-  mdiViewList
+  mdiViewList,
+  mdiAccountEdit
 } from '@mdi/js'
 import { startCase } from 'lodash'
 import { useToolbar, toolbarHeight } from '@/utils/toolbar'
@@ -256,9 +258,6 @@ export default {
           )
         )
       }
-    },
-    userInitials () {
-      return this.userProfile.initials ? this.userProfile.initials : this.user.username[0].toUpperCase()
     }
   },
   created () {
@@ -334,6 +333,7 @@ export default {
     run: mdiPlay,
     stop: mdiStop,
     mdiCog,
+    mdiAccountEdit
   },
 }
 </script>

--- a/src/model/User.model.js
+++ b/src/model/User.model.js
@@ -25,9 +25,10 @@
  * @property {string} owner - UIS owner
  * @property {string[]} permissions - list of permissions
  * @property {string} mode - single or multi user mode
+ * @property {string} initials - user initials
  */
 export default class User {
-  constructor (username, groups, created, admin, server, owner, permissions, mode) {
+  constructor (username, groups, created, admin, server, owner, permissions, mode, initials) {
     // the authenticated user
     // (full info only available when authenticated via the hub)
     this.username = username
@@ -41,5 +42,6 @@ export default class User {
     this.owner = owner
     this.permissions = permissions
     this.mode = mode
+    this.initials = initials
   }
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -34,7 +34,8 @@ class UserService {
         data.server,
         data.owner,
         data.permissions,
-        data.mode
+        data.mode,
+        data.initials
       )
     })
   }

--- a/tests/e2e/specs/toolbar.cy.js
+++ b/tests/e2e/specs/toolbar.cy.js
@@ -28,9 +28,36 @@ describe('Toolbar component', () => {
       .get('#core-app-bar')
       .should('not.exist')
   })
-  it('Contains an avatar displaying user initial', () => {
+  it('Contains an avatar displaying user icon', () => {
     cy.visit('/#/workspace/one')
     cy
+      .get('#core-app-bar')
+      .get('.v-avatar')
+      .get('.v-icon')
+      .should('exist')
+  })
+})
+
+describe('Toolbar Component authenticated user', () => {
+  beforeEach(() => {
+    cy.intercept('/userprofile', {
+      body: {
+        username: 'user',
+        name: 'user',
+        initials: 'U',
+        owner: 'user',
+        permissions: [
+          'read',
+          'write'
+        ],
+        mode: 'single user'
+      }
+    }).as('test-data-server-owner-input')
+    cy.visit('/#/workspace/one')
+  })
+
+  it('Contains an avatar displaying user initials', () => {
+    cy.wait('@test-data-server-owner-input')
       .get('#core-app-bar')
       .get('.v-avatar')
       .should('have.text', 'U')

--- a/tests/unit/model/user.model.spec.js
+++ b/tests/unit/model/user.model.spec.js
@@ -28,6 +28,7 @@ describe('User model', () => {
       const owner = 'john.goe'
       const permissions = ['play', 'ping', 'read']
       const user = new User(name, groups, created, admin, server, owner, permissions)
+      const initials = 'jf'
       expect(user.username).to.equal(name)
       expect(user.groups.length === 2).to.equal(admin)
       expect(user.admin).to.equal(true)
@@ -35,6 +36,7 @@ describe('User model', () => {
       expect(user.server).to.equal(server)
       expect(user.owner).to.equal(owner)
       expect(user.permissions).to.equal(permissions)
+      expect(user.initials).to.equal(initials)
     })
   })
 })

--- a/tests/unit/model/user.model.spec.js
+++ b/tests/unit/model/user.model.spec.js
@@ -27,8 +27,9 @@ describe('User model', () => {
       const server = '/cylc/user/john.foe'
       const owner = 'john.goe'
       const permissions = ['play', 'ping', 'read']
-      const user = new User(name, groups, created, admin, server, owner, permissions)
+      const mode = 'single user'
       const initials = 'jf'
+      const user = new User(name, groups, created, admin, server, owner, permissions, mode, initials)
       expect(user.username).to.equal(name)
       expect(user.groups.length === 2).to.equal(admin)
       expect(user.admin).to.equal(true)
@@ -36,6 +37,7 @@ describe('User model', () => {
       expect(user.server).to.equal(server)
       expect(user.owner).to.equal(owner)
       expect(user.permissions).to.equal(permissions)
+      expect(user.mode).to.equal(mode)
       expect(user.initials).to.equal(initials)
     })
   })


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1504

The userprofile endpoint has been extended in https://github.com/cylc/cylc-uiserver/pull/510 so it now provides user initials.

If for whatever reason the initials field is empty the avatar will be a user symbol
![image](https://github.com/cylc/cylc-ui/assets/61982285/0edc762e-ab4a-4d57-9de6-b94336dbd5df)


And if the initials field is populated the avatar will look like one of the two 
![image](https://github.com/cylc/cylc-ui/assets/7523921/d668ad25-32d0-4062-b98c-af1506711a80)
![image](https://github.com/cylc/cylc-ui/assets/7523921/cadd00c1-3bc6-46a5-905f-5f25cb539ad2)

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
