### PR TITLE
Handle possible lack of jupyter extensions field in userprofile

### DIFF
--- a/src/services/mock/json/userprofile.json
+++ b/src/services/mock/json/userprofile.json
@@ -30,5 +30,8 @@
     "hold"
   ],
   "mode": "single user",
-  "owner": "user"
+  "owner": "user",
+  "extensions": {
+    "cylc": "/cylc"
+  }
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -39,26 +39,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </v-col>
                 <v-col cols="9">
                   <v-text-field
-                      :model-value="user.username"
-                      disabled
-                      id="profile-username"
-                      aria-disabled="true"
-                      class="text-body-1"
+                    :model-value="user.username"
+                    disabled
+                    id="profile-username"
+                    class="text-body-1"
                   />
                 </v-col>
               </v-row>
 
-              <v-row no-gutters class="align-center wrap">
+              <v-row
+                v-if="user.extensions"
+                no-gutters
+                class="align-center wrap"
+              >
                 <v-col cols="3">
                   <span>Jupyter Server Extensions</span>
                 </v-col>
                 <v-col cols="9">
                   <v-text-field
-                      :model-value="Object.keys(user.extensions).join(', ') || 'None'"
-                      disabled
-                      id="profile-extensions"
-                      aria-disabled="true"
-                      class="text-body-1"
+                    :model-value="Object.keys(user.extensions).join(', ') || 'None'"
+                    disabled
+                    id="profile-extensions"
+                    class="text-body-1"
                   />
                 </v-col>
               </v-row>


### PR DESCRIPTION
This can be the case during development using an older UIS version.

Also added cylc extension to mock data.

Closes #2026

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
