### PR TITLE
toolbar: add n-window-selector

### DIFF
--- a/changes.d/1755.feat.md
+++ b/changes.d/1755.feat.md
@@ -1,0 +1,1 @@
+Add a toolbar button for changing the graph window extent.

--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -227,7 +227,7 @@ export default {
         // NOTE: cycle point nodes don't have associated node data at present
         ret += ' - '
         if (this.node.type === 'workflow') {
-          ret += this.node.node.statusMsg || 'state unknown'
+          ret += this.node.node.statusMsg || this.node.node.status || 'state unknown'
         } else {
           ret += this.node.node.state || 'state unknown'
           if (this.node.node.isHeld) {

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -86,6 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <!-- n-window selector -->
       <v-chip
+        :disabled="isStopped"
         link
         size="small"
       >
@@ -356,9 +357,6 @@ export default {
         )
       }
     },
-    userInitials () {
-      return this.user.username[0].toUpperCase()
-    },
     nEdgeDistance () {
       // the graph window distance reported by the scheduler
       return this.currentWorkflow?.node?.nEdgeDistance
@@ -381,7 +379,7 @@ export default {
     },
     nEdgeDistance (newVal) {
       // the scheduler has reported that the window size has changed
-      if (newVal !== undefined) {
+      if (newVal != undefined) {
         this.nWindow = newVal
       }
     }

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -51,6 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-cylc-object="currentWorkflow"
           :icon="$options.icons.menu"
           size="small"
+          density="comfortable"
         />
 
         <v-btn
@@ -60,6 +61,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-if="!isRunning"
           @click="onClickPlay"
           size="small"
+          density="comfortable"
         />
 
         <v-btn
@@ -69,6 +71,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-if="isRunning"
           @click="onClickReleaseHold"
           size="small"
+          density="comfortable"
         />
 
         <v-btn
@@ -77,8 +80,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :disabled="!enabled.stopToggle"
           @click="onClickStop"
           size="small"
+          density="comfortable"
         />
       </div>
+
+      <!-- n-window selector -->
+      <v-chip
+        link
+        size="small"
+      >
+        N={{ nWindow }}
+        <v-menu activator="parent" :close-on-content-click="false">
+          <v-card title="Graph Window Depth">
+            <v-card-subtitle>
+              This changes the number of tasks which are displayed.
+
+              Higher values may impact performance.
+            </v-card-subtitle>
+            <v-card-text>
+              <v-select
+                density="compact"
+                v-model="nWindow"
+                :items="[0,1,2,3]"
+              />
+            </v-card-text>
+          </v-card>
+        </v-menu>
+      </v-chip>
 
       <!-- workflow status message -->
       <span class="status-msg text-md-body-1 text-body-2">
@@ -175,6 +203,48 @@ import graphql from '@/mixins/graphql'
 import {
   mutationStatus
 } from '@/utils/aotf'
+import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
+import SubscriptionQuery from '@/model/SubscriptionQuery.model'
+import gql from 'graphql-tag'
+
+const QUERY = gql(`
+subscription Workflow ($workflowId: ID) {
+  deltas(workflows: [$workflowId]) {
+    added {
+      ...AddedDelta
+    }
+    updated (stripNull: true) {
+      ...UpdatedDelta
+    }
+    pruned {
+      ...PrunedDelta
+    }
+  }
+}
+
+fragment WorkflowData on Workflow {
+  id
+  status
+  statusMsg
+  nEdgeDistance
+}
+
+fragment AddedDelta on Added {
+  workflow {
+    ...WorkflowData
+  }
+}
+
+fragment UpdatedDelta on Updated {
+  workflow {
+    ...WorkflowData
+  }
+}
+
+fragment PrunedDelta on Pruned {
+  workflow
+}
+`)
 
 export default {
   name: 'Toolbar',
@@ -185,7 +255,8 @@ export default {
   },
 
   mixins: [
-    graphql
+    graphql,
+    subscriptionComponentMixin
   ],
 
   props: {
@@ -206,13 +277,24 @@ export default {
       play: null,
       paused: null,
       stop: null
-    }
+    },
+    nWindow: 1
   }),
 
   computed: {
     ...mapState('app', ['title']),
     ...mapState('user', ['user']),
     ...mapState('workflows', ['cylcTree']),
+    query () {
+      return new SubscriptionQuery(
+        QUERY,
+        this.variables,
+        'workflow',
+        [],
+        /* isDelta */ true,
+        /* isGlobalCallback */ true
+      )
+    },
     currentWorkflow () {
       return this.cylcTree.$index[this.workflowId]
     },
@@ -273,6 +355,13 @@ export default {
           )
         )
       }
+    },
+    userInitials () {
+      return this.user.username[0].toUpperCase()
+    },
+    nEdgeDistance () {
+      // the graph window distance reported by the scheduler
+      return this.currentWorkflow?.node?.nEdgeDistance
     }
   },
 
