### PR TITLE
toolbar: disable n-window selector if appropriate

### DIFF
--- a/changes.d/1979.fix.md
+++ b/changes.d/1979.fix.md
@@ -1,0 +1,1 @@
+Don't offer the n-window selection if you don't have permissions to use it.

--- a/src/components/cylc/workspace/Toolbar.vue
+++ b/src/components/cylc/workspace/Toolbar.vue
@@ -108,6 +108,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <v-select
                 v-model="nWindow"
                 :items="[0,1,2,3]"
+                :disabled="!user.permissions?.includes('setGraphWindowExtent')"
               >
                 <template #append-inner>
                   <v-progress-circular


### PR DESCRIPTION
* Closes #1845
* Disable the n-window selector if the authenticated user does not have the required permissions to run the setGraphWindowExtent mutation.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.