### PR TITLE
Disable Edit Runtime in mutation menu when workflow is stopped/stopping

### DIFF
--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -118,7 +118,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import { mdiFilter, mdiFolderRefresh } from '@mdi/js'
 import { TaskStateNames } from '@/model/TaskState.model'
-import { WorkflowState } from '@/model/WorkflowState.model'
+import { WorkflowStateNames } from '@/model/WorkflowState.model'
 import Tree from '@/components/cylc/tree/Tree.vue'
 import { filterByName, filterByState } from '@/components/cylc/gscan/filters'
 import { sortedWorkflowTree } from '@/components/cylc/gscan/sort.js'
@@ -227,7 +227,7 @@ export default {
    * @type {{ [name: string]: string[] }}
    */
   allStates: {
-    'workflow state': WorkflowState.enumValues.map(x => x.name),
+    'workflow state': WorkflowStateNames,
     'task state': TaskStateNames,
   },
 }

--- a/src/model/WorkflowState.model.js
+++ b/src/model/WorkflowState.model.js
@@ -59,4 +59,7 @@ export const WorkflowStateOrder = new Map([
   [undefined, 9]
 ])
 
+/** @type {string[]} */
+export const WorkflowStateNames = WorkflowState.enumValues.map(({ name }) => name)
+
 export default WorkflowState

--- a/tests/unit/utils/aotf.spec.js
+++ b/tests/unit/utils/aotf.spec.js
@@ -74,7 +74,7 @@ describe('aotf (Api On The Fly)', () => {
       const output = {
         ...input,
         _title: 'Foo Bar',
-        _icon: aotf.mutationIcons[''],
+        _icon: aotf.getMutationIcon(),
         _shortDescription: 'Short description.',
         _help: 'Long\ndescription.\nValid for: stopped, paused workflows.',
         _validStates: ['stopped', 'paused']


### PR DESCRIPTION
Related to https://github.com/cylc/cylc-flow/pull/6095

Edit Runtime should be disabled in the mutation menu for stopped/stopping workflows as it is not possible/sensical to broadcast to them.

Includes some tidying

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No tests included (this is what TypeScript is for)
- [x] No changelog entry needed, as minor
