### PR TITLE
Prepare release: 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "license": "GPL-3.0-only",
   "type": "module",
+  "bugs": {
+    "url": "https://github.com/cylc/cylc-ui/issues"
+  },
   "scripts": {
     "build": "vite build",
     "build:watch": "yarn run build --watch --mode development",
@@ -95,9 +98,6 @@
     "react-dom": {
       "optional": true
     }
-  },
-  "bugs": {
-    "url": "https://github.com/cylc/cylc-ui/issues"
   },
   "packageManager": "yarn@4.1.1"
 }


### PR DESCRIPTION
#1733 release stage 2 didn't run because (and I didn't realise this) GH Actions skips if the head commit of a PR contains `[skip ci]` in the message even for a normal merge