### PR TITLE
Save view state not between workflows

### DIFF
--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -143,6 +143,7 @@ import { matchNode } from '@/components/cylc/common/filter'
 import TaskFilter from '@/components/cylc/TaskFilter.vue'
 import { dtMean } from '@/utils/tasks'
 import { useCyclePointsOrderDesc } from '@/composables/localStorage'
+import useViewState from '@/composables/useViewState'
 
 export default {
   name: 'TableComponent',
@@ -166,6 +167,7 @@ export default {
 
   setup () {
     const cyclePointsOrderDesc = useCyclePointsOrderDesc()
+    const { options } = useViewState()
     return {
       itemsPerPage: ref(50),
       sortBy: ref([
@@ -174,13 +176,16 @@ export default {
           order: cyclePointsOrderDesc.value ? 'desc' : 'asc'
         },
       ]),
-      tasksFilter: ref({})
+      options
     }
   },
 
   computed: {
     filteredTasks () {
       return this.tasks.filter(({ task }) => matchNode(task, this.tasksFilter.id, this.tasksFilter.states))
+    },
+    tasksFilter () {
+      return this.options.table.tasksFilter.value
     }
   },
 

--- a/src/composables/localStorage.js
+++ b/src/composables/localStorage.js
@@ -30,3 +30,5 @@ export const useCyclePointsOrderDesc = () => useLocalStorage('cyclePointsOrderDe
 export const useJobTheme = () => useLocalStorage('jobTheme', 'default')
 
 export const useReducedAnimation = () => useLocalStorage('reducedAnimation', false)
+
+export const useViewStateLocalStore = () => useLocalStorage('viewState', false)

--- a/src/composables/useViewState.js
+++ b/src/composables/useViewState.js
@@ -1,0 +1,17 @@
+import { ref } from 'vue'
+
+// options ref needs to be defined outside of export function to ensure
+// state persists between components
+const options = ref({
+  tree: {},
+  table: {},
+  graph: {},
+  log: {},
+  analysis: {}
+})
+
+export default function useViewState () {
+  return {
+    options,
+  }
+}

--- a/src/composables/useViewState.js
+++ b/src/composables/useViewState.js
@@ -2,21 +2,28 @@ import { ref } from 'vue'
 
 // options ref needs to be defined outside of export function to ensure
 // state persists between components
-const options = ref({
-  tree: {
-    tasksFilter: { type: Object, value: { id: null, states: null } },
-    expandAll: { type: Array, value: [] },
-  },
-  table: {
-    tasksFilter: { type: Object, value: { id: null, states: null } },
-  },
-  graph: {},
-  log: {},
-  analysis: {}
-})
+
+const optionsArray = ref([])
 
 export default function useViewState () {
+  const options = {
+    tree: {
+      tasksFilter: { type: Object, value: { id: null, states: null } },
+      expandAll: { type: Array, value: [] },
+    },
+    table: {
+      tasksFilter: { type: Object, value: { id: null, states: null } },
+    },
+    graph: {},
+    log: {},
+    analysis: {}
+  }
+  const getOptions = (workflow) => optionsArray.value.find(obj => obj.workflow === workflow)
+  const newOptions = (workflow) => optionsArray.value.push({ workflow, options })
   return {
     options,
+    optionsArray,
+    getOptions,
+    newOptions
   }
 }

--- a/src/composables/useViewState.js
+++ b/src/composables/useViewState.js
@@ -1,7 +1,7 @@
 import { ref } from 'vue'
 
-// options ref needs to be defined outside of export function to ensure
-// state persists between components
+// optionsArray ref needs to be defined outside of export function to ensure
+// state persists between workflows
 
 const optionsArray = ref([])
 

--- a/src/composables/useViewState.js
+++ b/src/composables/useViewState.js
@@ -7,7 +7,9 @@ const options = ref({
     tasksFilter: { type: Object, value: { id: null, states: null } },
     expandAll: { type: Array, value: [] },
   },
-  table: {},
+  table: {
+    tasksFilter: { type: Object, value: { id: null, states: null } },
+  },
   graph: {},
   log: {},
   analysis: {}

--- a/src/composables/useViewState.js
+++ b/src/composables/useViewState.js
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 // options ref needs to be defined outside of export function to ensure
 // state persists between components
 const options = ref({
-  tree: {},
+  tree: {
+    tasksFilter: { type: Object, value: { id: null, states: null } },
+    expandAll: { type: Array, value: [] },
+  },
   table: {},
   graph: {},
   log: {},

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -17,6 +17,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="h-100">
+    {{this.workflowId}}
+    <div>-----------optionsArray-----------</div>
+    <pre>
+      {{ this.optionsArray }}
+    </pre>
+    <div>-----------getOptions(this.workflowId)-----------</div>
+    {{this.getOptions(this.workflowId)}}
+    <div>-----------options-----------</div>
+    {{ this.options }}
+    <!-- {{optionsArray}} -->
     <v-container
       fluid
       class="c-tree pa-2"
@@ -218,9 +228,24 @@ export default {
   },
 
   setup () {
-    const { options } = useViewState()
+    const { optionsArray, getOptions, newOptions } = useViewState()
     return {
-      options,
+      optionsArray,
+      getOptions,
+      newOptions
+    }
+  },
+
+  data: () => ({
+    options: {}
+  }),
+
+  mounted () {
+    if (this.getOptions(this.workflowId)) {
+      this.options = this.getOptions(this.workflowId).options
+    } else {
+      this.newOptions(this.workflowId)
+      this.options = this.getOptions(this.workflowId).options
     }
   },
 

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -18,10 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <template>
   <div class="h-100">
     {{this.workflowId}}
-    <div>-----------optionsArray-----------</div>
-    <pre>
-      {{ this.optionsArray }}
-    </pre>
+    <div>-----------optionsArrayfrom Component-----------</div>
+    {{ this.optionsArray }}
     <div>-----------getOptions(this.workflowId)-----------</div>
     {{this.getOptions(this.workflowId)}}
     <div>-----------options-----------</div>
@@ -237,15 +235,34 @@ export default {
   },
 
   data: () => ({
-    options: {}
+    options: {},
   }),
 
+  // load or create new options object if changing components
   mounted () {
     if (this.getOptions(this.workflowId)) {
       this.options = this.getOptions(this.workflowId).options
     } else {
       this.newOptions(this.workflowId)
       this.options = this.getOptions(this.workflowId).options
+    }
+  },
+
+  watch: {
+    // load or create new options object if changing workflows
+    workflowId (newVal, oldVal) {
+      if (this.getOptions(newVal)) {
+        this.options = this.getOptions(newVal).options
+      } else {
+        this.newOptions(newVal)
+        this.options = this.getOptions(newVal).options
+      }
+    },
+    // save options to localStorage
+    options (newVal, oldVal) {
+      console.log('-----------------')
+      console.log(this.optionsArray)
+      console.log('-----------------')
     }
   },
 

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -37,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             class="d-flex flex-nowrap ml-2"
           >
             <v-btn
-              @click="expandAll = ['workflow', 'cycle', 'family']"
+              @click="options.tree.expandAll.value = [ 'workflow', 'cycle', 'family' ] "
               icon
               variant="flat"
               size="small"
@@ -47,7 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <v-tooltip>Expand all</v-tooltip>
             </v-btn>
             <v-btn
-              @click="expandAll = []"
+            @click="options.tree.expandAll.value = [] "
               icon
               variant="flat"
               size="small"
@@ -92,6 +92,7 @@ import SubscriptionQuery from '@/model/SubscriptionQuery.model'
 import TaskFilter from '@/components/cylc/TaskFilter.vue'
 import TreeComponent from '@/components/cylc/tree/Tree.vue'
 import { matchID, matchState } from '@/components/cylc/common/filter'
+import useViewState from '@/composables/useViewState'
 
 const QUERY = gql`
 subscription Workflow ($workflowId: ID) {
@@ -216,13 +217,12 @@ export default {
     }
   },
 
-  data: () => ({
-    expandAll: null,
-    tasksFilter: {
-      id: null,
-      states: null,
-    },
-  }),
+  setup () {
+    const { options } = useViewState()
+    return {
+      options,
+    }
+  },
 
   computed: {
     ...mapState('workflows', ['cylcTree']),
@@ -251,6 +251,14 @@ export default {
       return (this.tasksFilter.id?.trim() || this.tasksFilter.states?.length)
         ? this.tasksFilter
         : null
+    },
+
+    expandAll () {
+      return this.options.tree.expandAll.value
+    },
+
+    tasksFilter () {
+      return this.options.tree.tasksFilter.value
     }
   },
 

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -17,14 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <div class="h-100">
-    {{this.workflowId}}
-    <div>-----------optionsArrayfrom Component-----------</div>
-    {{ this.optionsArray }}
-    <div>-----------getOptions(this.workflowId)-----------</div>
-    {{this.getOptions(this.workflowId)}}
-    <div>-----------options-----------</div>
-    {{ this.options }}
-    <!-- {{optionsArray}} -->
     <v-container
       fluid
       class="c-tree pa-2"
@@ -249,21 +241,13 @@ export default {
       this.options = this.getOptions(this.workflowId).options
     }
     // load optionsArray from local sotrage if it exists
-    if (localStorage.getItem('viewState')) {
-
-      // console.log('-----MOUNTED and found viewState-----')
-      // console.log(localStorage.getItem('viewState'))
-      // console.log(JSON.parse(localStorage.getItem('viewState')))
-      // this.optionsArray = JSON.parse(localStorage.getItem('viewState'))
-
-      // this.optionsArray = JSON.parse(localStorage.getItem('viewState'))
-      // if (this.getOptions(this.workflowId)) {
-      //   this.options = this.getOptions(this.workflowId).options
-      // } else {
-      //   this.newOptions(this.workflowId)
-      //   this.options = this.getOptions(this.workflowId).options
-      // }
-    } else { console.log('no viewState in local storage') }
+    if (localStorage.getItem('viewState') !== 'false') {
+      this.optionsArray = JSON.parse(localStorage.getItem('viewState'))
+      this.options = this.getOptions(this.workflowId).options
+    } else {
+      // need a completely new optionsArray
+      this.optionsArray = useViewState().optionsArray
+    }
   },
 
   watch: {
@@ -276,7 +260,7 @@ export default {
         this.options = this.getOptions(newVal).options
       }
     },
-    // save options to localStorage
+    // save options to local storage whenever options ref changes
     options: {
       handler: function (newVal, oldVal) {
         this.viewStateLocalStore = JSON.stringify(this.optionsArray)

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -101,6 +101,7 @@ import TaskFilter from '@/components/cylc/TaskFilter.vue'
 import TreeComponent from '@/components/cylc/tree/Tree.vue'
 import { matchID, matchState } from '@/components/cylc/common/filter'
 import useViewState from '@/composables/useViewState'
+import { useViewStateLocalStore } from '@/composables/localStorage'
 
 const QUERY = gql`
 subscription Workflow ($workflowId: ID) {
@@ -230,7 +231,8 @@ export default {
     return {
       optionsArray,
       getOptions,
-      newOptions
+      newOptions,
+      viewStateLocalStore: useViewStateLocalStore()
     }
   },
 
@@ -238,14 +240,30 @@ export default {
     options: {},
   }),
 
-  // load or create new options object if changing components
   mounted () {
+    // load or create new options object if changing components
     if (this.getOptions(this.workflowId)) {
       this.options = this.getOptions(this.workflowId).options
     } else {
       this.newOptions(this.workflowId)
       this.options = this.getOptions(this.workflowId).options
     }
+    // load optionsArray from local sotrage if it exists
+    if (localStorage.getItem('viewState')) {
+
+      // console.log('-----MOUNTED and found viewState-----')
+      // console.log(localStorage.getItem('viewState'))
+      // console.log(JSON.parse(localStorage.getItem('viewState')))
+      // this.optionsArray = JSON.parse(localStorage.getItem('viewState'))
+
+      // this.optionsArray = JSON.parse(localStorage.getItem('viewState'))
+      // if (this.getOptions(this.workflowId)) {
+      //   this.options = this.getOptions(this.workflowId).options
+      // } else {
+      //   this.newOptions(this.workflowId)
+      //   this.options = this.getOptions(this.workflowId).options
+      // }
+    } else { console.log('no viewState in local storage') }
   },
 
   watch: {
@@ -259,10 +277,11 @@ export default {
       }
     },
     // save options to localStorage
-    options (newVal, oldVal) {
-      console.log('-----------------')
-      console.log(this.optionsArray)
-      console.log('-----------------')
+    options: {
+      handler: function (newVal, oldVal) {
+        this.viewStateLocalStore = JSON.stringify(this.optionsArray)
+      },
+      deep: true
     }
   },
 


### PR DESCRIPTION
Supersedes https://github.com/cylc/cylc-ui/pull/1669 and https://github.com/cylc/cylc-ui/pull/1246

I set up a composable for defining and managing all the view options.
The state persists when switching between workflows

Still to do - 
Set up a watcher that saves to local storage
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
