### PR TITLE
Increase width of Edit Runtime dialog

### DIFF
--- a/changes.d/1888.feat.md
+++ b/changes.d/1888.feat.md
@@ -1,0 +1,1 @@
+Increased the width of the Edit Runtime dialog.

--- a/src/components/cylc/commandMenu/Menu.vue
+++ b/src/components/cylc/commandMenu/Menu.vue
@@ -92,7 +92,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <v-dialog
       v-if="dialogMutation"
       v-model="dialog"
-      width="700px"
+      :width="dialogMutation._dialogWidth ?? '700px'"
       max-width="100%"
       content-class="c-mutation-dialog mx-0"
     >

--- a/src/components/graphqlFormGenerator/components/MapItem.vue
+++ b/src/components/graphqlFormGenerator/components/MapItem.vue
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           v-bind="{ ...$attrs, ...$options.textFieldProps }"
         />
         <v-tooltip v-bind="tooltipProps">
-          <span>Pre-existing settings cannot be renamed</span>
+          <span><code>{{ modelValue.key }}</code><br/>(Pre-existing settings cannot be renamed)</span>
         </v-tooltip>
       </div>
     </v-col>

--- a/src/components/graphqlFormGenerator/components/MapItem.vue
+++ b/src/components/graphqlFormGenerator/components/MapItem.vue
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     class="c-key-val my-1"
     no-gutters
   >
-    <v-col cols="4">
+    <v-col cols="5">
       <div>
         <v-text-field
           placeholder="key"

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -304,6 +304,7 @@ export const dummyMutations = [
     _appliesTo: [cylcObjects.Namespace, cylcObjects.CyclePoint],
     _requiresInfo: true,
     _validStates: [WorkflowState.RUNNING.name, WorkflowState.PAUSED.name],
+    _dialogWidth: '1200px',
   },
   {
     name: 'log',


### PR DESCRIPTION
Closes #1874

For long env var names, they will be included in the hover tooltip so you can see them even if they are cut off in the text field.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are not needed.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed

