### PR TITLE
GH Actions: fix screenshots artifact name clash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots
+          name: 'cypress-screenshots_${{ matrix.type }}_${{ matrix.browser }}_${{ matrix.os }}'
           path: tests/e2e/screenshots
 
       - name: Upload coverage artifact


### PR DESCRIPTION
This was preventing more than one job in the matrix from uploading screenshots on failure