### PR TITLE
Table view: sort empty entries last regardless of sort order

### DIFF
--- a/src/components/cylc/common/sort.js
+++ b/src/components/cylc/common/sort.js
@@ -28,21 +28,14 @@
 
 /**
  * The default comparator used to compare strings for cycle points, family proxies names,
- * task proxies names, and jobs. Note: nullish or empty strings are treated as infinity.
+ * task proxies names, and jobs.
  *
- * @param {string?} left
- * @param {string?} right
+ * @param {string} left
+ * @param {string} right
  * @returns {number}
  * @constructor
  */
 export const DEFAULT_COMPARATOR = (left, right) => {
-  if (!left && !right) {
-    return 0
-  } else if (!left) {
-    return 1
-  } else if (!right) {
-    return -1
-  }
   return left.toLowerCase().localeCompare(
     right.toLowerCase(),
     undefined,

--- a/src/components/cylc/common/sort.js
+++ b/src/components/cylc/common/sort.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,23 +28,29 @@
 
 /**
  * The default comparator used to compare strings for cycle points, family proxies names,
- * task proxies names, and jobs.
+ * task proxies names, and jobs. Note: nullish or empty strings are treated as infinity.
  *
- * @param {string} left
- * @param {string} right
+ * @param {string?} left
+ * @param {string?} right
  * @returns {number}
  * @constructor
  */
 export const DEFAULT_COMPARATOR = (left, right) => {
-  return left.toLowerCase()
-    .localeCompare(
-      right.toLowerCase(),
-      undefined,
-      {
-        numeric: true,
-        sensitivity: 'base'
-      }
-    )
+  if (!left && !right) {
+    return 0
+  } else if (!left) {
+    return 1
+  } else if (!right) {
+    return -1
+  }
+  return left.toLowerCase().localeCompare(
+    right.toLowerCase(),
+    undefined,
+    {
+      numeric: true,
+      sensitivity: 'base',
+    }
+  )
 }
 
 /**

--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -105,7 +105,10 @@ import Task from '@/components/cylc/Task.vue'
 import Job from '@/components/cylc/Job.vue'
 import { mdiChevronDown } from '@mdi/js'
 import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
-import { datetimeComparator } from '@/components/cylc/table/sort'
+import {
+  datetimeComparator,
+  numberComparator,
+} from '@/components/cylc/table/sort'
 import { dtMean } from '@/utils/tasks'
 import { useCyclePointsOrderDesc } from '@/composables/localStorage'
 import {
@@ -180,43 +183,43 @@ export default {
       title: 'Platform',
       key: 'latestJob.node.platform',
       sortable: true,
-      sort: (a, b) => DEFAULT_COMPARATOR(a ?? '', b ?? '')
+      sort: DEFAULT_COMPARATOR,
     },
     {
       title: 'Job Runner',
       key: 'latestJob.node.jobRunnerName',
       sortable: true,
-      sort: (a, b) => DEFAULT_COMPARATOR(a ?? '', b ?? '')
+      sort: DEFAULT_COMPARATOR,
     },
     {
       title: 'Job ID',
       key: 'latestJob.node.jobId',
       sortable: true,
-      sort: (a, b) => DEFAULT_COMPARATOR(a ?? '', b ?? '')
+      sort: DEFAULT_COMPARATOR,
     },
     {
       title: 'Submit',
       key: 'latestJob.node.submittedTime',
       sortable: true,
-      sort: (a, b) => datetimeComparator(a ?? '', b ?? '')
+      sort: datetimeComparator,
     },
     {
       title: 'Start',
       key: 'latestJob.node.startedTime',
       sortable: true,
-      sort: (a, b) => datetimeComparator(a ?? '', b ?? '')
+      sort: datetimeComparator,
     },
     {
       title: 'Finish',
       key: 'latestJob.node.finishedTime',
       sortable: true,
-      sort: (a, b) => datetimeComparator(a ?? '', b ?? '')
+      sort: datetimeComparator,
     },
     {
       title: 'Run Time',
       key: 'task.node.task.meanElapsedTime',
       sortable: true,
-      sort: (a, b) => parseInt(a ?? 0) - parseInt(b ?? 0)
+      sort: numberComparator,
     },
   ],
 

--- a/src/components/cylc/table/sort.js
+++ b/src/components/cylc/table/sort.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,6 @@
  * Comparator function for sorting datetime strings. Note: nullish or empty
  * strings are treated as infinity.
  *
- * @export
  * @param {*} a - The first element for comparison.
  * @param {*} b - The second element for comparison.
  * @return {number} A number > 0 if a > b, or < 0 if a < b, or 0 if a === b
@@ -27,6 +26,20 @@
 export function datetimeComparator (a, b) {
   a = (a ?? '') === '' ? Infinity : new Date(a).getTime()
   b = (b ?? '') === '' ? Infinity : new Date(b).getTime()
+  // Avoid return NaN for a === b === Infinity
+  return a === b ? 0 : a - b
+}
+
+/**
+ * Comparator function for sorting numbers. Note: nullish values are treated as infinity.
+ *
+ * @param {number?} a
+ * @param {number?} b
+ * @returns {number}
+ */
+export function numberComparator (a, b) {
+  a ??= Infinity
+  b ??= Infinity
   // Avoid return NaN for a === b === Infinity
   return a === b ? 0 : a - b
 }

--- a/src/components/cylc/table/sort.js
+++ b/src/components/cylc/table/sort.js
@@ -16,30 +16,23 @@
  */
 
 /**
- * Comparator function for sorting datetime strings. Note: nullish or empty
- * strings are treated as infinity.
+ * Comparator function for sorting datetime strings.
  *
- * @param {*} a - The first element for comparison.
- * @param {*} b - The second element for comparison.
+ * @param {string} a - The first element for comparison.
+ * @param {string} b - The second element for comparison.
  * @return {number} A number > 0 if a > b, or < 0 if a < b, or 0 if a === b
  */
 export function datetimeComparator (a, b) {
-  a = (a ?? '') === '' ? Infinity : new Date(a).getTime()
-  b = (b ?? '') === '' ? Infinity : new Date(b).getTime()
-  // Avoid return NaN for a === b === Infinity
-  return a === b ? 0 : a - b
+  return new Date(a) - new Date(b)
 }
 
 /**
- * Comparator function for sorting numbers. Note: nullish values are treated as infinity.
+ * Comparator function for sorting numbers.
  *
- * @param {number?} a
- * @param {number?} b
+ * @param {number} a
+ * @param {number} b
  * @returns {number}
  */
 export function numberComparator (a, b) {
-  a ??= Infinity
-  b ??= Infinity
-  // Avoid return NaN for a === b === Infinity
-  return a === b ? 0 : a - b
+  return a - b
 }

--- a/tests/e2e/specs/table.cy.js
+++ b/tests/e2e/specs/table.cy.js
@@ -117,13 +117,13 @@ describe('Table view', () => {
       cy.get('@dTHeader')
         .click()
         .get('tbody > :nth-child(1) > :nth-child(10)')
-        .should(($ele) => {
-          expect($ele.text().trim()).equal('')
-        })
-        .get('tbody > :nth-child(6) > :nth-child(10)')
         .contains('00:00:12')
-        .get('tbody > :nth-child(7) > :nth-child(10)')
+        .get('tbody > :nth-child(2) > :nth-child(10)')
         .contains('00:00:04')
+        .get('tbody > :nth-child(3) > :nth-child(10)')
+        .should(($ele) => {
+          expect($ele.text().trim()).equal('') // no value still sorted after numbers
+        })
     })
   })
 })

