### PR TITLE
Renovate: address warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "automergeStrategy": "squash",
   "packageRules": [
     {
-      "matchPackageNames": ["yarn"],
+      "matchDepNames": ["yarn"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Address warning in [dependency dashboard](https://github.com/cylc/cylc-ui/issues/1014):

![image](https://github.com/renovatebot/renovate/assets/61982285/8b039034-c420-41ce-98ed-2e4c9a4bdad1)

Following advice from https://github.com/renovatebot/renovate/discussions/28753#discussioncomment-9276162

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
