### PR TITLE
Added an icon for set

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -35,7 +35,7 @@ import {
   mdiDelete,
   mdiEmail,
   mdiFileDocumentOutline,
-  mdiGraph,
+  mdiVectorPolylineEdit,
   mdiMinusCircleOutline,
   mdiPause,
   mdiPauseCircleOutline,
@@ -136,7 +136,7 @@ export const mutationIcons = {
   reload: mdiReload,
   remove: mdiMinusCircleOutline,
   resume: mdiPlay,
-  setOutputs: mdiGraph,
+  set: mdiVectorPolylineEdit,
   stop: mdiStop,
   trigger: mdiCursorPointer
 }
@@ -184,7 +184,7 @@ export const primaryMutations = {
     'trigger',
     'kill',
     'log',
-    'setOutputs'
+    'set'
   ]
 }
 


### PR DESCRIPTION
Ancillary to https://github.com/cylc/cylc-flow/pull/5658 - should not be merged until after that PR.

- [x] Check that there is no reference to "setVerbosity".
- [x] Replace `setOutputs` with `set`.
- [x] Pick a sensible icon. Ensure that it is different from set outputs to make it clear that this isn't the same thing. 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] ~Tests are included~ No functional (just naming changes).
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
