### PR TITLE
Gantt view: colour code by cycle point

### DIFF
--- a/changes.d/1466.feat.md
+++ b/changes.d/1466.feat.md
@@ -1,0 +1,1 @@
+Added gantt view: a new view showing job durations over time.


### PR DESCRIPTION
Follow-up to #1466 

At present there isn't a great deal of use in the colour coding the gantt view by task name. I had a go at making it colour coded by cycle point, and added the job ID to the tooltip

![image](https://github.com/cylc/cylc-ui/assets/61982285/37597740-28f3-43f4-bce4-3585d581bfe3)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Tests are included (or explain why tests are not needed).
- [x] No changelog entry needed as follow-up to unreleased enhancement
- [x] No doc PR needed

