### PR TITLE
GH Actions: upload coverage to Codecov in separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        browser: [firefox, chrome]
         type: [e2e, component]
+        browser: [firefox, chrome]
+        os: [ubuntu-latest]
 # TODO: re-enable once macos build is stable #590
 #         include:
 #           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,14 +33,12 @@ jobs:
         run: |
           yarn run coverage:unit
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/clover.xml
-          name: '${{ github.job }}'
-          flags: unittests
-          fail_ci_if_error: false
+          name: coverage_unit
+          path: coverage/clover.xml
+          retention-days: 4
 
       - name: Build
         run: yarn run build
@@ -90,17 +88,36 @@ jobs:
           component: true
           browser: ${{ matrix.browser }}
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: tests/e2e/screenshots
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'coverage_${{ matrix.type }}_${{ matrix.browser }}_${{ matrix.os }}'
+          path: coverage/lcov.info
+          retention-days: 4
+
+  codecov-upload:
+    needs: [unit-test-and-build, cypress-run]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Codecov upload
         uses: codecov/codecov-action@v3
         with:
+          name: ${{ github.workflow }}
+          fail_ci_if_error: true
+          # Token not required for public repos, but avoids upload failure due
+          # to rate-limiting (but not for PRs opened from forks)
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/lcov.info
-          name: '${{ github.job }} ${{ matrix.os }} ${{ matrix.browser }} ${{ matrix.type }}'
-          flags: ${{ matrix.type }}
-          fail_ci_if_error: false


### PR DESCRIPTION
Workaround https://github.com/codecov/codecov-action/issues/837

- Reduces how hard we hit Codecov API
- Allows easy re-attempt to upload
- Fail CI check if coverage fails to upload