### PR TITLE
Graph view: use `initialOptions` to save & restore view state on navigation

### DIFF
--- a/changes.d/1717.feat.md
+++ b/changes.d/1717.feat.md
@@ -1,0 +1,1 @@
+More view options are now remembered & restored when navigating between workflows.

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -639,7 +639,7 @@ export default {
       // once nodeDimensions have rendered for the first time
       // we prevent further refreshing by setting initialLoad to false
       if (nodeDimensions) {
-        if (this.initialLoad === true) { this.initialLoad = false }
+        if (this.initialLoad) { this.initialLoad = false }
       } else {
         return
       }
@@ -740,7 +740,6 @@ export default {
       // do a final refresh
       if (!this.autoRefresh) {
         this.updateTimer()
-        this.refresh()
       }
     }
   }

--- a/tests/e2e/specs/graph.cy.js
+++ b/tests/e2e/specs/graph.cy.js
@@ -37,6 +37,31 @@ function checkGraphLayoutPerformed ($el, depth = 0) {
   }
 }
 
+function addView (view) {
+  cy.get('[data-cy=add-view-btn]').click()
+  cy.get(`#toolbar-add-${view}-view`).click()
+    // wait for menu to close
+    .should('not.be.exist')
+}
+
+function checkRememberToolbarSettings (selector, stateBefore, stateAfter) {
+  cy
+    .get(selector)
+    .find('.v-btn')
+    .should(stateBefore, 'text-blue')
+    .click()
+  // Navigate away
+  cy.visit('/#/')
+  cy.get('.c-dashboard')
+  // Navigate back
+  cy.visit('/#/workspace/one')
+  waitForGraphLayout()
+  cy
+    .get(selector)
+    .find('.v-btn')
+    .should(stateAfter, 'text-blue')
+}
+
 describe('Graph View', () => {
   it('should load', () => {
     cy.visit('/#/graph/one')
@@ -68,5 +93,41 @@ describe('Graph View', () => {
       .children()
       .should('have.length', 10)
       .should('be.visible')
+  })
+
+  it('loads graph when switching between workflows', () => {
+    cy.visit('/#/workspace/one')
+    addView('Graph')
+    waitForGraphLayout()
+    cy.visit('/#/workspace/other/multi/run2')
+    addView('Graph')
+    waitForGraphLayout()
+    cy
+    // there should be 2 graph nodes (all on-screen)
+      .get('.c-graph:first')
+      .find('.graph-node-container')
+      .should('be.visible')
+      .should('have.length', 2)
+    cy.visit('/#/workspace/one')
+    cy
+    // there should be 7 graph nodes (all on-screen)
+      .get('.c-graph:first')
+      .find('.graph-node-container')
+      .should('be.visible')
+      .should('have.length', 7)
+  })
+
+  it('remembers autorefresh setting when switching between workflows', () => {
+    cy.visit('/#/workspace/one')
+    addView('Graph')
+    waitForGraphLayout()
+    checkRememberToolbarSettings('[data-cy=control-autoRefresh]', 'have.class', 'not.have.class')
+  })
+
+  it('remembers transpose setting when switching between workflows', () => {
+    cy.visit('/#/workspace/one')
+    addView('Graph')
+    waitForGraphLayout()
+    checkRememberToolbarSettings('[data-cy=control-transpose]', 'not.have.class', 'have.class')
   })
 })


### PR DESCRIPTION
These changes build on the work undertaken to save & restore workspace layout on navigation https://github.com/cylc/cylc-ui/pull/1664

Which is part of a larger issue https://github.com/cylc/cylc-ui/issues/662

There was an equivalent pull request for the log view https://github.com/cylc/cylc-ui/pull/1688
There is an equivalent pull request for the tree view which this builds on: https://github.com/cylc/cylc-ui/pull/1705
There is an equivalent pull request for the table view which this builds on: https://github.com/cylc/cylc-ui/pull/1711

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
