### PR TITLE
Renovate: schedule lock file maintenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,15 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'renovate.json'
+      - '.github/dependabot.yml'
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - 'renovate.json'
+      - '.github/dependabot.yml'
+      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,11 @@
       "addLabels": ["analysis view"]
     }
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["on the last day of the month"]
+  },
   "vulnerabilityAlerts": {
     "addLabels": ["security"]
   }


### PR DESCRIPTION
> You can use `lockFileMaintenance` to refresh lock files to keep them up-to-date.
>
> When Renovate performs `lockFileMaintenance` it deletes the lock file and runs the relevant package manager. That package manager creates a new lock file, where all dependency versions are updated to the latest version. Renovate then commits that lock file to the update branch and creates the lock file update PR.

https://docs.renovatebot.com/configuration-options/#lockfilemaintenance

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