--- a/tests/e2e/specs/table.cy.js
+++ b/tests/e2e/specs/table.cy.js
@@ -100,27 +100,30 @@ describe('Table view', () => {
         .should('be.visible')
     })
     it('displays and sorts mean run time', () => {
-      cy
-        // sort dt-mean ascending
-        .get('.c-table')
+      // sort dt-mean ascending
+      cy.get('.c-table')
         .contains('th', 'Run Time').as('dTHeader')
         .click()
-
-        // check 0 is at the top (1st row, 10th column)
+        // (1st row, 10th column)
         .get('tbody > :nth-child(1) > :nth-child(10)')
+        .contains('00:00:04')
+        .get('tbody > :nth-child(2) > :nth-child(10)')
+        .contains('00:00:12')
+        .get('tbody > :nth-child(3) > :nth-child(10)')
         .should(($ele) => {
-          expect($ele.text().trim()).equal('') // no value sorted first
+          expect($ele.text().trim()).equal('') // no value sorted after numbers
         })
-
         // sort dt-mean descending
-        .get('@dTHeader')
+      cy.get('@dTHeader')
         .click()
-
-        // check 7 is at the top (1st row, 10th column)
         .get('tbody > :nth-child(1) > :nth-child(10)')
         .should(($ele) => {
-          expect($ele.text().trim()).equal('00:00:12')
+          expect($ele.text().trim()).equal('')
         })
+        .get('tbody > :nth-child(6) > :nth-child(10)')
+        .contains('00:00:12')
+        .get('tbody > :nth-child(7) > :nth-child(10)')
+        .contains('00:00:04')
     })
   })
 })

