### PR TITLE
Save & restore workspace layout on navigation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ ones in. -->
 -------------------------------------------------------------------------------
 ## __cylc-ui-2.4.0 (<span actions:bind='release-date'>Upcoming</span>)__
 
+### Enhancements
+
+[#1664](https://github.com/cylc/cylc-ui/pull/1664) -
+Workspace tab layout is now remembered & restored when navigating between workflows.
+
 ### Fixes
 
 [#1643](https://github.com/cylc/cylc-ui/pull/1643) -

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -277,7 +277,7 @@ export default {
         this.$eventBus.emit(
           'add-view',
           {
-            viewName: 'Log',
+            name: 'Log',
             initialOptions: {
               tokens: this.node.tokens
             }

--- a/src/components/cylc/workflow/Lumino.vue
+++ b/src/components/cylc/workflow/Lumino.vue
@@ -119,13 +119,13 @@ onMounted(() => {
   Widget.attach(boxPanel, mainDiv.value)
   // Watch for resize of the main element to trigger relayout:
   resizeObserver.observe(mainDiv.value)
-  $eventBus.on('add-view', addWidget)
+  $eventBus.on('add-view', addView)
   getLayout(props.workflowName)
 })
 
 onBeforeUnmount(() => {
   resizeObserver.disconnect()
-  $eventBus.off('add-view', addWidget)
+  $eventBus.off('add-view', addView)
   saveLayout()
   // Register with Lumino that the dock panel is no longer used,
   // otherwise uncaught errors can occur when restoring layout
@@ -138,7 +138,7 @@ onBeforeUnmount(() => {
  * @param {AddViewEvent} view
  * @param {boolean} onTop
  */
-const addWidget = (view, onTop = true) => {
+const addView = (view, onTop = true) => {
   const id = uniqueId('widget')
   const luminoWidget = new LuminoWidget(id, startCase(view.name), /* closable */ true)
   dockPanel.addWidget(luminoWidget, { mode: 'tab-after' })
@@ -155,7 +155,7 @@ const addWidget = (view, onTop = true) => {
 /**
  * Remove all the widgets present in the DockPanel.
  */
-const removeAllWidgets = () => {
+const closeAllViews = () => {
   for (const widget of Array.from(dockPanel.widgets())) {
     widget.close()
   }
@@ -168,7 +168,7 @@ const removeAllWidgets = () => {
  * @param {string} workflowName
  */
 const getLayout = (workflowName) => {
-  restoreLayout(workflowName) || addWidget({ name: defaultView.value })
+  restoreLayout(workflowName) || addView({ name: defaultView.value })
 }
 
 /**
@@ -212,7 +212,7 @@ const restoreLayout = (workflowName) => {
  */
 const changeLayout = (workflowName) => {
   saveLayout()
-  removeAllWidgets()
+  closeAllViews()
   // Wait if necessary for the workflowName prop to be updated to the new value:
   when(
     () => props.workflowName === workflowName,

--- a/src/components/cylc/workflow/Lumino.vue
+++ b/src/components/cylc/workflow/Lumino.vue
@@ -15,187 +15,243 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-  <div ref="main" class="main pa-2 fill-height">
+  <div ref="mainDiv" class="main pa-2 fill-height">
     <!-- Lumino box panel gets inserted here -->
   </div>
   <template
-    v-for="(item, id) in views"
+    v-for="[id, { name, initialOptions }] in views"
     :key="id"
   >
     <Teleport :to="`#${id}`">
       <component
-        :is="item.view"
+        :is="props.allViews.get(name).component"
         :workflow-name="workflowName"
-        :initialOptions="item.initialOptions"
+        :initial-options="initialOptions"
         class="h-100"
       />
     </Teleport>
   </template>
 </template>
 
-<script>
-import { startCase } from 'lodash'
+<script setup>
+import {
+  inject,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+} from 'vue'
+import { useStore } from 'vuex'
+import { startCase, uniqueId } from 'lodash'
 import LuminoWidget from '@/components/cylc/workflow/lumino-widget'
 import { BoxPanel, DockPanel, Widget } from '@lumino/widgets'
+import { when } from '@/utils'
+import { useDefaultView } from '@/views/views'
 
-/**
+/*
  * A component to wrap the Lumino application.
  *
  * It will create a BoxPanel (left to right, no gutters) with a dock
- * panel. Each component/view is rendered in a hidden div, then we transfer
- * the element into the Lumino widget div, creating the
- * impression that the component was created inside the tab/widget.
+ * panel. Each component/view is teleported into the Lumino widget div.
  *
  * Lumino uses DOM, and Vue the VDOM. So this is an approach that
  * works, but there could be alternative approaches too.
  */
-export default {
-  name: 'Lumino',
 
-  components: {}, // Filled on created()
+/**
+ * Mitt event for adding a view to the workspace.
+ * @typedef {Object} AddViewEvent
+ * @property {string} name - the view to add
+ * @property {Object=} initialOptions - prop passed to the view component
+ */
 
-  props: {
-    /**
-     * Parent-provided mapping of widget ID to the name of
-     * view component class + options.
-     *
-     * @type {{ [id: string]: { view: string, initialOptions: Object } }}
-     */
-    views: {
-      type: Object,
-      default: () => {}
-    },
-    workflowName: {
-      type: String,
-      required: true
-    },
-    /** All possible view component classes that can be rendered */
-    allViews: {
-      type: Array,
-      required: true
-    },
+const $eventBus = inject('eventBus')
+const $store = useStore()
+
+const props = defineProps({
+  workflowName: {
+    type: String,
+    required: true
   },
-
-  emits: [
-    'lumino:activated',
-    'lumino:deleted'
-  ],
-
-  beforeCreate () {
-    // Populate components
-    for (const { name, component } of this.allViews) {
-      this.$options.components[name] = component
-    }
-  },
-
   /**
-   * Here we define the ID's for the Lumino DOM elements, and add the Dock panel to the main
-   * Box panel. In the next tick of Vue, the DOM element and the Vue element/ref are attached.
+   * All possible view component classes that can be rendered
+   *
+   * @type {Map<string, import('@/views/views.js').CylcView>}
    */
-  created () {
-    // create a box panel, which holds the dock panel, and controls its layout
-    this.box = new BoxPanel({ direction: 'left-to-right', spacing: 0 })
-    // create dock panel, which holds the widgets
-    this.dock = new DockPanel()
-    // Note: box & dock must not be in data() as the functionality breaks if
-    // the lumino objects are proxied by Vue
-
-    this.box.addWidget(this.dock)
-    BoxPanel.setStretch(this.dock, 1)
-
-    const resizeObserver = new ResizeObserver(() => {
-      this.box.update()
-    })
-
-    this.$nextTick(() => {
-      // Attach box panel to DOM:
-      Widget.attach(this.box, this.$refs.main)
-      // Watch for resize of the main element to trigger relayout:
-      resizeObserver.observe(this.$refs.main)
-    })
+  allViews: {
+    type: Map,
+    required: true
   },
+})
 
-  computed: {
-    /**
-     * We want to watch this.views; however, the (newVal, oldVal) args
-     * do not differ when a deeply watched object's properties change.
-     * So here is a workaround.
-     */
-    _views () {
-      return Object.assign({}, this.views)
+const emit = defineEmits([
+  'emptied'
+])
+
+/**
+ * Template ref
+ * @type {import('vue').Ref<HTMLElement>}
+ */
+const mainDiv = ref(null)
+
+/**
+ * Mapping of widget ID to the name of view component and its initialOptions prop.
+ *
+ * @type {import('vue').Ref<Map<string, AddViewEvent>>}
+ */
+const views = ref(new Map())
+
+const defaultView = useDefaultView()
+
+// create a box panel, which holds the dock panel, and controls its layout
+const boxPanel = new BoxPanel({ direction: 'left-to-right', spacing: 0 })
+// create dock panel, which holds the widgets
+const dockPanel = new DockPanel()
+boxPanel.addWidget(dockPanel)
+BoxPanel.setStretch(dockPanel, 1)
+
+const resizeObserver = new ResizeObserver(() => {
+  boxPanel.update()
+})
+
+onMounted(() => {
+  // Attach box panel to DOM:
+  Widget.attach(boxPanel, mainDiv.value)
+  // Watch for resize of the main element to trigger relayout:
+  resizeObserver.observe(mainDiv.value)
+  $eventBus.on('add-view', addWidget)
+  getLayout(props.workflowName)
+})
+
+onBeforeUnmount(() => {
+  resizeObserver.disconnect()
+  $eventBus.off('add-view', addWidget)
+  saveLayout()
+  // Register with Lumino that the dock panel is no longer used,
+  // otherwise uncaught errors can occur when restoring layout
+  dockPanel.dispose()
+})
+
+/**
+ * Create a widget and add it to the dock.
+ *
+ * @param {AddViewEvent} view
+ * @param {boolean} onTop
+ */
+const addWidget = (view, onTop = true) => {
+  const id = uniqueId('widget')
+  const luminoWidget = new LuminoWidget(id, startCase(view.name), /* closable */ true)
+  dockPanel.addWidget(luminoWidget, { mode: 'tab-after' })
+  // give time for Lumino's widget DOM element to be created
+  nextTick(() => {
+    views.value.set(id, view)
+    addWidgetEventListeners(id)
+    if (onTop) {
+      dockPanel.selectWidget(luminoWidget)
     }
-  },
+  })
+}
 
-  watch: {
-    _views: {
-      deep: true,
-      handler: 'syncWidgets'
-    }
-  },
-
-  methods: {
-    /**
-     * Look for newly added views, creating a corresponding Lumino Widget
-     * for each.
-     */
-    syncWidgets (newVal, oldVal) {
-      for (const [id, item] of Object.entries(newVal)) {
-        if (!(id in oldVal)) {
-          this.addWidget(id, item.view)
-        }
-      }
-    },
-
-    /**
-     * Create a widget and add it to the dock.
-     */
-    addWidget (id, name, onTop = true) {
-      const luminoWidget = new LuminoWidget(id, startCase(name), /* closable */ true)
-      this.dock.addWidget(luminoWidget, { mode: 'tab-after' })
-      // give time for Lumino's widget DOM element to be created
-      this.$nextTick(() => {
-        const widgetEl = document.getElementById(id)
-        widgetEl.addEventListener('lumino:activated', this.onWidgetActivated)
-        widgetEl.addEventListener('lumino:deleted', this.onWidgetDeleted)
-        if (onTop) {
-          this.dock.selectWidget(luminoWidget)
-        }
-      })
-    },
-
-    /**
-     * React to a deleted event.
-     *
-     * @param {{
-     *   detail: {
-     *     id: string,
-     *     name: string,
-     *     closable: boolean
-     *   }
-     * }} customEvent
-     */
-    onWidgetActivated (customEvent) {
-      this.$emit('lumino:activated', customEvent.detail)
-    },
-
-    /**
-     * React to a deleted event.
-     *
-     * @param {{
-     *   detail: {
-     *     id: string,
-     *     name: string,
-     *     closable: boolean
-     *   }
-     * }} customEvent
-     */
-    onWidgetDeleted (customEvent) {
-      const { id } = customEvent.detail
-      const widgetEl = document.getElementById(id)
-      widgetEl.removeEventListener('lumino:deleted', this.onWidgetDeleted)
-      widgetEl.removeEventListener('lumino:activated', this.onWidgetActivated)
-      this.$emit('lumino:deleted', customEvent.detail)
-    },
+/**
+ * Remove all the widgets present in the DockPanel.
+ */
+const removeAllWidgets = () => {
+  for (const widget of Array.from(dockPanel.widgets())) {
+    widget.close()
   }
 }
+
+/**
+ * Get the saved layout (if there is one) for the given workflow,
+ * else add the default view.
+ *
+ * @param {string} workflowName
+ */
+const getLayout = (workflowName) => {
+  restoreLayout(workflowName) || addWidget({ name: defaultView.value })
+}
+
+/**
+ * Save the current layout/views to the store.
+ */
+const saveLayout = () => {
+  $store.commit('app/saveLayout', {
+    workflowName: props.workflowName,
+    layout: dockPanel.saveLayout(),
+    views: new Map(views.value),
+  })
+}
+
+/**
+ * Restore the layout for this workflow from the store, if it was saved.
+ *
+ * @param {string} workflowName
+ * @returns {boolean} true if the layout was restored, false otherwise
+ */
+const restoreLayout = (workflowName) => {
+  const stored = $store.state.app.workspaceLayouts.get(workflowName)
+  if (stored) {
+    dockPanel.restoreLayout(stored.layout)
+    // Wait for next tick so that Lumino has created the widget divs that the
+    // views will be teleported into
+    nextTick(() => {
+      views.value = stored.views
+      for (const id of views.value.keys()) {
+        addWidgetEventListeners(id)
+      }
+    })
+    return true
+  }
+  return false
+}
+
+/**
+ * Save & close the current layout and open the one for the given workflow.
+ *
+ * @param {string} workflowName
+ */
+const changeLayout = (workflowName) => {
+  saveLayout()
+  removeAllWidgets()
+  // Wait if necessary for the workflowName prop to be updated to the new value:
+  when(
+    () => props.workflowName === workflowName,
+    () => getLayout(workflowName),
+  )
+}
+
+/**
+ * @param {string} id - widget ID
+ */
+const addWidgetEventListeners = (id) => {
+  const widgetEl = document.getElementById(id)
+  widgetEl.addEventListener('lumino:deleted', onWidgetDeleted)
+  // widgetEl.addEventListener('lumino:activated', this.onWidgetActivated)
+}
+
+/**
+ * React to a deleted event.
+ *
+ * @param {{
+ *   detail: {
+ *     id: string,
+ *     name: string,
+ *     closable: boolean
+ *   }
+ * }} customEvent
+ */
+const onWidgetDeleted = (customEvent) => {
+  const { id } = customEvent.detail
+  views.value.delete(id)
+  const widgetEl = document.getElementById(id)
+  widgetEl.removeEventListener('lumino:deleted', onWidgetDeleted)
+  // widgetEl.removeEventListener('lumino:activated', this.onWidgetActivated)
+  if (!views.value.size) {
+    emit('emptied')
+  }
+}
+
+defineExpose({
+  changeLayout,
+})
 </script>

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -106,15 +106,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         >
           <v-list>
             <v-list-item
-              v-for="view in views"
-              :id="`toolbar-add-${ view.name }-view`"
-              :key="view.name"
-              @click="$emit('add', { viewName: view.name })"
+              v-for="[name, view] in views"
+              :id="`toolbar-add-${name}-view`"
+              :key="name"
+              @click="$eventBus.emit('add-view', { name })"
             >
               <template #prepend>
                 <v-icon>{{ view.icon }}</v-icon>
               </template>
-              <v-list-item-title>{{ startCase(view.name) }}</v-list-item-title>
+              <v-list-item-title>{{ startCase(name) }}</v-list-item-title>
             </v-list-item>
           </v-list>
         </v-menu>
@@ -189,13 +189,16 @@ export default {
   ],
 
   props: {
+    /**
+     * All possible view component classes that can be rendered
+     *
+     * @type {Map<string, import('@/views/views.js').CylcView>}
+     */
     views: {
-      type: Array,
+      type: Map,
       required: true
     }
   },
-
-  emits: ['add'],
 
   data: () => ({
     expecting: {

--- a/src/components/cylc/workflow/lumino-widget.js
+++ b/src/components/cylc/workflow/lumino-widget.js
@@ -43,9 +43,6 @@ export default class LuminoWidget extends Widget {
     // classes and flags
     this.setFlag(Widget.Flag.DisallowLayout)
     this.addClass('content')
-    // tab title
-    this.title.label = name
-    this.title.closable = closable
   }
 
   /**
@@ -57,6 +54,18 @@ export default class LuminoWidget extends Widget {
     const div = document.createElement('div')
     div.setAttribute('id', id)
     return div
+  }
+
+  onBeforeAttach (msg) {
+    // Set tab title as this is not handled automatically for some reason.
+    // NOTE: We do this in the onBeforeAttach hook rather than in the constructor
+    // because the constructor does not get called when we restore layout to the
+    // dock panel.
+    // Setting these properties are handled by setters in the @lumino/widgets code
+    // which cause the tab panel to be updated.
+    this.title.label = this.name
+    this.title.closable = this.closable
+    super.onBeforeAttach(msg)
   }
 
   onActivateRequest (msg) {

--- a/src/mixins/subscriptionComponent.js
+++ b/src/mixins/subscriptionComponent.js
@@ -37,7 +37,7 @@ export default {
   beforeCreate () {
     // Uniquely identify this component/view so we can keep track of which
     // ones are sharing subscriptions.
-    this._uid = `${uniqueId()}_${this.$options.name}`
+    this._uid = uniqueId(this.$options.name)
   },
   beforeMount () {
     if (this.query) {

--- a/src/mixins/subscriptionComponent.js
+++ b/src/mixins/subscriptionComponent.js
@@ -42,6 +42,10 @@ export default {
   beforeMount () {
     if (this.query) {
       this.$workflowService.subscribe(this)
+    }
+  },
+  mounted () {
+    if (this.query) {
       this.$workflowService.startSubscriptions()
     }
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -76,9 +76,7 @@ router.beforeEach(async (to, from) => {
   if (!store.state.user.user.permissions.includes('read') && to.name !== 'noAuth') {
     return { name: 'noAuth' }
   }
-})
 
-router.beforeResolve((to, from) => {
   if (to.name) {
     let title = to.name
     let workflowName = null

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -15,9 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { markRaw } from 'vue'
+
 const state = () => ({
   drawer: null,
   title: null,
+  workspaceLayouts: new Map(),
 })
 
 const mutations = {
@@ -27,6 +30,16 @@ const mutations = {
   setTitle (state, title) {
     state.title = title
   },
+  saveLayout (state, { workflowName, layout, views }) {
+    /* NOTE: use markRaw to prevent proxying of the Lumino layout in particular.
+    It is not necessary for this saved state to be reactive, and moreover
+    proxying the layout breaks some parts of the 3rd party Lumino backend. */
+    state.workspaceLayouts.set(workflowName, markRaw({ layout, views }))
+    if (state.workspaceLayouts.size > 10) {
+      const firstKey = state.workspaceLayouts.keys().next().value
+      state.workspaceLayouts.delete(firstKey)
+    }
+  }
 }
 
 export const app = {

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -30,14 +30,16 @@ const mutations = {
   setTitle (state, title) {
     state.title = title
   },
-  saveLayout (state, { workflowName, layout, views }) {
+  saveLayout ({ workspaceLayouts }, { workflowName, layout, views }) {
+    // Delete and re-add to keep this FIFO
+    workspaceLayouts.delete(workflowName)
     /* NOTE: use markRaw to prevent proxying of the Lumino layout in particular.
     It is not necessary for this saved state to be reactive, and moreover
     proxying the layout breaks some parts of the 3rd party Lumino backend. */
-    state.workspaceLayouts.set(workflowName, markRaw({ layout, views }))
-    if (state.workspaceLayouts.size > 10) {
-      const firstKey = state.workspaceLayouts.keys().next().value
-      state.workspaceLayouts.delete(firstKey)
+    workspaceLayouts.set(workflowName, markRaw({ layout, views }))
+    if (workspaceLayouts.size > 100) {
+      const firstKey = workspaceLayouts.keys().next().value
+      workspaceLayouts.delete(firstKey)
     }
   }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { watch } from 'vue'
 import { i18n } from '@/i18n'
 
 /**
@@ -26,4 +27,26 @@ import { i18n } from '@/i18n'
  */
 export const getPageTitle = (key, params = {}) => {
   return `${i18n.global.t('App.name')} | ${i18n.global.t(key, params)}`
+}
+
+/**
+ * Watch source until it is truthy, then call the callback (and stop watching).
+ *
+ * Immediate by default.
+ *
+ * @param {import('vue').WatchSource} source
+ * @param {import('vue').WatchCallback} callback
+ * @param {import('vue').WatchOptions?} options
+ */
+export const when = (source, callback, options = {}) => {
+  const unwatch = watch(
+    source,
+    (ready) => {
+      if (ready) {
+        callback()
+        unwatch()
+      }
+    },
+    { immediate: true, ...options }
+  )
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -218,15 +218,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </v-col>
                 <v-select
                   v-model="defaultView"
-                  :items="Object.keys($options.allViews)"
-                  :prepend-inner-icon="$options.allViews[defaultView]"
+                  :items="Array.from($options.allViews.keys())"
+                  :prepend-inner-icon="$options.allViews.get(defaultView).icon"
                   data-cy="select-default-view"
                   :menu-props="{ 'data-cy': 'select-default-view-menu' }"
                 >
                   <template v-slot:item="{ item, props }">
                     <v-list-item
                       v-bind="props"
-                      :prepend-icon="$options.allViews[item.value]"
+                      :prepend-icon="$options.allViews.get(item.value).icon"
                     />
                   </template>
                 </v-select>
@@ -285,9 +285,7 @@ export default {
     getCurrentFontSize,
   },
 
-  allViews: Object.fromEntries(
-    allViews.map(({ name, icon }) => [name, icon])
-  ),
+  allViews,
 
   vuetifyDefaults: {
     global: {

--- a/src/views/Workspace.vue
+++ b/src/views/Workspace.vue
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <Toolbar
       :views="allViews"
       :workflow-name="workflowName"
-      @add="addView"
     />
     <div
       class="workflow-panel"
@@ -28,8 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     >
       <Lumino
         ref="lumino"
-        @lumino:deleted="onWidgetDeletedEvent"
-        :views="widgets"
+        @emptied="onEmptied"
         :workflow-name="workflowName"
         :allViews="allViews"
       />
@@ -38,16 +36,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
-import {
-  inject,
-  nextTick,
-  onBeforeUnmount,
-  onMounted,
-  ref
-} from 'vue'
-import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router'
-import { uniqueId } from 'lodash'
-import { allViews, useDefaultView } from '@/views/views.js'
+import { ref } from 'vue'
+import { onBeforeRouteUpdate } from 'vue-router'
+import { allViews } from '@/views/views.js'
 import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
 import subscriptionMixin from '@/mixins/subscription'
@@ -76,94 +67,25 @@ export default {
   },
 
   setup () {
-    const $eventBus = inject('eventBus')
-    const $workflowService = inject('workflowService')
-
-    /**
-     * The widgets added to the view.
-     *
-     * @type {{ [id: string]: { view: string, initialOptions: Object } }}
-     */
-    const widgets = ref({})
-
     /** Template ref */
     const lumino = ref(null)
 
-    onMounted(() => {
-      $workflowService.startSubscriptions()
-      addDefaultView()
-
-      $eventBus.on('add-view', addView)
-    })
-
-    onBeforeUnmount(() => {
-      $eventBus.off('add-view', addView)
-    })
-
     onBeforeRouteUpdate((to, from) => {
-      // start over again with the new deltas query/variables/new widget as in onMounted
-      removeAllWidgets()
-      addDefaultView()
+      lumino.value.changeLayout(to.params.workflowName)
     })
-
-    onBeforeRouteLeave((to, from) => {
-      removeAllWidgets()
-    })
-
-    /**
-     * Add a new view widget.
-     *
-     * viewName - the name of the view to be added (Vue component name).
-     */
-    const addView = ({ viewName, initialOptions = {} }) => {
-      widgets.value[uniqueId('widget_')] = { view: viewName, initialOptions }
-    }
-
-    const addDefaultView = () => {
-      // in the next tick as otherwise we would get stale/old variables for the graphql query
-      nextTick(() => {
-        addView({ viewName: useDefaultView().value })
-      })
-    }
-
-    /**
-     * Remove all the widgets present in the DockPanel.
-     */
-    const removeAllWidgets = () => {
-      Array.from(lumino.value.dock.widgets())
-        .forEach(widget => widget.close())
-    }
 
     return {
-      addView,
       allViews,
       lumino,
-      widgets,
     }
   },
 
   methods: {
-    /**
-     * Called for each widget removed. Each widget contains a subscription
-     * attached. This method will check if it needs to cancel the
-     * subscription (e.g. we removed the last widget using a deltas
-     * subscription).
-     *
-     * Calling it might change the value of the `isLoading` data
-     * attribute.
-     *
-     * @param {{
-     *   id: string
-     * }} event UI event containing the widget ID (string value, needs to be parsed)
-     */
-    onWidgetDeletedEvent (event) {
-      delete this.widgets[event.id]
+    onEmptied () {
       // If we have no more widgets in the view, then we are not loading, not complete, not error,
       // but back to beginning. When a widget is added, if it uses a query, then the mixins will
       // take care to set the state to LOADING and then COMPLETE (and hopefully not ERROR).
-      if (!Object.keys(this.widgets).length) {
-        this.viewState = ViewState.NO_STATE
-      }
+      this.viewState = ViewState.NO_STATE
     }
   },
 

--- a/src/views/views.js
+++ b/src/views/views.js
@@ -36,7 +36,6 @@ const SimpleTreeView = defineAsyncComponent(() => import('@/views/SimpleTree.vue
 
 /**
  * @typedef {Object} CylcView
- * @property {string} name - the name of the view (Vue component name)
  * @property {import('vue').DefineComponent} component - the dynamic async Vue component
  * @property {string} icon - the icon for this view
  */
@@ -44,34 +43,32 @@ const SimpleTreeView = defineAsyncComponent(() => import('@/views/SimpleTree.vue
 export const TREE = 'Tree'
 
 /**
- * A list of Vue views or components.
+ * A map of Vue views or components.
  *
- * Each view in this list will be available from the Toolbar to be added as
+ * Each view in this map will be available from the Toolbar to be added as
  * a widget to the workspace view.
  *
  * Note for peformance reasons this should not be made reactive as they are
  * already Vue components.
  *
- * @type {CylcView[]}
+ * @type {Map<string, CylcView>}
  */
-export const allViews = [
-  { name: TREE, component: TreeView, icon: mdiFileTree },
-  { name: 'Table', component: TableView, icon: mdiTable },
-  { name: 'Graph', component: GraphView, icon: mdiGraph },
-  { name: 'Log', component: LogView, icon: mdiFileDocumentMultipleOutline },
-  { name: 'Analysis', component: AnalysisView, icon: mdiChartLine },
-]
+export const allViews = new Map([
+  [TREE, { component: TreeView, icon: mdiFileTree }],
+  ['Table', { component: TableView, icon: mdiTable }],
+  ['Graph', { component: GraphView, icon: mdiGraph }],
+  ['Log', { component: LogView, icon: mdiFileDocumentMultipleOutline }],
+  ['Analysis', { component: AnalysisView, icon: mdiChartLine }],
+])
 // Development views that we don't want in production:
 if (import.meta.env.MODE !== 'production') {
-  allViews.push(
-    { name: 'SimpleTree', component: SimpleTreeView, icon: mdiTree },
-  )
+  allViews.set('SimpleTree', { component: SimpleTreeView, icon: mdiTree })
 }
 
 export const useDefaultView = () => {
   const defaultView = useLocalStorage('defaultView', TREE)
   // Check if the view is implemented (in case we remove/rename a view in future)
-  if (!allViews.some(({ name }) => name === defaultView.value)) {
+  if (!allViews.has(defaultView.value)) {
     defaultView.value = TREE
   }
   return defaultView

--- a/tests/e2e/specs/drawer.cy.js
+++ b/tests/e2e/specs/drawer.cy.js
@@ -24,7 +24,7 @@ import { initialWidth, minWidth } from '@/components/cylc/Drawer.vue'
  */
 const resize = (width) => cy
   .get('#c-sidebar .resize-bar')
-  .trigger('mousedown', { which: 1 })
+  .trigger('mousedown')
   .trigger('mousemove', { clientX: width, clientY: 500 })
   .trigger('mouseup', { force: true })
 

--- a/tests/unit/services/workflow.service.spec.js
+++ b/tests/unit/services/workflow.service.spec.js
@@ -69,11 +69,7 @@ describe('WorkflowService', () => {
     sandbox.stub(console, 'debug')
     apolloClient = sandbox.spy({
       query: () => {},
-      subscribe: (options) => {
-        return {
-          subscribe: (subscriptionOptions) => {}
-        }
-      }
+      subscribe: (options) => {}
     })
     subscriptionClient = null
     sandbox.stub(graphqlModule, 'createApolloClient').returns(apolloClient)
@@ -100,7 +96,8 @@ describe('WorkflowService', () => {
       'root',
       [],
       true,
-      true)
+      true
+    )
     // Subscription
     subscription = new Subscription(subscriptionQuery, true)
     service.subscriptions[subscriptionQuery.name] = subscription

--- a/tests/unit/store/app.spec.js
+++ b/tests/unit/store/app.spec.js
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isReactive } from 'vue'
 import { createStore } from 'vuex'
 import storeOptions from '@/store/options'
 
@@ -22,15 +23,14 @@ import storeOptions from '@/store/options'
  * Tests for the store/app module.
  */
 describe('app', () => {
-  const store = createStore(storeOptions)
+  let store
+  beforeEach(() => {
+    store = createStore(storeOptions)
+  })
   /**
    * Tests for store.app.drawer.
    */
   describe('drawer', () => {
-    const resetState = () => {
-      store.state.app.drawer = null
-    }
-    beforeEach(resetState)
     it('should start with no drawer', () => {
       expect(store.state.app.drawer).to.equal(null)
     })
@@ -44,10 +44,6 @@ describe('app', () => {
    * Tests for store.app.title.
    */
   describe('title', () => {
-    const resetState = () => {
-      store.state.app.title = null
-    }
-    beforeEach(resetState)
     it('should start with no title', () => {
       expect(store.state.app.title).to.equal(null)
     })
@@ -55,6 +51,20 @@ describe('app', () => {
       const title = 'Cylc'
       store.commit('app/setTitle', title)
       expect(store.state.app.title).to.equal(title)
+    })
+  })
+
+  describe('workspaceLayouts', () => {
+    it('saves unproxied layout', () => {
+      // Test that the Lumino layout saved in the store is not proxied, because
+      // proxying the layout breaks some parts of the 3rd party Lumino backend
+      const workflowName = 'zane'
+      const fakeLayout = { a: { b: 'c' } }
+      const fakeViews = new Map([[1, 2], [3, 4]])
+      store.commit('app/saveLayout', { workflowName, layout: fakeLayout, views: fakeViews })
+      const stored = store.state.app.workspaceLayouts.get(workflowName)
+      expect(stored).toEqual({ layout: fakeLayout, views: fakeViews })
+      expect(isReactive(stored.layout)).toBe(false)
     })
   })
 })

--- a/tests/unit/utils/index.spec.js
+++ b/tests/unit/utils/index.spec.js
@@ -15,10 +15,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getPageTitle } from '@/utils/index'
+import { nextTick, ref } from 'vue'
+import { getPageTitle, when } from '@/utils/index'
 
 describe('getPageTitle()', () => {
   it('displays the application title correctly', () => {
     expect(getPageTitle('App.dashboard')).to.equal('Cylc UI | Dashboard')
+  })
+})
+
+describe('when()', () => {
+  it('watches source until true and then stops watching', async () => {
+    const source = ref(false)
+    let counter = 0
+    when(source, () => counter++)
+    expect(counter).toEqual(0)
+    source.value = true
+    await nextTick()
+    expect(counter).toEqual(1)
+    source.value = false
+    await nextTick()
+    source.value = true
+    await nextTick()
+    expect(counter).toEqual(1)
   })
 })


### PR DESCRIPTION
Closes #1278
Partially addresses #662

> 2. Save the layout last used by a workspace (important).
>     * When the user navigates away from a workflow, save the tab layout.
>     * When the user navigates back to the workflow, load the tab layout.
>     * When the user navigates to a new run of the same workflow, copy the layout from the last run of the workflow.

The layout is saved in the vuex store so only persists for the browser session. Ongoing investigation into saving it in local storage.

![demo14](https://github.com/cylc/cylc-ui/assets/61982285/461e8ac4-06ba-45af-9416-470c1773915d)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included
- [x] `CHANGES.md` entry included
- [ ] Changelog entry added in cylc-doc
