### PR TITLE
Fix N-window selector sending mutation upon navigation to stopped workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preview": "node ./scripts/concurrently.cjs serve:jupyterhub preview",
     "serve": "node ./scripts/concurrently.cjs serve:jupyterhub serve:vue",
     "serve:vue": "vite --mode offline",
-    "serve:jupyterhub": "nodemon -e js,mjs,cjs,json src/services/mock/json-server.cjs",
+    "serve:jupyterhub": "nodemon src/services/mock/json-server.cjs --watch src/services/mock/",
     "test:component": "cypress open --component",
     "test:e2e": "yarn run serve e2e:open",
     "test:unit": "vitest",

--- a/src/components/cylc/workflow/Toolbar.vue
+++ b/src/components/cylc/workflow/Toolbar.vue
@@ -89,12 +89,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :disabled="isStopped"
         link
         size="small"
+        data-cy="n-win-selector"
       >
         N={{ nWindow }}
         <v-menu
           activator="parent"
           :close-on-content-click="false"
           max-width="400"
+          data-cy="n-win-popup"
         >
           <v-card title="Graph Window Depth">
             <v-card-text>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -38,15 +38,30 @@ export const getPageTitle = (key, params = {}) => {
  * @param {import('vue').WatchCallback} callback
  * @param {import('vue').WatchOptions?} options
  */
-export const when = (source, callback, options = {}) => {
+export function when (source, callback, options = {}) {
   const unwatch = watch(
     source,
     (ready) => {
       if (ready) {
-        callback()
         unwatch()
+        callback()
       }
     },
     { immediate: true, ...options }
   )
+}
+
+/**
+ * Return a promise that resolves when the source becomes truthy.
+ *
+ * Awaitable version of when().
+ *
+ * @param {import('vue').WatchSource} source
+ * @param {import('vue').WatchOptions?} options
+ * @returns {Promise<void>}
+ */
+export function until (source, options = {}) {
+  return new Promise((resolve) => {
+    when(source, resolve, options)
+  })
 }

--- a/tests/e2e/specs/toolbar.cy.js
+++ b/tests/e2e/specs/toolbar.cy.js
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { mutationStatus } from '@/utils/aotf'
+import { Deferred } from '$tests/util'
+
 describe('Toolbar component', () => {
   it('Is displayed when we are looking at a workflow', () => {
     cy.visit('/#/workspace/one')
@@ -61,5 +64,70 @@ describe('Toolbar Component authenticated user', () => {
       .get('#core-app-bar')
       .get('.v-avatar')
       .should('have.text', 'U')
+  })
+})
+
+describe('N-window selector', () => {
+  /** Capture mutations. */
+  function captureGraphWinMutation () {
+    const mutations = []
+    const deferred = new Deferred()
+    cy.window().its('app.$workflowService').then((service) => {
+      // mock the workflow service's mutate method to catch high-level calls
+      service.mutate = async (name, id, args) => {
+        switch (name) {
+          case 'setGraphWindowExtent':
+            mutations.push(args.nEdgeDistance)
+            await deferred.promise
+            return [mutationStatus.SUCCEEDED, '']
+          default:
+            throw new Error('This mutation is not mocked by the tests')
+        }
+      }
+    })
+    return { mutations, deferred }
+  }
+
+  it('Is enabled for workflows that are not stopped', () => {
+    // Disabled for stopped workflow:
+    cy.visit('/#/workspace/multi/level/run1')
+      .get('#core-app-bar')
+      .find('[data-cy=n-win-selector]')
+      .should('have.attr', 'disabled')
+    // Enabled for running workflow:
+    cy.visit('/#/workspace/one')
+      .get('[data-cy=n-win-selector]')
+      .click()
+      .get('[data-cy=n-win-popup]')
+      .find('input')
+      .invoke('val')
+      .should('eq', '1')
+  })
+
+  it('Sets the n-window', () => {
+    cy.visit('/#/workspace/one')
+    const { mutations, deferred } = captureGraphWinMutation()
+    cy.get('[data-cy=n-win-selector]')
+      .click()
+      .get('[data-cy=n-win-popup]')
+      .find('[role=combobox]')
+      .click()
+      .invoke('attr', 'aria-owns').then((dropdownID) => {
+        cy.get(`#${dropdownID}`)
+          .contains('3')
+          .click()
+          .then(() => {
+            expect(mutations).to.deep.equal([3])
+            // Should show loading spinner while waiting for response
+            cy.get('[data-cy=n-win-popup] .v-progress-circular').as('loadingSpinner')
+              .should('be.visible').then(() => {
+                // Allow the "response" to complete
+                deferred.resolve()
+                cy.get('@loadingSpinner')
+                  .should('not.exist')
+                // Note we cannot mock websockets in Cypress so we cannot test the actual update of the n-window in the GraphQL subscription
+              })
+          })
+      })
   })
 })

--- a/tests/unit/utils/index.spec.js
+++ b/tests/unit/utils/index.spec.js
@@ -16,7 +16,7 @@
  */
 
 import { nextTick, ref } from 'vue'
-import { getPageTitle, when } from '@/utils/index'
+import { getPageTitle, when, until } from '@/utils/index'
 
 describe('getPageTitle()', () => {
   it('displays the application title correctly', () => {
@@ -24,11 +24,19 @@ describe('getPageTitle()', () => {
   })
 })
 
-describe('when()', () => {
-  it('watches source until true and then stops watching', async () => {
+describe.each([
+  { func: when, description: 'watches source until true and then stops watching' },
+  { func: until, description: 'returns a promise that resolves when source becomes true' },
+])('$func', ({ func, description }) => {
+  it(description, async () => {
     const source = ref(false)
     let counter = 0
-    when(source, () => counter++)
+    switch (func) {
+      case when:
+        when(source, () => counter++); break
+      case until:
+        until(source).then(() => counter++); break
+    }
     expect(counter).toEqual(0)
     source.value = true
     await nextTick()


### PR DESCRIPTION
Fixes an unreleased bug on master. Also adds some tests. Follow-up to #1755 

#### How to reproduce the bug on master

1. Start a workflow and use the UI to set the n-window to a value other than 1, e.g. 2
2. Stop the workflow
3. Navigate to the dashboard or a different workflow
4. Navigate back to the original workflow
5. You should see an error snackbar for a failed mutation

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included
- [x] No changelog entry needed as fixes unreleased bug

