### PR TITLE
GH Actions: print draft changelog job summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,9 +57,7 @@ jobs:
         run: yarn run lint:compat
 
       - name: Towncrier - draft changelog
-        run: |
-          python3 -m pip install -q towncrier
-          towncrier build --draft --version $(node -p "require('./package.json').version")
+        uses: cylc/release-actions/towncrier-draft@v1
 
   cypress-run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It's kind of useful to be able to see the rendered changelog.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary

To see it, you can go to the Actions summary page https://github.com/cylc/cylc-ui/actions/runs/9082240185#summary-24958150609

![image](https://github.com/cylc/cylc-ui/assets/61982285/7329b788-0ee8-452e-85ba-1db8e7f414b3)

#### Needs

- https://github.com/cylc/release-actions/pull/72

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
