### PR TITLE
tree/table: remove unnecessary root family queries

### DIFF
--- a/src/views/Table.vue
+++ b/src/views/Table.vue
@@ -54,9 +54,6 @@ fragment AddedDelta on Added {
   workflow {
     ...WorkflowData
   }
-  cyclePoints: familyProxies (ids: ["*/root"]) {
-    ...CyclePointData
-  }
   taskProxies {
     ...TaskProxyData
   }
@@ -68,9 +65,6 @@ fragment AddedDelta on Added {
 fragment UpdatedDelta on Updated {
   workflow {
     ...WorkflowData
-  }
-  cyclePoints: familyProxies (ids: ["*/root"]) {
-    ...CyclePointData
   }
   taskProxies {
     ...TaskProxyData
@@ -90,18 +84,6 @@ fragment PrunedDelta on Pruned {
 fragment WorkflowData on Workflow {
   id
   reloaded
-}
-
-fragment CyclePointData on FamilyProxy {
-  __typename
-  id
-  state
-  ancestors {
-    name
-  }
-  childTasks {
-    id
-  }
 }
 
 fragment TaskProxyData on TaskProxy {

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -113,9 +113,6 @@ fragment AddedDelta on Added {
   workflow {
     ...WorkflowData
   }
-  cyclePoints: familyProxies (ids: ["*/root"]) {
-    ...CyclePointData
-  }
   familyProxies {
     ...FamilyProxyData
   }
@@ -130,9 +127,6 @@ fragment AddedDelta on Added {
 fragment UpdatedDelta on Updated {
   workflow {
     ...WorkflowData
-  }
-  cyclePoints: familyProxies (ids: ["*/root"]) {
-    ...CyclePointData
   }
   familyProxies {
     ...FamilyProxyData
@@ -155,18 +149,6 @@ fragment PrunedDelta on Pruned {
 fragment WorkflowData on Workflow {
   id
   reloaded
-}
-
-fragment CyclePointData on FamilyProxy {
-  __typename
-  id
-  state
-  ancestors {
-    name
-  }
-  childTasks {
-    id
-  }
 }
 
 fragment FamilyProxyData on FamilyProxy {


### PR DESCRIPTION
* The tree view is already requesting all families (including the root family) so this was requesting the root family twice.
* The table view doesn't use families, the cycle point query is hangover from when it shared the same query as the table view (see 5081d3c377e6aec57dbad0942aac6a759df25eec).
* Closes #1581

In theory there should be no behavioural changes.

Give it a good functional test (both tree & table), if you find any quirks, test them against master.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.