### PR TITLE
Include XSRF token in userprofile request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ below.
  - Jamie Allen
  - Christopher Bennett
  - Mark Dawson
+ - Min RK
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/changes.d/1778.fix
+++ b/changes.d/1778.fix
@@ -1,0 +1,1 @@
+Compatibility with JupyterHub 4.1 XSRF changes

--- a/src/graphql/graphiql.js
+++ b/src/graphql/graphiql.js
@@ -18,7 +18,8 @@
 // Code related to GraphiQL
 
 import { parse } from 'graphql'
-import { createGraphQLUrls, getCylcHeaders } from '@/graphql/index'
+import { createGraphQLUrls } from '@/graphql/index'
+import { getCylcHeaders } from '@/utils/urls'
 
 // TODO: https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher/issues/16
 //       the functions hasSubscriptionOperation and graphQLFetcher are both from

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -27,7 +27,7 @@ import { WebSocketLink } from '@apollo/client/link/ws'
 import { setContext } from '@apollo/client/link/context'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { store } from '@/store/index'
-import { createUrl } from '@/utils/urls'
+import { createUrl, getCylcHeaders } from '@/utils/urls'
 
 /** @typedef {import('subscriptions-transport-ws').ClientOptions} ClientOptions */
 
@@ -44,21 +44,6 @@ export function createGraphQLUrls () {
     httpUrl,
     wsUrl
   }
-}
-
-/**
- * Get request headers for use with UI Server requests.
- *
- * - Adds X-XSRFToken header for hubless token based auth.
- */
-export function getCylcHeaders () {
-  const xsrfToken = document.cookie.match('\\b_xsrf=([^;]*)\\b')
-  const cylcHeaders = {}
-  if (Array.isArray(xsrfToken) && xsrfToken.length > 0) {
-    // pick the last match
-    cylcHeaders['X-XSRFToken'] = xsrfToken.splice(-1)
-  }
-  return cylcHeaders
 }
 
 /**

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -17,7 +17,7 @@
 
 import axios from 'axios'
 import User from '@/model/User.model'
-import { createUrl } from '@/utils/urls'
+import { createUrl, getCylcHeaders } from '@/utils/urls'
 
 class UserService {
   /**
@@ -25,7 +25,10 @@ class UserService {
    * @returns {Promise<*>} - a promise that dispatches Vuex action
    */
   getUserProfile () {
-    return axios.get(createUrl('userprofile')).then(({ data }) => {
+    return axios.get(
+      createUrl('userprofile'),
+      { headers: getCylcHeaders() },
+    ).then(({ data }) => {
       return new User(
         data.name,
         data.groups,

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -72,6 +72,22 @@ function createUrl (path, websockets = false, baseOnly = false) {
   return normalize(url)
 }
 
+/**
+ * Get request headers for use with UI Server requests.
+ *
+ * - Adds X-XSRFToken header cookie-based auth.
+ */
+function getCylcHeaders () {
+  const xsrfToken = document.cookie.match('\\b_xsrf=([^;]*)\\b')
+  const cylcHeaders = {}
+  if (Array.isArray(xsrfToken) && xsrfToken.length > 0) {
+    // pick the last match
+    cylcHeaders['X-XSRFToken'] = xsrfToken.splice(-1)
+  }
+  return cylcHeaders
+}
+
 export {
-  createUrl
+  createUrl,
+  getCylcHeaders,
 }


### PR DESCRIPTION
JupyterHub 4.1 applies XSRF checks consistently to authenticated GET requests, so apply the same `getCylcHeaders` logic in the graphQL POST request to all requests (userprofile was the only other one I found). As a result, the `getCylcHeaders` is moved to a common location in `utils/url`, rather than being confined to graphQL.

This solves the userprofile request, described in https://github.com/jupyterhub/jupyterhub/issues/4800

Together with https://github.com/cylc/cylc-uiserver/pull/592, cylc works with JupyterHub 4.1.5


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are not needed for this change
- [x] `CHANGES.md` entry included if this is a change that can affect users