### PR TITLE
Tests: fix mocking of apollo client

### DIFF
--- a/tests/unit/services/workflow.service.spec.js
+++ b/tests/unit/services/workflow.service.spec.js
@@ -18,6 +18,7 @@
 import { createStore } from 'vuex'
 import storeOptions from '@/store/options'
 import CylcTreeCallback from '@/services/treeCallback'
+import { vi } from 'vitest'
 import sinon from 'sinon'
 import { print } from 'graphql/language'
 import gql from 'graphql-tag'
@@ -26,7 +27,6 @@ import 'cross-fetch/polyfill'
 import Subscription from '@/model/Subscription.model'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
 import WorkflowService from '@/services/workflow.service'
-import * as graphqlModule from '@/graphql/index'
 import ViewState from '@/model/ViewState.model'
 import { TreeCallback, WorkflowCallback } from './testCallback'
 
@@ -37,10 +37,6 @@ describe('WorkflowService', () => {
    * @type {String}
    */
   const url = '/graphql'
-  /**
-   * @type {ApolloClient}
-   */
-  let apolloClient
   /**
    * @type {SubscriptionClient|null}
    */
@@ -67,12 +63,15 @@ describe('WorkflowService', () => {
   let subscription
   beforeEach(() => {
     sandbox.stub(console, 'debug')
-    apolloClient = sandbox.spy({
-      query: () => {},
-      subscribe: (options) => {}
-    })
+    vi.mock('@/graphql/index', () => ({
+      createApolloClient: () => ({
+        query: vi.fn(),
+        subscribe: () => ({
+          subscribe: vi.fn()
+        }),
+      })
+    }))
     subscriptionClient = null
-    sandbox.stub(graphqlModule, 'createApolloClient').returns(apolloClient)
     // TODO: really load some mutations
     sandbox.stub(WorkflowService.prototype, 'loadTypes').returns(
       Promise.resolve({


### PR DESCRIPTION
This mocking did not seem to be working, resulting in noisy warnings when running the tests:

```
stdout | tests/unit/services/workflow.service.spec.js > WorkflowService > startSubscriptions > should start pending subscriptions
Subscription error: Failed to parse URL from /graphql ViewState { enumKey: 'ERROR', enumOrdinal: 2 } TypeError: Failed to parse URL from /graphql
    at node:internal/deps/undici/undici:12502:13 {
  [cause]: TypeError: Invalid URL: /graphql
      at new URLImpl (C:\Users\ronnie.dutta\GitHub\cylc-ui\node_modules\whatwg-url\lib\URL-impl.js:23:13)
      at Object.exports.setup (C:\Users\ronnie.dutta\GitHub\cylc-ui\node_modules\whatwg-url\lib\URL.js:54:12)
      at new URL (C:\Users\ronnie.dutta\GitHub\cylc-ui\node_modules\whatwg-url\lib\URL.js:115:22)
      at new Request (node:internal/deps/undici/undici:4853:25)
      at fetch (node:internal/deps/undici/undici:9662:25)
      at fetch (node:internal/deps/undici/undici:12500:10)
      at value (node:internal/bootstrap/web/exposed-window-or-worker:72:12)
      at C:\Users\ronnie.dutta\GitHub\cylc-ui\node_modules\@apollo\client\link\http\createHttpLink.js:127:13
      at new Subscription (C:\Users\ronnie.dutta\GitHub\cylc-ui\node_modules\zen-observable\lib\Observable.js:197:34)
      at Observable.subscribe (C:\Users\ronnie.dutta\GitHub\cylc-ui\node_modules\zen-observable\lib\Observable.js:279:14)
}
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
