### PR TITLE
Revert version & fix GH Actions release workflow

### DIFF
--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 'lts/*'
 
       - name: Install
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cylc-ui",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "private": true,
   "license": "GPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
Release PR #1566 failed due to second stage using old node version

After this I will retrigger the release workflow
