### PR TITLE
jupyter lab dashboard link

### DIFF
--- a/changes.d/1982.feat.md
+++ b/changes.d/1982.feat.md
@@ -1,0 +1,1 @@
+Add link to Jupyter Lab from the Dashboard (if Jupyter Lab is installed).

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mitt": "3.0.1",
     "nprogress": "1.0.0-1",
     "preact": "10.24.3",
+    "simple-icons": "2.17.1",
     "subscriptions-transport-ws": "0.11.0",
     "svg-pan-zoom": "3.6.2",
     "vue": "3.4.11",

--- a/src/model/User.model.js
+++ b/src/model/User.model.js
@@ -16,7 +16,7 @@
  */
 
 export default class User {
-  constructor ({ username, owner, permissions, mode, initials, color }) {
+  constructor ({ username, owner, permissions, mode, initials, color, extensions }) {
     /**
      * @type {string}
      */
@@ -47,5 +47,9 @@ export default class User {
      * @type {string | null}
      */
     this.color = color
+    /**
+      * Jupyter server extensions.
+      */
+    this.extensions = extensions
   }
 }

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * SVG icons for use in the Cylc UI:
+ * - Centralise icons for use throughout multiple components.
+ * - Define custom icons.
+ * - Reformat icons for other source.
+ *
+ * Note, the `<v-icon>` component expects icons in the MDI format i.e.:
+ * - A string representing an SVG path.
+ * - Consisting of a bezier curve (e.g. `M 0,0 C 1,1 Z`).
+ * - That fits within a 24px box.
+ */
+
+import { Jupyter } from 'simple-icons'
+
+export const jupyterLogo = Jupyter.svg.replace(/.*d="(.*)".*/, '$1')

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -95,6 +95,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               You are not running Cylc UI via Cylc Hub.
             </v-tooltip>
           </div>
+          <div>
+            <v-list-item
+              id="jupyter-lab-button"
+              :disabled="!user.extensions?.lab"
+              :href="user.extensions?.lab"
+              target="_blank"
+            >
+              <template v-slot:prepend>
+                <v-icon size="1.6em">{{ $options.icons.jupyterLogo }}</v-icon>
+              </template>
+              <v-list-item-title class="text-h6 font-weight-light">
+                Jupyter Lab
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                Open Jupyter Lab in a new browser tab.
+              </v-list-item-subtitle>
+            </v-list-item>
+            <v-tooltip :disabled="user.extensions?.lab">
+              Jupyter Lab is not installed.
+            </v-tooltip>
+          </div>
         </v-list>
       </v-col>
       <v-col md="6" lg="6">
@@ -141,6 +162,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <script>
 import { mapState, mapGetters } from 'vuex'
 import { mdiBook, mdiBookMultiple, mdiBookOpenVariant, mdiCog, mdiHubspot, mdiTable } from '@mdi/js'
+import { jupyterLogo } from '@/utils/icons'
 import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import { createUrl } from '@/utils/urls'
 import { WorkflowState, WorkflowStateOrder } from '@/model/WorkflowState.model'
@@ -250,6 +272,7 @@ export default {
     quickstart: mdiBook,
     workflow: mdiBookOpenVariant,
     documentation: mdiBookMultiple,
+    jupyterLogo,
   },
 }
 </script>

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -50,6 +50,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
               <v-row no-gutters class="align-center wrap">
                 <v-col cols="3">
+                  <span>Jupyter Server Extensions</span>
+                </v-col>
+                <v-col cols="9">
+                  <v-text-field
+                      :model-value="Object.keys(user.extensions).join(', ') || 'None'"
+                      disabled
+                      id="profile-extensions"
+                      aria-disabled="true"
+                      class="text-body-1"
+                  />
+                </v-col>
+              </v-row>
+
+              <v-row no-gutters class="align-center wrap">
+                <v-col cols="3">
                   <span>{{ $t('UserProfile.permissions') }}</span>
                 </v-col>
                 <v-col cols="9">

--- a/tests/e2e/specs/dashboard.cy.js
+++ b/tests/e2e/specs/dashboard.cy.js
@@ -54,6 +54,12 @@ describe('Dashboard', () => {
       .should('have.class', 'v-list-item--disabled')
   })
 
+  it('Disables Jupyter Lab button when not installed', () => {
+    cy
+      .get('#jupyter-lab-button')
+      .should('have.class', 'v-list-item--disabled')
+  })
+
   for (const ref of ['workflow-table-link', 'user-settings-link', 'quickstart-link']) {
     it(`Visits ${ref}`, () => {
       cy.get(`[data-cy=${ref}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,6 +3609,7 @@ __metadata:
     nyc: "npm:17.1.0"
     preact: "npm:10.24.3"
     sass: "npm:1.77.8"
+    simple-icons: "npm:2.17.1"
     sinon: "npm:19.0.2"
     standard: "npm:17.1.2"
     subscriptions-transport-ws: "npm:0.11.0"
@@ -8981,6 +8982,13 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-icons@npm:2.17.1":
+  version: 2.17.1
+  resolution: "simple-icons@npm:2.17.1"
+  checksum: 10c0/134bcac6e5c9f737dafe2d24a323f78259dd5a8bb31ea0034469ccac837242ec75982a1fd63e23e33f516e0fedb65cb254209e414142ac4d6ccb75d5fba041ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Requires https://github.com/cylc/cylc-uiserver/pull/641

To review:

* Try running `cylc gui` and insepecting the Dashboard page (unless you have installed Jupyter lab) the link should be disabled.
* Try installing Jupyter Lab (`pip install jupyterlab`) and re-run the `cylc gui`, then follow the link on the Dashboard page.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.