### PR TITLE
Fix yarn warnings about `react`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "mitt": "3.0.1",
     "nprogress": "1.0.0-1",
     "preact": "10.19.6",
-    "preact-compat": "3.19.0",
     "subscriptions-transport-ws": "0.11.0",
     "svg-pan-zoom": "3.6.1",
     "vue": "3.4.11",
@@ -88,6 +87,14 @@
     "vite-plugin-istanbul": "5.0.0",
     "vite-plugin-vuetify": "2.0.2",
     "vitest": "1.3.1"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "bugs": {
     "url": "https://github.com/cylc/cylc-ui/issues"

--- a/src/views/GraphiQL.vue
+++ b/src/views/GraphiQL.vue
@@ -21,8 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script>
 import 'graphiql/graphiql.min.css'
-import ReactDOM from 'react-dom'
-import React from 'react'
+import { render, createElement } from 'preact/compat'
 import GraphiQL from 'graphiql'
 import { fallbackGraphQLFetcher, graphQLFetcher } from '@/graphql/graphiql'
 
@@ -41,8 +40,8 @@ export default {
   },
   mounted () {
     this.fetcher = this.createFetcher()
-    ReactDOM.render(
-      React.createElement(GraphiQL, {
+    render(
+      createElement(GraphiQL, {
         fetcher: this.fetcher,
         defaultVariableEditorOpen: false
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,7 +3519,6 @@ __metadata:
     nprogress: "npm:1.0.0-1"
     nyc: "npm:15.1.0"
     preact: "npm:10.19.6"
-    preact-compat: "npm:3.19.0"
     sass: "npm:1.71.1"
     sinon: "npm:17.0.1"
     standard: "npm:17.1.0"
@@ -3537,6 +3536,11 @@ __metadata:
     vue3-apexcharts: "npm:1.4.1"
     vuetify: "npm:3.5.4"
     vuex: "npm:4.1.0"
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5727,15 +5731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutability-helper@npm:^2.7.1":
-  version: 2.9.1
-  resolution: "immutability-helper@npm:2.9.1"
-  dependencies:
-    invariant: "npm:^2.2.0"
-  checksum: 10c0/0e087f39f1e3dce387094471e55c6e6bf2ab109eaf07d8549b4ca4b01f60712331a5c45fc89344c9e273fa27742cd9b6443d9adee19edaefc1e546dba33087e1
-  languageName: node
-  linkType: hard
-
 "immutable@npm:^4.0.0":
   version: 4.3.5
   resolution: "immutable@npm:4.3.5"
@@ -5809,7 +5804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.0, invariant@npm:^2.2.4":
+"invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -7985,51 +7980,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preact-compat@npm:3.19.0":
-  version: 3.19.0
-  resolution: "preact-compat@npm:3.19.0"
-  dependencies:
-    immutability-helper: "npm:^2.7.1"
-    preact-context: "npm:^1.1.3"
-    preact-render-to-string: "npm:^3.8.2"
-    preact-transition-group: "npm:^1.1.1"
-    prop-types: "npm:^15.6.2"
-    standalone-react-addons-pure-render-mixin: "npm:^0.1.1"
-  peerDependencies:
-    preact: <10
-  checksum: 10c0/fea8b9c08596e52cf782feeec3a9b805e7cee8499eb992b245cda722a6efa8f22cfe2d640db0349c9f13e3790b437df538bd06276cc4908d2540114620283e27
-  languageName: node
-  linkType: hard
-
-"preact-context@npm:^1.1.3":
-  version: 1.1.4
-  resolution: "preact-context@npm:1.1.4"
-  peerDependencies:
-    preact: ^8.2.7
-  checksum: 10c0/a3eb81da4a2a2751d4ba3e3c888a20f2978e0a57e3fa1ff438ec717e09ad742f10dd8a7cf3ba5145a0b680bd000097502f5493f41df0e1926962d003cab54007
-  languageName: node
-  linkType: hard
-
-"preact-render-to-string@npm:^3.8.2":
-  version: 3.8.2
-  resolution: "preact-render-to-string@npm:3.8.2"
-  dependencies:
-    pretty-format: "npm:^3.5.1"
-  peerDependencies:
-    preact: "*"
-  checksum: 10c0/e139fb6d0bbfa4131f5ab07ab8175fd1633fb4dc3d68a045499b38bf30428131e7a7ebdf86778f9a2981b6f315083eb2d698302e74351ac1a48cebc3baa0bb35
-  languageName: node
-  linkType: hard
-
-"preact-transition-group@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "preact-transition-group@npm:1.1.1"
-  peerDependencies:
-    preact: "*"
-  checksum: 10c0/dc40e114508cff3e7952d4681eb717d20514cd87349da7455b46ed897d71c4e1b209eeadc1f2788cf851d25c3e9d781456c177a16549ebfb4c76fae3222668c6
-  languageName: node
-  linkType: hard
-
 "preact@npm:10.19.6":
   version: 10.19.6
   resolution: "preact@npm:10.19.6"
@@ -8059,13 +8009,6 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 10c0/edc5ff89f51916f036c62ed433506b55446ff739358de77207e63e88a28ca2894caac6e73dcb68166a606e51c8087d32d400473e6a9fdd2dbe743f46c9c0276f
-  languageName: node
-  linkType: hard
-
-"pretty-format@npm:^3.5.1":
-  version: 3.8.0
-  resolution: "pretty-format@npm:3.8.0"
-  checksum: 10c0/69f12937bfb7b2a537a7463b9f875a16322401f1e44d7702d643faa0d21991126c24c093217ef6da403b54c15942a834174fa1c016b72e2cb9edaae6bb3729b6
   languageName: node
   linkType: hard
 
@@ -8102,7 +8045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -9030,13 +8973,6 @@ __metadata:
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
-  languageName: node
-  linkType: hard
-
-"standalone-react-addons-pure-render-mixin@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "standalone-react-addons-pure-render-mixin@npm:0.1.1"
-  checksum: 10c0/1c6ca4c69c621e05adaa53e1f0424829ad37e1bb7eea4e32656c9c31e225b302613f9ca5d6c141f47caa38cba7d043e7b6ee30a07e51e8762598afcfa490d818
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- We use `preact` as a replacement for `react`
- Remove outdated and unused `preact-compat` dependency (the correct package is `preact/compat` which is included with `preact` (not to be confused with `@preact/compat` which is not needed either!))

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No changelog entry needed

