### PR TITLE
Try to fix E2E test flake on Firefox

### DIFF
--- a/tests/e2e/specs/userprofile.cy.js
+++ b/tests/e2e/specs/userprofile.cy.js
@@ -87,24 +87,25 @@ describe('User Profile', () => {
 
   it('Sets reduced animations mode', () => {
     const testMenu = (shouldAnimate) => {
-      let animationSpy
       cy.get('[data-c-interactive]:first')
         .click()
         .get('.c-mutation-menu').as('mutationMenu')
         .should('be.visible')
         .then(([$el]) => {
-          animationSpy = cy.spy($el, 'animate')
-        })
-        // Close menu:
-        .get('noscript').click({ force: true })
-        .get('@mutationMenu')
-        .should('not.exist')
-        .then(() => {
-          if (shouldAnimate) {
-            expect(animationSpy).to.be.called
-          } else {
-            expect(animationSpy).not.to.be.called
-          }
+          const animationSpy = cy.spy($el, 'animate')
+          // Close menu (wait because animation might interfere with click outside on Firefox):
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(400)
+          cy.get('noscript').click({ force: true })
+            .get('@mutationMenu')
+            .should('not.exist')
+            .then(() => {
+              if (shouldAnimate) {
+                expect(animationSpy).to.be.called
+              } else {
+                expect(animationSpy).not.to.be.called
+              }
+            })
         })
     }
 


### PR DESCRIPTION
Follow-up to #1775 

![User Profile -- Sets reduced animations mode (failed)](https://github.com/cylc/cylc-ui/assets/61982285/7df465f5-c23b-4af8-8da3-d9c460a99323)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