@@ -285,6 +374,16 @@ export default {
     },
     isStopped () {
       this.expecting.stop = null
+    },
+    nWindow (newVal) {
+      // the user has requested to change the window size
+      this.setGraphWindow(newVal)
+    },
+    nEdgeDistance (newVal) {
+      // the scheduler has reported that the window size has changed
+      if (newVal !== undefined) {
+        this.nWindow = newVal
+      }
     }
   },
 
@@ -318,6 +417,13 @@ export default {
           this.expecting.stop = WorkflowState.STOPPING
         }
       })
+    },
+    setGraphWindow (nWindow) {
+      this.$workflowService.mutate(
+        'setGraphWindowExtent',
+        this.currentWorkflow.id,
+        { nEdgeDistance: nWindow }
+      )
     },
     startCase,
   },

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -379,7 +379,7 @@ export default {
     },
     nEdgeDistance (newVal) {
       // the scheduler has reported that the window size has changed
-      if (newVal != undefined) {
+      if (newVal !== undefined) {
         this.nWindow = newVal
       }
     }

--- a/src/services/workflow.service.js
+++ b/src/services/workflow.service.js
@@ -109,14 +109,17 @@ class WorkflowService {
    * @param {string} id
    * @returns {Promise<MutationResponse>}
    */
-  async mutate (mutationName, id) {
+  async mutate (mutationName, id, args = {}) {
     const mutation = await this.getMutation(mutationName)
     return await mutate(
       mutation,
-      getMutationArgsFromTokens(
-        mutation,
-        tokenise(id)
-      ),
+      {
+        ...getMutationArgsFromTokens(
+          mutation,
+          tokenise(id),
+        ),
+        ...args
+      },
       this.apolloClient
     )
   }

--- a/tests/unit/components/cylc/workflow/toolbar.vue.spec.js
+++ b/tests/unit/components/cylc/workflow/toolbar.vue.spec.js
@@ -21,6 +21,9 @@ import { mount } from '@vue/test-utils'
 import storeOptions from '@/store/options'
 import Toolbar from '@/components/cylc/workflow/Toolbar.vue'
 import CylcObjectPlugin from '@/components/cylc/cylcObject/plugin'
+import sinon from 'sinon'
+import WorkflowService from '@/services/workflow.service'
+const $workflowService = sinon.createStubInstance(WorkflowService)
 
 describe('Workspace toolbar component', () => {
   let store
@@ -35,6 +38,7 @@ describe('Workspace toolbar component', () => {
     const wrapper = mount(Toolbar, {
       global: {
         plugins: [store, createVuetify(), CylcObjectPlugin],
+        mocks: { $workflowService },
       },
       props: {
         views: [],


### PR DESCRIPTION
* Closes #864
* Add a selector for switching the n-window extent between 0 & 3 inclusive.
* The n-window value appears to be preserved when navigating back to the workflow.

![n-window-changing](https://github.com/cylc/cylc-ui/assets/16705946/5f6aef5e-6b9d-4460-9131-7af75850f4d6)



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included - seems to be hard to test meaningfully without true e2e tests (i.e. with live workflows).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] docs issue - https://github.com/cylc/cylc-doc/issues/719
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
