### PR TITLE
GH Actions: add timeouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   unit-test-and-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,6 +53,7 @@ jobs:
 
   cypress-run:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We use timeouts on GH Actions to stop this sort of thing where something went wrong and it hung for a long time:

![image](https://github.com/cylc/cylc-ui/assets/61982285/d06bd97e-2c5a-490d-9def-065e6d66f63a)


https://github.com/cylc/cylc-ui/actions/runs/8344029991/job/22835513719
