### PR TITLE
Towncrier: enable checking of fragment names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ template = "changes.d/template.jinja"
 underlines = ["", "", ""]
 title_format = "## cylc-ui-{version} (Released {project_date})"
 issue_format = "[#{issue}](https://github.com/cylc/cylc-ui/pull/{issue})"
+ignore = ["template.jinja"]
 
 # These changelog sections will be shown in the defined order:
 [[tool.towncrier.type]]


### PR DESCRIPTION
Thanks to https://github.com/twisted/towncrier/pull/622, `towncrier build` will now fail on CI if anyone creates a changelog fragment with an invalid name.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No docs, changelog, tests etc. needed