### PR TITLE
Remove unused error state from workflow states

### DIFF
--- a/src/components/cylc/gscan/WorkflowIcon.vue
+++ b/src/components/cylc/gscan/WorkflowIcon.vue
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script>
 import WorkflowState from '@/model/WorkflowState.model'
+import { mdiHelpCircle } from '@mdi/js'
 
 /**
  * GScan workflow icon.
@@ -40,17 +41,12 @@ export default {
   methods: {
     /**
      * Return the workflow icon, based on the status prop. If the state is
-     * not valid, we return a pre-defined error icon.
-     * @returns {String} - status, one of the WorkflowState enum values
+     * not valid, we return an unknown state icon.
+     * @returns {string} icon
      */
     getIcon () {
-      // TBD: enumValueOf returned the wrong value?
-      const state = [...WorkflowState.enumValues]
-        .find(state => state.name === this.status)
-      if (!state || state.length === 0) {
-        return WorkflowState.ERROR.icon
-      }
-      return state.icon
+      const state = WorkflowState.enumValues.find(({ name }) => name === this.status)
+      return state?.icon || mdiHelpCircle
     }
   }
 }

--- a/src/model/WorkflowState.model.js
+++ b/src/model/WorkflowState.model.js
@@ -18,7 +18,6 @@
 import { Enumify } from 'enumify'
 
 import {
-  mdiHelpCircle,
   mdiPauseCircle,
   mdiPlayCircle,
   mdiSkipNextCircle,
@@ -33,7 +32,6 @@ export class WorkflowState extends Enumify {
   static PAUSED = new WorkflowState('paused', mdiPauseCircle)
   static STOPPING = new WorkflowState('stopping', mdiSkipNextCircle)
   static STOPPED = new WorkflowState('stopped', mdiStopCircle)
-  static ERROR = new WorkflowState('error', mdiHelpCircle)
   static _ = this.closeEnum()
 
   /**

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -59,9 +59,6 @@ describe('GScan component', () => {
     it('sets workflow sort order by status', () => {
       // for each worflow state ...
       for (const workflowState of WorkflowState) {
-        // ... except ERROR
-        if (workflowState === WorkflowState.ERROR) { continue }
-
         // it should associate a workflow with the correct sort order
         expect(
           getWorkflowTreeSortValue({

--- a/tests/unit/components/cylc/gscan/workflowicon.spec.js
+++ b/tests/unit/components/cylc/gscan/workflowicon.spec.js
@@ -19,40 +19,29 @@ import { shallowMount } from '@vue/test-utils'
 import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon.vue'
 import WorkflowState from '@/model/WorkflowState.model'
 import { createVuetify } from 'vuetify'
+import { mdiHelpCircle } from '@mdi/js'
 
 const vuetify = createVuetify()
 
 describe('WorkflowIcon', () => {
-  /**
-   * @param {Object} options - component options
-   * @returns {Wrapper<WorkflowIcon>} - component test wrapper
-   */
-  const mountFunction = options => {
-    return shallowMount(WorkflowIcon, {
+  it.each([
+    {
+      status: '',
+      expected: mdiHelpCircle
+    },
+    {
+      status: WorkflowState.STOPPED.name,
+      expected: WorkflowState.STOPPED.icon
+    },
+  ])('uses the right icon for state: $status', ({ status, expected }) => {
+    const wrapper = shallowMount(WorkflowIcon, {
       global: {
         plugins: [vuetify]
       },
-      ...options
-    })
-  }
-  it('should create a workflow-icon component with the right icon', () => {
-    const tests = [
-      {
-        status: '',
-        expected: WorkflowState.ERROR.icon
-      },
-      {
-        status: WorkflowState.STOPPED.name,
-        expected: WorkflowState.STOPPED.icon
+      props: {
+        status,
       }
-    ]
-    tests.forEach(test => {
-      const wrapper = mountFunction({
-        props: {
-          status: test.status
-        }
-      })
-      expect(wrapper.vm.getIcon()).to.equal(test.expected)
     })
+    expect(wrapper.vm.getIcon()).to.equal(expected)
   })
 })


### PR DESCRIPTION
Replaces / closes #1556

There is no 'error' state in cylc-flow: https://github.com/cylc/cylc-flow/blob/642ab8d22652f0aa3d5576d29736355a98b337d0/cylc/flow/workflow_status.py#L44-L58

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [x] No `CHANGES.md` entry needed
- [x] No docs