--- a/tests/unit/components/cylc/common/sort.spec.js
+++ b/tests/unit/components/cylc/common/sort.spec.js
@@ -27,10 +27,6 @@ describe('DEFAULT_COMPARATOR', () => {
     ['1', '2', -1],
     ['01', '1', 0],
     ['20000101T0000Z', '20000101T0001Z', -1],
-    [undefined, 'a', 1],
-    ['a', undefined, -1],
-    [undefined, undefined, 0],
-    [undefined, null, 0],
   ])('(%o, %o) -> %o', (a, b, expected) => {
     expect(DEFAULT_COMPARATOR(a, b)).toEqual(expected)
   })

--- a/tests/unit/components/cylc/common/sort.spec.js
+++ b/tests/unit/components/cylc/common/sort.spec.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DEFAULT_COMPARATOR } from '@/components/cylc/common/sort'
+
+describe('DEFAULT_COMPARATOR', () => {
+  it.each([
+    ['a', 'b', -1],
+    ['b', 'a', 1],
+    ['a', 'a', 0],
+    ['A', 'a', 0],
+    ['A', 'b', -1],
+    ['1', '2', -1],
+    ['01', '1', 0],
+    ['20000101T0000Z', '20000101T0001Z', -1],
+    [undefined, 'a', 1],
+    ['a', undefined, -1],
+    [undefined, undefined, 0],
+    [undefined, null, 0],
+  ])('(%o, %o) -> %o', (a, b, expected) => {
+    expect(DEFAULT_COMPARATOR(a, b)).toEqual(expected)
+  })
+})

--- a/tests/unit/components/cylc/table/sort.spec.js
+++ b/tests/unit/components/cylc/table/sort.spec.js
@@ -26,11 +26,6 @@ describe('datetimeComparator()', () => {
     expect(datetimeComparator('2022-09-26T12:30:01Z', '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
     expect(datetimeComparator('2022-09-26T12:30:00Z', '2022-09-26T12:30:00Z')).to.equal(0)
   })
-  it('should rank nullish as higher than proper datetimes', () => {
-    expect(datetimeComparator('', '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
-    expect(datetimeComparator(undefined, '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
-    expect(datetimeComparator(undefined, '')).to.equal(0)
-  })
 })
 
 describe('numberComparator()', () => {
@@ -38,10 +33,6 @@ describe('numberComparator()', () => {
     [1, 2, -1],
     [2, 1, 1],
     [1, 1, 0],
-    [undefined, 1, Infinity],
-    [1, undefined, -Infinity],
-    [undefined, undefined, 0],
-    [undefined, null, 0],
   ])('(%o, %o) -> %o', (a, b, expected) => {
     expect(numberComparator(a, b)).toEqual(expected)
   })

--- a/tests/unit/components/cylc/table/sort.spec.js
+++ b/tests/unit/components/cylc/table/sort.spec.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,7 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { datetimeComparator } from '@/components/cylc/table/sort'
+import {
+  datetimeComparator,
+  numberComparator,
+} from '@/components/cylc/table/sort'
 
 describe('datetimeComparator()', () => {
   it('should rank datetime strings appropriately', () => {
@@ -27,5 +30,19 @@ describe('datetimeComparator()', () => {
     expect(datetimeComparator('', '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
     expect(datetimeComparator(undefined, '2022-09-26T12:30:00Z')).to.be.greaterThan(0)
     expect(datetimeComparator(undefined, '')).to.equal(0)
+  })
+})
+
+describe('numberComparator()', () => {
+  it.each([
+    [1, 2, -1],
+    [2, 1, 1],
+    [1, 1, 0],
+    [undefined, 1, Infinity],
+    [1, undefined, -Infinity],
+    [undefined, undefined, 0],
+    [undefined, null, 0],
+  ])('(%o, %o) -> %o', (a, b, expected) => {
+    expect(numberComparator(a, b)).toEqual(expected)
   })
 })


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1255

When sorting by e.g. Submitted Time, an absence of a value means a job has not yet been submitted by the task that this row corresponds to. If sorting ascending, it is therefore logical that empty values should come last. But if sorting descending, you are probably interested in the newest jobs so again the empty values should come last. Note this is somewhat different behaviour to the linked issue.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [x] No changelog entry included as minor
