### PR TITLE
Turn off nprogress loading spinner

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -34,6 +34,8 @@ import 'nprogress/css/nprogress.css'
 import paths from './paths'
 import { Alert } from '@/model/Alert.model'
 
+NProgress.configure({ showSpinner: false })
+
 function route (path) {
   const copy = Object.assign({}, path)
   const view = copy.view


### PR DESCRIPTION
We use [nprogress](https://www.npmjs.com/package/nprogress) to show a blue loading bar at the top of the viewport. (The progress of the loading bar is totally fake - it's just to relieve user impatience by showing that something is loading)

Here I've turned off the loading spinner icon that was showing in the top right corner, because it clashes with the user icon in the toolbar.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are not needed
- [x] No changelog entry needed as minor change
- [x] No docs

