### PR TITLE
data store: remove redundant safety check

### DIFF
--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -310,12 +310,7 @@ function update (state, updatedData) {
 
   // create a new tree item
   let treeParent
-  const ret = createTreeNode(state, id, tokens, updatedData)
-  if (!ret) {
-    // node already exists, nothing more to do here
-    return
-  }
-  [treeParent, treeItem] = ret
+  [treeParent, treeItem] = createTreeNode(state, id, tokens, updatedData)
 
   // add the new item to the tree
   addChild(treeParent, treeItem)
@@ -426,11 +421,6 @@ function createTreeNode (state, id, tokens, node) {
     } else {
       pointer = child
     }
-  }
-
-  if (pointer.children.some(child => child.id === id)) {
-    // node already in the tree
-    return
   }
 
   const treeNode = {


### PR DESCRIPTION
* This was checking whether a node already exists in the tree before creating a new one.
* However, the `$index` already serves this function (nodes will be retrieved from the index if they already exist) so this check was redundant.
* This reduces the cost of the `createTreeNode` routine when the number of sibling elements is large.

Coverage suggests the `return` statement was never hit, logically, it shouldn't be possible (except, possibly in the event of traceback).

For the example in this issue https://github.com/cylc/cylc-ui/issues/1614 with `{% set hours = 20 %}` this reduces the cost of the `createTreeNode` routine by ~2/3.

The `some` operation should  be `O(n)`, but it gets called once for each of `n` items being added to the tree so it ends up `O(n^2)` which causes heavy load for high `n`.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
