### PR TITLE
task: change expired icon

### DIFF
--- a/src/components/cylc/SVGTask.vue
+++ b/src/components/cylc/SVGTask.vue
@@ -127,32 +127,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           ry="7.5"
         />
       </g>
-      <!-- expired
-
-      -->
-      <g
-        class="expired"
-      >
-        <rect
-          x="50"
-          y="46"
-          width="42"
-          height="8"
-          rx="5"
-          ry="5"
-          transform="rotate(-90, 50, 50)"
-        />
-        <rect
-          x="50"
-          y="46"
-          width="30"
-          height="8"
-          rx="5"
-          ry="5"
-          transform="rotate(45, 50, 50)"
-        />
-      </g>
     </g>
+
     <!-- modifier
 
       Represents any task state modifiers e.g. isHeld, isRunahead, isQueued.
@@ -343,6 +319,8 @@ export default {
         // NOTE: ensure the outline is filled so that it can be clicked
         fill: $background;
         stroke: $foreground;
+        stroke-dasharray: 0;  // a solid line
+        stroke-linecap: round;  // rounded edges
       }
       .progress {
         fill: transparent;
@@ -361,10 +339,6 @@ export default {
         stroke: none;
       }
       .cross rect {
-        fill: none;
-        stroke: none;
-      }
-      .expired rect {
         fill: none;
         stroke: none;
       }
@@ -425,16 +399,9 @@ export default {
       }
     }
 
-    &.expired .status {
-      .outline {
-        fill: $foreground;
-      }
-      .dot {
-        fill: $background;
-      }
-      .expired rect {
-        fill: $background;
-      }
+    &.expired .status .outline {
+      fill: $background;
+      stroke-dasharray: 8 20;  // a dashed line
     }
 
     &.held .modifier {


### PR DESCRIPTION
Small proposal as a PR for consideration sometime after 8.3.0 release.

The task expired icon isn't the most obvious and could be a little better:

* Filled shapes are used for "finished" states (succeeded & failed), empty shapes are used for "non finished" states (waiting, preparing, submitted, submit-failed). Due to the nature of expiry, a non-finished state is more appropriate.
* The meaning of the clockface isn't especially obvious, especially as tasks in an expired state may now be the result of manual user intervention.

**Before:**

![task-expired](https://github.com/cylc/cylc-ui/assets/16705946/ad6954c7-2479-4e90-a5a4-5ad4dcf55fe3)


**After:**

![task-expired](https://github.com/cylc/cylc-ui/assets/16705946/29e79f4f-0dec-4628-886f-078b087de047)

This also uses fewer SVG elements which should make it more efficient (note the expired styling is only applied for expired icons).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.