### PR TITLE
Log view: wrap lines and improve UX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ ones in. -->
 [#1664](https://github.com/cylc/cylc-ui/pull/1664) -
 Workspace tab layout is now remembered & restored when navigating between workflows.
 
+[#1708](https://github.com/cylc/cylc-ui/pull/1708) -
+Usability improvements for the log view.
+
 ### Fixes
 
 [#1623](https://github.com/cylc/cylc-ui/pull/1623),

--- a/cypress/component/viewToolbar.cy.js
+++ b/cypress/component/viewToolbar.cy.js
@@ -75,7 +75,7 @@ describe('View Toolbar Component', () => {
     // test action=toggle
     cy
       // the toggle should be blue because it's active (default true)
-      .get('.control.toggle .v-btn')
+      .get('[data-cy=control-toggle] .v-btn')
       .should('have.class', 'text-blue')
       // clicking the toggle should emit a "setOption" event with the
       // controls key (toggle) and new value (false)
@@ -86,7 +86,7 @@ describe('View Toolbar Component', () => {
         ).to.deep.equal(['toggle', false])
       })
       // it should not be grey because it's inactive (false)
-      .get('.control.toggle .v-btn')
+      .get('[data-cy=control-toggle] .v-btn')
       .not('.text-blue')
       // click it again and it should become active again
       .click({ force: true })
@@ -95,13 +95,13 @@ describe('View Toolbar Component', () => {
           wrapper.emitted().setOption.at(-1)
         ).to.deep.equal(['toggle', true])
       })
-      .get('.control.toggle .v-btn')
+      .get('[data-cy=control-toggle] .v-btn')
       .should('have.class', 'text-blue')
 
     // test action=callback
     expect(callbacks).to.have.length(0)
     cy
-      .get('.control.callback .v-btn')
+      .get('[data-cy=control-callback] .v-btn')
       // clicking the icon should fire the callback
       .click({ force: true })
       .then(() => {
@@ -147,33 +147,33 @@ describe('View Toolbar Component', () => {
 
     cy
       // foo should start enabled (bar=true, baz=false)
-      .get('.control.foo .v-btn')
+      .get('[data-cy=control-foo] .v-btn')
       .not('.v-btn--disabled')
 
       // toggle bar
-      .get('.control.bar .v-btn')
+      .get('[data-cy=control-bar] .v-btn')
       .click({ force: true })
 
       // foo should be disabled (bar=false, baz=false)
-      .get('.control.foo .v-btn')
+      .get('[data-cy=control-foo] .v-btn')
       .should('have.class', 'v-btn--disabled')
 
       // toggle bar & baz
-      .get('.control.bar .v-btn')
+      .get('[data-cy=control-bar] .v-btn')
       .click({ force: true })
-      .get('.control.baz .v-btn')
+      .get('[data-cy=control-baz] .v-btn')
       .click({ force: true })
 
       // foo should be disabled (bar=true, baz=true)
-      .get('.control.foo .v-btn')
+      .get('[data-cy=control-foo] .v-btn')
       .should('have.class', 'v-btn--disabled')
 
       // toggle baz
-      .get('.control.baz .v-btn')
+      .get('[data-cy=control-baz] .v-btn')
       .click({ force: true })
 
       // foo should be enabled (bar=true, baz=false)
-      .get('.control.foo .v-btn')
+      .get('[data-cy=control-foo] .v-btn')
       .not('.v-btn--disabled')
   })
 

--- a/src/components/cylc/ViewToolbar.vue
+++ b/src/components/cylc/ViewToolbar.vue
@@ -25,12 +25,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     >
       <!-- control -->
       <div
-        :class="['control', iControl.key]"
         v-for="iControl in iGroup.iControls"
         :key="iControl.title"
+        class="control"
+        :data-cy="`control-${iControl.key}`"
       >
         <v-btn
-          :class="iControl.title"
           icon
           variant="text"
           :disabled="iControl.disabled"

--- a/src/components/cylc/ViewToolbar.vue
+++ b/src/components/cylc/ViewToolbar.vue
@@ -16,7 +16,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div class="c-view-toolbar">
+  <div
+    class="c-view-toolbar"
+    :style="{ fontSize }"
+  >
     <!-- control group -->
     <div
       class="group"
@@ -36,8 +39,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :disabled="iControl.disabled"
           :color="iControl.color"
           @click="iControl.callback"
+          :size="size"
         >
-          <v-icon size="large">{{ iControl.icon }}</v-icon>
+          <v-icon>{{ iControl.icon }}</v-icon>
           <v-tooltip>{{ iControl.title }}</v-tooltip>
         </v-btn>
       </div>
@@ -91,6 +95,11 @@ export default {
           }
         ]
       */
+    },
+    /** Button size in px or vuetify named size */
+    size: {
+      type: String,
+      default: 'default',
     }
   },
 
@@ -153,6 +162,21 @@ export default {
         ret.push(iGroup)
       }
       return ret
+    },
+    /**
+     * Scale icon size to button size.
+     * https://github.com/vuetifyjs/vuetify/issues/16288
+     *
+     * @returns {string=} font size
+     */
+    fontSize () {
+      const size = parseInt(this.size)
+      if (Number.isNaN(size)) {
+        // do nothing for named sizes ('small', 'large', etc.)
+        return undefined
+      }
+      // Round to even px then convert to rem
+      return `${2 * Math.round(0.2 * size) / 16}rem`
     }
   },
 
