### PR TITLE
store: more efficient family tree building

### DIFF
--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -134,17 +134,6 @@ function getIndex (state, id) {
   return state.cylcTree.$index[id]
 }
 
-/* Return true if a node has at least one child.
- *
- * Defaults to looking in node.children, set childAttr to use a different
- * tree (e.g. familyTree).
- */
-function hasChild (node, id, attr = 'id', childAttr = 'children') {
-  return node[childAttr].some(
-    item => item[attr] === id
-  )
-}
-
 /* Add a child node under a parent Node */
 function addChild (parentNode, childNode) {
   // determine which list to add this node to
@@ -276,10 +265,11 @@ function cleanParents (state, node) {
  */
 function applyInheritance (state, node) {
   if (node.type === 'family' && node.node.childTasks) {
-    // add new tasks
+    // build a mapping of {childID: childNode} for faster lookup
+    const childIDs = node.children.reduce((map, obj) => { map[obj.id] = obj; return map }, {})
     for (const child of node.node.childTasks) {
-      if (!hasChild(node, child.id)) {
-        // child has been added to childTasks
+      if (!(child.id in childIDs)) {
+        // add any new tasks to the family
         const childNode = getIndex(state, child.id)
         if (childNode) {
           addChild(node, childNode)


### PR DESCRIPTION
* Reduce the overheads of `applyInheritance` for families with lots of children.
* Use a map for O(1) lookup times when checking whether child nodes are present in the store.
* This should change scaling from `O(nm)` to `O(m)` where `n` is the number of tasks in a family when created and `m` is the number of children after an update (n~=m for most cases).
* Partially addresses https://github.com/cylc/cylc-ui/issues/1614
* For the reduced example (`hours = 20`) this reduces the time taken by `applyInheritance` by ~85% from ~0.6s to <0.1s (though I'm sure these times will be subject to much jitter).
* Due to the non-linear scaling, I think this will make a larger difference to the full example.

Note, if you have no families in your workflow, then all tasks inherit from `root`.

Before:

![Screenshot from 2024-01-09 16-04-47](https://github.com/cylc/cylc-ui/assets/16705946/15b4bb2f-7a26-4a81-b1e5-a9fb54ff41ef)

After:

![Screenshot from 2024-01-09 16-04-59](https://github.com/cylc/cylc-ui/assets/16705946/93be4ba0-20ce-437b-b285-a6c93d4eb33a)

To profile for yourself:
* Install and start the reduced example from #1614 in paused mode.
* Open the GUI and start the profiler.
* Open the workflow (assumes the Tree view is the default view).
* Stop the profiler when the tree view is populated.
* In the profiler results, dig for `applyInheritance`.
* Checkout this branch and repeat.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.