@@ -180,15 +204,13 @@ export default {
         }
       }
       return vars
-    }
+    },
   }
 }
 </script>
 
 <style lang="scss">
   .c-view-toolbar {
-    // give the toolbar a little respect space
-    padding: 0.5rem;
     display: flex;
 
     .group {

--- a/src/components/cylc/ViewToolbar.vue
+++ b/src/components/cylc/ViewToolbar.vue
@@ -16,10 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div
-    class="c-view-toolbar"
-    :style="{ fontSize }"
-  >
+  <div class="c-view-toolbar">
     <!-- control group -->
     <div
       class="group"
@@ -34,12 +31,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :data-cy="`control-${iControl.key}`"
       >
         <v-btn
-          icon
-          variant="text"
+          v-bind="btnProps"
           :disabled="iControl.disabled"
           :color="iControl.color"
           @click="iControl.callback"
-          :size="size"
         >
           <v-icon>{{ iControl.icon }}</v-icon>
           <v-tooltip>{{ iControl.title }}</v-tooltip>
@@ -50,6 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
+import { btnProps } from '@/utils/viewToolbar'
+
 export default {
   name: 'ViewToolbar',
 
@@ -163,20 +160,8 @@ export default {
       }
       return ret
     },
-    /**
-     * Scale icon size to button size.
-     * https://github.com/vuetifyjs/vuetify/issues/16288
-     *
-     * @returns {string=} font size
-     */
-    fontSize () {
-      const size = parseInt(this.size)
-      if (Number.isNaN(size)) {
-        // do nothing for named sizes ('small', 'large', etc.)
-        return undefined
-      }
-      // Round to even px then convert to rem
-      return `${2 * Math.round(0.2 * size) / 16}rem`
+    btnProps () {
+      return btnProps(this.size)
     }
   },
 

--- a/src/components/cylc/log/Log.vue
+++ b/src/components/cylc/log/Log.vue
@@ -16,15 +16,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <div>
-    <pre><span v-for="(log, index) in computedLogs" :key="index">{{log}}</span></pre>
-  </div>
+  <pre><span
+    v-for="(log, index) in computedLogs"
+    :key="index"
+    :class="wordWrap ? 'text-pre-wrap' : 'text-pre'"
+  >{{ log }}</span></pre>
 </template>
 
 <script>
 
 export default {
   name: 'LogComponent',
+
   props: {
     placeholder: {
       type: String,
@@ -38,13 +41,20 @@ export default {
     logs: {
       type: Array,
       required: true
-    }
+    },
+    wordWrap: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
   },
+
   data () {
     return {
       match: ''
     }
   },
+
   computed: {
     computedLogs () {
       if (this.logs.length > 0) {
@@ -56,14 +66,16 @@ export default {
       } else {
         return []
       }
-    }
+    },
   },
+
   methods: {
     updateLogs () {
       return this.logs.map((logLine) => {
         return this.stripTimestamp(logLine)
       })
     },
+
     stripTimestamp (logLine) {
       const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-][\d:]+)?\s(.*\s*)/
       this.match = logLine.match(regex)

--- a/src/services/mock/graphql.cjs
+++ b/src/services/mock/graphql.cjs
@@ -50,7 +50,7 @@ function getOperationName (query) {
  *
  * @param {string} operationName - GraphQL query operation name (e.g. GScanQuery, WorkflowTableQuery, etc)
  * @param {?Record<string, *>} variables - GraphQL query variables
- * @returns {*} GraphQL response
+ * @returns {*|Promise<*>} GraphQL response
  */
 function getGraphQLQueryResponse (operationName, variables) {
   const res = data[operationName] || {}
@@ -65,7 +65,7 @@ function getGraphQLQueryResponse (operationName, variables) {
  * and returning the valid response (if any).
  *
  * @param {*} request - Express HTTP GraphQL request
- * @returns {*} GraphQL response
+ * @returns {*|Promise<*>} GraphQL response
  */
 function handleGraphQLRequest (request) {
   const isSchemaQuery = request.body.query.includes('__schema')

--- a/src/services/mock/json-server.cjs
+++ b/src/services/mock/json-server.cjs
@@ -54,7 +54,7 @@ server.ws('/subscriptions', (ws) => {
  * @param req - express HTTP request
  * @param res - express HTTP response
  */
-router.render = (req, res) => {
+router.render = async (req, res) => {
   // This is the original response.
   let responseData = res.locals.data || {}
   // Here we want to customize the response for GraphQL requests.
@@ -63,7 +63,7 @@ router.render = (req, res) => {
     if (req.method === 'GET') {
       responseData = { errors: [{ message: 'Must provide query string.' }] }
     } else {
-      responseData = graphql.handleGraphQLRequest(req)
+      responseData = await graphql.handleGraphQLRequest(req)
     }
   }
   // NB: json-server returns 404 for requests that are not in db.json, but

--- a/src/services/mock/json/logData.cjs
+++ b/src/services/mock/json/logData.cjs
@@ -31,6 +31,8 @@ const workflowLogLines = [
   '2023-05-25T10:48:01+01:00 INFO - Workflow: one\n',
   '2023-05-25T10:48:01+01:00 INFO - LOADING workflow parameters\n',
   '2023-05-25T10:48:01+01:00 INFO - + cycle point time zone = Z\n',
+  '2023-08-17T14:10:51+01:00 INFO - The quick brown 🦊 jumps over the lazy 🐶\n',
+  '2024-02-07T13:38:25+01:00 INFO - Ce programme est distribué dans l\'espoir qu\'il sera utile, mais SANS TOUTE GARANTIE ; sans même la garantie implicite de QUALITÉ MARCHANDE ou d\'ADAPTATION À UN USAGE PARTICULIER. Consultez la GNU General Public License pour plus de détails.\n',
   '2038-01-19T04:14:07+01:00 CRITICAL - It\'s the Epochalypse!\n',
 ]
 
@@ -49,7 +51,7 @@ const LogData = ({ id, file }) => {
     logs: {
       connected: file !== deletedFile,
       error: file === deletedFile
-        ? `tail: ${path}: No such file or directory\ntail: no files remaining`
+        ? 'No such file or directory'
         : undefined,
       path: `my-host:${path}`,
       lines: isJob ? jobLogLines : workflowLogLines,

--- a/src/services/mock/json/logData.cjs
+++ b/src/services/mock/json/logData.cjs
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const { simulatedDelay } = require('./util.cjs')
 const { deletedFile } = require('./logFiles.cjs')
 
 const logDirPath = '/path/to/the/log/file/note/these/paths/get/really/log'
@@ -44,9 +45,10 @@ const workflowLogLines = [
  *   file: string,
  * }} variables
  */
-const LogData = ({ id, file }) => {
+const LogData = async ({ id, file }) => {
   const isJob = id.includes('//')
   const path = `${logDirPath}/${file}`
+  await simulatedDelay(1e3)
   return {
     logs: {
       connected: file !== deletedFile,

--- a/src/services/mock/json/util.cjs
+++ b/src/services/mock/json/util.cjs
@@ -15,42 +15,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { simulatedDelay } = require('./util.cjs')
-
-const deletedFile = 'deleted.log'
-
-const jobLogFiles = [
-  'job.out',
-  'job.err',
-  'job',
-]
-
-const workflowLogFiles = [
-  'scheduler/01-start-01.log',
-  deletedFile,
-]
+const process = require('process')
 
 /**
- * Return a mock GQL response for list of log files.
+ * Simulate a loading delay.
  *
- * @param {{ id: string }} variables
+ * NOTE: skips the delay if the CI env var is set so as not to slow down tests.
+ *
+ * @param {number} delay - in ms
+ * @returns {Promise}
  */
-const LogFiles = async ({ id }) => {
-  await simulatedDelay(500)
-  return {
-    data: {
-      logFiles: {
-        files: id == null
-          ? []
-          : id.includes('//') ? jobLogFiles : workflowLogFiles
-      }
-    }
-  }
+function simulatedDelay (delay) {
+  return process.env.CI
+    ? Promise.resolve()
+    : new Promise((resolve) => setTimeout(resolve, delay))
 }
 
 module.exports = {
-  LogFiles,
-  deletedFile,
-  jobLogFiles,
-  workflowLogFiles,
+  simulatedDelay,
 }

--- a/src/services/mock/websockets.cjs
+++ b/src/services/mock/websockets.cjs
@@ -46,7 +46,7 @@ function wsResponse (id, type, data = null) {
  * @param {WebSocket} ws
  * @param {string} msg - JSON encoded client message
  */
-function sendWSResponse (ws, msg) {
+async function sendWSResponse (ws, msg) {
   const parsed = JSON.parse(msg)
   if (parsed) {
     if (parsed.type === 'connection_init') {
@@ -57,7 +57,7 @@ function sendWSResponse (ws, msg) {
       const operationName = (
         parsed.payload.operationName || graphql.getOperationName(parsed.payload.query)
       )
-      const responseData = graphql.getGraphQLQueryResponse(operationName, parsed.payload.variables)
+      const responseData = await graphql.getGraphQLQueryResponse(operationName, parsed.payload.variables)
       for (const item of isArray(responseData) ? responseData : [responseData]) {
         ws.send(wsResponse(parsed.id, 'data', item))
       }

--- a/src/utils/viewToolbar.js
+++ b/src/utils/viewToolbar.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Scale icon size to button size.
+ * https://github.com/vuetifyjs/vuetify/issues/16288
+ *
+ * @param {string} btnSize - button size
+ * @returns {string=} font size
+ */
+export function btnIconFontSize (btnSize) {
+  const size = parseInt(btnSize)
+  if (Number.isNaN(size)) {
+    // do nothing for named sizes ('small', 'large', etc.)
+    return undefined
+  }
+  // Round to even px then convert to rem
+  return `${2 * Math.round(0.2 * size) / 16}rem`
+}
+
+export const btnProps = (size) => ({
+  icon: true,
+  variant: 'text',
+  size,
+  style: {
+    fontSize: btnIconFontSize(size)
+  },
+})

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -136,6 +136,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             data-cy="log-viewer"
             :logs="results.lines"
             :timestamps="timestamps"
+            :word-wrap="wordWrap"
           />
         </template>
       </v-col>
@@ -152,6 +153,7 @@ import {
   mdiFolderRefresh,
   mdiPowerPlugOff,
   mdiPowerPlug,
+  mdiWrap,
 } from '@mdi/js'
 import { getPageTitle } from '@/utils/index'
 import graphqlMixin from '@/mixins/graphql'
@@ -318,6 +320,12 @@ export default {
      */
     const file = useInitialOptions('file', { props, emit })
 
+    /** Toggle timestamps in log files */
+    const timestamps = useInitialOptions('timestamps', { props, emit }, true)
+
+    /** Wrap lines? */
+    const wordWrap = useInitialOptions('wordWrap', { props, emit }, false)
+
     /** Set the value of relativeID at most every 0.5 seconds, used for text input */
     const debouncedUpdateRelativeID = debounce((value) => {
       relativeID.value = value
@@ -340,8 +348,8 @@ export default {
       // toggle between viewing workflow logs (0) and job logs (1).
       // default to displaying workflow logs unless initial task/job ID is provided.
       jobLog: ref(relativeID.value == null ? 0 : 1),
-      // toggle timestamps in log files
-      timestamps: ref(true),
+      timestamps,
+      wordWrap,
       debouncedUpdateRelativeID,
     }
   },
@@ -356,11 +364,18 @@ export default {
               title: 'Timestamps',
               icon: mdiClockOutline,
               action: 'toggle',
-              value: true,
+              value: this.timestamps,
               key: 'timestamps'
             },
             {
-              title: 'Refresh File List',
+              title: 'Word wrap',
+              icon: mdiWrap,
+              action: 'toggle',
+              value: this.wordWrap,
+              key: 'wordWrap',
+            },
+            {
+              title: 'Refresh file list',
               icon: mdiFolderRefresh,
               action: 'callback',
               callback: () => { this.updateLogFileList(false) }

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -26,98 +26,114 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <template>
   <v-container
-    class="c-log py-1"
+    class="c-log h-100 pa-0 d-flex flex-column"
     fluid
   >
-    <!-- the controls -->
-    <v-row dense>
-      <v-col>
-        <v-btn-toggle
-          v-model="jobLog"
-          divided
-          mandatory
-          variant="outlined"
-          color="primary"
-        >
-          <v-btn data-cy="workflow-toggle">Workflow</v-btn>
-          <v-btn data-cy="job-toggle">Job</v-btn>
-        </v-btn-toggle>
-        <ViewToolbar
-          :groups="controlGroups"
-          @setOption="setOption"
-        />
-      </v-col>
-    </v-row>
-
-    <!-- the inputs -->
-    <v-row dense>
-      <v-col cols="8">
-        <v-text-field
-          v-if="jobLog"
-          data-cy="job-id-input"
-          class="flex-grow-1 flex-column"
-          :model-value="relativeID"
-          @update:modelValue="debouncedUpdateRelativeID"
-          placeholder="cycle/task/job"
-          clearable
-        />
-        <v-text-field
-          v-else
-          data-cy="workflow-id-input"
-          v-model="workflowId"
-          disabled
-        />
-      </v-col>
-      <v-col cols="4">
-        <v-select
-          data-cy="file-input"
-          :label="fileLabel"
-          :disabled="fileDisabled"
-          :items="logFiles"
-          v-model="file"
-          clearable
-          :menu-props="{ 'data-cy': 'file-input-menu' }"
-        />
-      </v-col>
-    </v-row>
-
-    <!-- the status line -->
-    <v-row dense>
-      <v-col
-        v-if="results.path"
-        class="d-flex align-center overflow-x-auto text-pre"
+    <v-container fluid>
+      <!-- the controls -->
+      <v-row
+        dense
+        class="flex-0-0"
       >
-        <v-chip
-          data-cy="connected-icon"
-          variant="outlined"
-          class="flex-shrink-0"
-          v-bind="results.connected ? {
-            color: 'success',
-            prependIcon: $options.icons.mdiPowerPlug,
-          } : {
-            color: 'error',
-            prependIcon: $options.icons.mdiPowerPlugOff,
-            onClick: updateQuery
-          }"
+        <v-col class="pt-0">
+          <v-btn-toggle
+            v-model="jobLog"
+            divided
+            mandatory
+            variant="outlined"
+            color="primary"
+            density="comfortable"
+          >
+            <v-btn data-cy="workflow-toggle">Workflow</v-btn>
+            <v-btn data-cy="job-toggle">Job</v-btn>
+          </v-btn-toggle>
+          <ViewToolbar
+            :groups="controlGroups"
+            @setOption="setOption"
+            size="40"
+          />
+        </v-col>
+      </v-row>
+
+      <!-- the inputs -->
+      <v-row
+        dense
+        class="flex-0-0"
+      >
+        <v-col cols="8">
+          <v-text-field
+            v-if="jobLog"
+            data-cy="job-id-input"
+            class="flex-grow-1 flex-column"
+            :model-value="relativeID"
+            @update:modelValue="debouncedUpdateRelativeID"
+            placeholder="cycle/task/job"
+            clearable
+          />
+          <v-text-field
+            v-else
+            data-cy="workflow-id-input"
+            v-model="workflowId"
+            disabled
+          />
+        </v-col>
+        <v-col cols="4">
+          <v-select
+            data-cy="file-input"
+            :label="fileLabel"
+            :disabled="fileDisabled"
+            :items="logFiles"
+            v-model="file"
+            clearable
+            :menu-props="{ 'data-cy': 'file-input-menu' }"
+          />
+        </v-col>
+      </v-row>
+
+      <!-- the status line -->
+      <v-row
+        dense
+        class="flex-0-0"
+      >
+        <v-col
+          v-if="results.path"
+          class="d-flex align-center overflow-x-auto text-pre"
         >
-          {{ results.connected ? 'Connected' : 'Reconnect' }}
-        </v-chip>
-        <span
-          data-cy="log-path"
-          style="padding-left: 0.5em; color: rgb(150,150,150);"
-        >
-          {{ results.path }}
-        </span>
-      </v-col>
-    </v-row>
+          <v-chip
+            data-cy="connected-icon"
+            variant="outlined"
+            class="flex-shrink-0"
+            v-bind="results.connected ? {
+              color: 'success',
+              prependIcon: $options.icons.mdiPowerPlug,
+            } : {
+              color: 'error',
+              prependIcon: $options.icons.mdiPowerPlugOff,
+              onClick: updateQuery
+            }"
+          >
+            {{ results.connected ? 'Connected' : 'Reconnect' }}
+          </v-chip>
+          <span
+            data-cy="log-path"
+            style="padding-left: 0.5em; color: rgb(150,150,150);"
+          >
+            {{ results.path }}
+          </span>
+        </v-col>
+      </v-row>
+    </v-container>
 
     <!-- the log file viewer -->
-    <v-row>
+    <v-row
+      no-gutters
+      class="overflow-auto px-4 pb-2"
+    >
       <v-col>
         <v-skeleton-loader
           v-if="id && file && results.connected == null"
           type="text@5"
-          class="mx-n4"
+          class="mx-n4 align-content-start"
         />
         <template v-else>
           <v-alert

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -50,7 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <ViewToolbar
             :groups="controlGroups"
             @setOption="setOption"
-            size="40"
+            :size="toolbarBtnSize"
           />
         </v-col>
       </v-row>
@@ -77,7 +77,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             disabled
           />
         </v-col>
-        <v-col cols="4">
+        <v-col
+          cols="4"
+          class="d-flex col-gap-2"
+        >
           <v-select
             data-cy="file-input"
             :label="fileLabel"
@@ -87,6 +90,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             clearable
             :menu-props="{ 'data-cy': 'file-input-menu' }"
           />
+          <v-btn
+            @click="() => this.updateLogFileList(false)"
+            v-bind="toolbarBtnProps"
+            data-cy="refresh-files"
+          >
+            <v-icon :icon="$options.icons.mdiFolderRefresh"/>
+            <v-tooltip>Refresh file list</v-tooltip>
+          </v-btn>
         </v-col>
       </v-row>
 
@@ -173,6 +184,7 @@ import {
   mdiWrap,
 } from '@mdi/js'
 import { getPageTitle } from '@/utils/index'
+import { btnProps } from '@/utils/viewToolbar'
 import graphqlMixin from '@/mixins/graphql'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import {
@@ -361,6 +373,9 @@ export default {
       relativeID.value = value
     }, 500)
 
+    /** View toolbar button size */
+    const toolbarBtnSize = '40'
+
     return {
       // the log subscription query
       query: ref(null),
@@ -381,6 +396,8 @@ export default {
       wordWrap,
       reset,
       debouncedUpdateRelativeID,
+      toolbarBtnSize,
+      toolbarBtnProps: btnProps(toolbarBtnSize),
     }
   },
 
@@ -404,12 +421,6 @@ export default {
               value: this.wordWrap,
               key: 'wordWrap',
             },
-            {
-              title: 'Refresh file list',
-              icon: mdiFolderRefresh,
-              action: 'callback',
-              callback: () => { this.updateLogFileList(false) }
-            }
           ]
         }
       ],
@@ -555,6 +566,7 @@ export default {
   // Misc options
   icons: {
     mdiFileAlertOutline,
+    mdiFolderRefresh,
     mdiPowerPlug,
     mdiPowerPlugOff,
   }

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -481,6 +481,12 @@ export default {
         this.handleNoLogFiles()
         return
       }
+
+      if (!this.id) {
+        // id has been cleared while we were waiting for the query to return
+        return
+      }
+
       const logFiles = result.data.logFiles?.files ?? []
 
       // reset the file if it is not present in the new selection

--- a/tests/e2e/specs/log.cy.js
+++ b/tests/e2e/specs/log.cy.js
@@ -37,6 +37,16 @@ function expectFileListContains (items) {
     .should('have.length', items.length)
 }
 
+/**
+ * Get the max width of the given elements.
+ *
+ * @param {JQuery<HTMLElement>} $els
+ * @returns {number}
+ */
+function getMaxLineWidth ($els) {
+  return Math.max(...Array.from($els, (el) => el.offsetWidth))
+}
+
 describe('Log View', () => {
   beforeEach(() => {
     cy.visit('/#/log/one')
@@ -75,15 +85,29 @@ describe('Log View', () => {
 
     // the workflow log files list should have been populated by the query
     expectFileListContains(workflowLogFiles)
+  })
 
-    // toggle timestamps
-    cy.get('.c-view-toolbar button.Timestamps')
+  it('toggles timestamps', () => {
+    cy.get('.c-view-toolbar [data-cy=control-timestamps]')
       .click()
-      .get('[data-cy=log-viewer] pre > *:first')
+      .get('[data-cy=log-viewer] span:first')
       .invoke('text')
       .then((text) => {
         expect(workflowLogLines[0].endsWith(text)).to.equal(true)
         expect(text.length).to.be.lessThan(workflowLogLines[0].length)
+      })
+  })
+
+  it('toggles word wrap', () => {
+    cy.get('[data-cy=log-viewer] span')
+      .then(($els) => {
+        const nonWrappedMaxWidth = getMaxLineWidth($els)
+        cy.get('.c-view-toolbar [data-cy=control-wordWrap]')
+          .click()
+        cy.get('[data-cy=log-viewer] span')
+          .then(($els) => {
+            expect(getMaxLineWidth($els)).to.be.lessThan(nonWrappedMaxWidth)
+          })
       })
   })
 
@@ -93,7 +117,7 @@ describe('Log View', () => {
     cy.get('[data-cy=job-toggle]')
       .click()
       // the old log file lines should have been wiped
-      .get('[data-cy=log-viewer] > pre')
+      .get('[data-cy=log-viewer]')
       .should('be.empty')
       .get('[data-cy=file-input] input')
       .should('be.disabled')
@@ -102,7 +126,7 @@ describe('Log View', () => {
     cy.get('[data-cy=job-id-input]')
       .find('input')
       .type('1/')
-      .get('[data-cy=log-viewer] > pre')
+      .get('[data-cy=log-viewer]')
       .should('be.empty')
       .get('[data-cy=file-input] input')
       .should('be.disabled')

--- a/tests/unit/utils/viewToolbar.spec.js
+++ b/tests/unit/utils/viewToolbar.spec.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { btnIconFontSize } from '@/utils/viewToolbar'
+
+describe('btnIconFontSize', () => {
+  it.each([
+    { size: '28', expected: '0.75rem' },
+    { size: '40', expected: '1rem' },
+    { size: '48', expected: '1.25rem' },
+    { size: 'large', expected: undefined },
+  ])('btnIconFontSize($size) -> $expected', ({ size, expected }) => {
+    expect(btnIconFontSize(size)).toBe(expected)
+  })
+})


### PR DESCRIPTION
Addresses numerous usability concerns raised by users:

- Close #1285 
- Close #1667
- Made the log display area scroll only, leaving the toolbar pinned to the top
- Moved the file list refresh button next to the file list dropdown

#### Before

![image](https://github.com/cylc/cylc-ui/assets/61982285/4445b498-c7e6-457a-9134-dcd84183c60d)


#### After

![image](https://github.com/cylc/cylc-ui/assets/61982285/e4b94de5-dc5f-4d30-aada-1598ac4a48f2)

With word wrapping turned on:

![image](https://github.com/cylc/cylc-ui/assets/61982285/d4d415a6-1bef-42bf-bbbc-d09606b7c357)


#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
