### PR TITLE
Update vitest to 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "3.13.11",
     "@vitejs/plugin-vue": "5.2.1",
-    "@vitest/coverage-istanbul": "2.1.8",
+    "@vitest/coverage-istanbul": "3.0.4",
     "@vue/test-utils": "2.4.6",
     "concurrently": "9.1.2",
     "cross-fetch": "4.1.0",
@@ -86,7 +86,7 @@
     "vite-plugin-eslint": "1.8.1",
     "vite-plugin-istanbul": "6.0.2",
     "vite-plugin-vuetify": "2.0.4",
-    "vitest": "2.1.9"
+    "vitest": "3.0.4"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,24 +589,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/aix-ppc64@npm:0.21.5"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/aix-ppc64@npm:0.24.2"
   conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/android-arm64@npm:0.21.5"
-  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -617,24 +603,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/android-arm@npm:0.21.5"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/android-arm@npm:0.24.2"
   conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/android-x64@npm:0.21.5"
-  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -645,24 +617,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/darwin-arm64@npm:0.21.5"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/darwin-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/darwin-arm64@npm:0.24.2"
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/darwin-x64@npm:0.21.5"
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -673,24 +631,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/freebsd-arm64@npm:0.21.5"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/freebsd-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/freebsd-arm64@npm:0.24.2"
   conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/freebsd-x64@npm:0.21.5"
-  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -701,24 +645,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-arm64@npm:0.21.5"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-arm64@npm:0.24.2"
   conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-arm@npm:0.21.5"
-  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -729,24 +659,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-ia32@npm:0.21.5"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-ia32@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-ia32@npm:0.24.2"
   conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-loong64@npm:0.21.5"
-  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -757,24 +673,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-mips64el@npm:0.21.5"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-mips64el@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-mips64el@npm:0.24.2"
   conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-ppc64@npm:0.21.5"
-  conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
@@ -785,13 +687,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-riscv64@npm:0.21.5"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-riscv64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-riscv64@npm:0.24.2"
@@ -799,24 +694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-s390x@npm:0.21.5"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-s390x@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-s390x@npm:0.24.2"
   conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/linux-x64@npm:0.21.5"
-  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
@@ -834,13 +715,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/netbsd-x64@npm:0.21.5"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/netbsd-x64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/netbsd-x64@npm:0.24.2"
@@ -855,24 +729,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/openbsd-x64@npm:0.21.5"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/openbsd-x64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/openbsd-x64@npm:0.24.2"
   conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/sunos-x64@npm:0.21.5"
-  conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
@@ -883,13 +743,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/win32-arm64@npm:0.21.5"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/win32-arm64@npm:0.24.2"
@@ -897,24 +750,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/win32-ia32@npm:0.21.5"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-ia32@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/win32-ia32@npm:0.24.2"
   conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.21.5":
-  version: 0.21.5
-  resolution: "@esbuild/win32-x64@npm:0.21.5"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2122,23 +1961,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.29.1"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-android-arm64@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-android-arm64@npm:4.27.4"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-android-arm64@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.29.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2150,23 +1975,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.29.1"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-darwin-x64@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-darwin-x64@npm:4.27.4"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-darwin-x64@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.29.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -2178,23 +1989,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.29.1"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-freebsd-x64@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-freebsd-x64@npm:4.27.4"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-freebsd-x64@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.29.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -2206,23 +2003,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.29.1"
-  conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-arm-musleabihf@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.27.4"
-  conditions: os=linux & cpu=arm & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm-musleabihf@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.29.1"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
@@ -2234,13 +2017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.29.1"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-arm64-musl@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-linux-arm64-musl@npm:4.27.4"
@@ -2248,30 +2024,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.29.1"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.29.1"
-  conditions: os=linux & cpu=loong64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-powerpc64le-gnu@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.27.4"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.29.1"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2283,23 +2038,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.29.1"
-  conditions: os=linux & cpu=riscv64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-s390x-gnu@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.27.4"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-s390x-gnu@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.29.1"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -2311,23 +2052,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.29.1"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-linux-x64-musl@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-linux-x64-musl@npm:4.27.4"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-x64-musl@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.29.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -2339,13 +2066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.29.1"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-win32-ia32-msvc@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.27.4"
@@ -2353,23 +2073,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.29.1"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@rollup/rollup-win32-x64-msvc@npm:4.27.4":
   version: 4.27.4
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.27.4"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-win32-x64-msvc@npm:4.29.1":
-  version: 4.29.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.29.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2557,12 +2263,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-istanbul@npm:2.1.8":
-  version: 2.1.8
-  resolution: "@vitest/coverage-istanbul@npm:2.1.8"
+"@vitest/coverage-istanbul@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/coverage-istanbul@npm:3.0.4"
   dependencies:
     "@istanbuljs/schema": "npm:^0.1.3"
-    debug: "npm:^4.3.7"
+    debug: "npm:^4.4.0"
     istanbul-lib-coverage: "npm:^3.2.2"
     istanbul-lib-instrument: "npm:^6.0.3"
     istanbul-lib-report: "npm:^3.0.1"
@@ -2570,91 +2276,100 @@ __metadata:
     istanbul-reports: "npm:^3.1.7"
     magicast: "npm:^0.3.5"
     test-exclude: "npm:^7.0.1"
-    tinyrainbow: "npm:^1.2.0"
+    tinyrainbow: "npm:^2.0.0"
   peerDependencies:
-    vitest: 2.1.8
-  checksum: 10c0/809eeccebaa7fd0e349d89a8d374e449c65a1d626f46b03b080aa507ac93dfb340c90dd491fe9a08dca896d6832e0f3dcffd6fd7ba3d05c1dc95c7a32aabc50c
+    vitest: 3.0.4
+  checksum: 10c0/0b7c924cb0e5bb262c1061794c720ed9d73f65511c89489abbfa63299d4a2924ca9c08d8e6b522a194a273783b44d0300062cdd04dd03ce217564f7df1b21b9f
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/expect@npm:2.1.9"
+"@vitest/expect@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/expect@npm:3.0.4"
   dependencies:
-    "@vitest/spy": "npm:2.1.9"
-    "@vitest/utils": "npm:2.1.9"
+    "@vitest/spy": "npm:3.0.4"
+    "@vitest/utils": "npm:3.0.4"
     chai: "npm:^5.1.2"
-    tinyrainbow: "npm:^1.2.0"
-  checksum: 10c0/98d1cf02917316bebef9e4720723e38298a1c12b3c8f3a81f259bb822de4288edf594e69ff64f0b88afbda6d04d7a4f0c2f720f3fec16b4c45f5e2669f09fdbb
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/9e5fe0f905a3f9f39e059d4384785a05bbca34d0f33e8a25ac41e479ce2035a3d86807ee53948a3681a039f751cfad3cd66179a5e691ed815405fe77051b6372
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/mocker@npm:2.1.9"
+"@vitest/mocker@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/mocker@npm:3.0.4"
   dependencies:
-    "@vitest/spy": "npm:2.1.9"
+    "@vitest/spy": "npm:3.0.4"
     estree-walker: "npm:^3.0.3"
-    magic-string: "npm:^0.30.12"
+    magic-string: "npm:^0.30.17"
   peerDependencies:
     msw: ^2.4.9
-    vite: ^5.0.0
+    vite: ^5.0.0 || ^6.0.0
   peerDependenciesMeta:
     msw:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/f734490d8d1206a7f44dfdfca459282f5921d73efa72935bb1dc45307578defd38a4131b14853316373ec364cbe910dbc74594ed4137e0da35aa4d9bb716f190
+  checksum: 10c0/3cf4aaa3516142c826ddc1088f542aab920327caec8b3b0e8d540beef73d4401d160d48592cda3a577a7f6b9ca8480278582d2ff533fe31d7e029c46178da1ac
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:2.1.9, @vitest/pretty-format@npm:^2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/pretty-format@npm:2.1.9"
+"@vitest/pretty-format@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/pretty-format@npm:3.0.4"
   dependencies:
-    tinyrainbow: "npm:^1.2.0"
-  checksum: 10c0/155f9ede5090eabed2a73361094bb35ed4ec6769ae3546d2a2af139166569aec41bb80e031c25ff2da22b71dd4ed51e5468e66a05e6aeda5f14b32e30bc18f00
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/a6d12eb454d527be592d98523b11f274be8fc6ee409333731def092a5d36939c68fa5817ae45aa48c5ca23d75f6cc1b76a3db73dff8ee7e28e0932b2ad68b42d
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/runner@npm:2.1.9"
+"@vitest/pretty-format@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "@vitest/pretty-format@npm:3.0.5"
   dependencies:
-    "@vitest/utils": "npm:2.1.9"
-    pathe: "npm:^1.1.2"
-  checksum: 10c0/e81f176badb12a815cbbd9bd97e19f7437a0b64e8934d680024b0f768d8670d59cad698ef0e3dada5241b6731d77a7bb3cd2c7cb29f751fd4dd35eb11c42963a
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/94dbe3dfffd53f880e2c1fc35da3c998b768e88a37d4248a1e531ec465d4a19ec917dd56c5ccf4f24bb1984b1376ffc55fe710c2b07ef94f9ebf61ca028a2177
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/snapshot@npm:2.1.9"
+"@vitest/runner@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/runner@npm:3.0.4"
   dependencies:
-    "@vitest/pretty-format": "npm:2.1.9"
-    magic-string: "npm:^0.30.12"
-    pathe: "npm:^1.1.2"
-  checksum: 10c0/394974b3a1fe96186a3c87f933b2f7f1f7b7cc42f9c781d80271dbb4c987809bf035fecd7398b8a3a2d54169e3ecb49655e38a0131d0e7fea5ce88960613b526
+    "@vitest/utils": "npm:3.0.4"
+    pathe: "npm:^2.0.2"
+  checksum: 10c0/8743c938047c5ee85f3917b917fe4eb9f13c7da911ace96fda92e7f59f15b609a719147fe8ea50089c4ac910668dad013e177d5690c82e68ca043fe72426b055
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/spy@npm:2.1.9"
+"@vitest/snapshot@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/snapshot@npm:3.0.4"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.0.4"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.2"
+  checksum: 10c0/d9a52c1ab42906c712872e42494a538573651e2cc0d1364e0f80f9c9810c48f189740e355c26233458051f88a93b6eaad34df260d792e8ae8e0747170339cc77
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/spy@npm:3.0.4"
   dependencies:
     tinyspy: "npm:^3.0.2"
-  checksum: 10c0/12a59b5095e20188b819a1d797e0a513d991b4e6a57db679927c43b362a3eff52d823b34e855a6dd9e73c9fa138dcc5ef52210841a93db5cbf047957a60ca83c
+  checksum: 10c0/e06490d4bf2245246c578f0bf357157203fe21f7d3c5f3dd984170b2b6ae898cbd1627a0339e64aa8f402df72c9ac908de65e28b8671644dc0b14e1fac9c9a83
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:2.1.9":
-  version: 2.1.9
-  resolution: "@vitest/utils@npm:2.1.9"
+"@vitest/utils@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@vitest/utils@npm:3.0.4"
   dependencies:
-    "@vitest/pretty-format": "npm:2.1.9"
+    "@vitest/pretty-format": "npm:3.0.4"
     loupe: "npm:^3.1.2"
-    tinyrainbow: "npm:^1.2.0"
-  checksum: 10c0/81a346cd72b47941f55411f5df4cc230e5f740d1e97e0d3f771b27f007266fc1f28d0438582f6409ea571bc0030ed37f684c64c58d1947d6298d770c21026fdf
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/cf36626ec1305d49196360f5bf8237aec8aeacb834927582901c52b7dbfd797abd63074ecff58854f1ddfad7f111987624aded89829561ab9acd9cb51d0672f8
   languageName: node
   linkType: hard
 
@@ -4045,7 +3760,7 @@ __metadata:
     "@lumino/widgets": "npm:2.5.0"
     "@mdi/js": "npm:7.4.47"
     "@vitejs/plugin-vue": "npm:5.2.1"
-    "@vitest/coverage-istanbul": "npm:2.1.8"
+    "@vitest/coverage-istanbul": "npm:3.0.4"
     "@vue/test-utils": "npm:2.4.6"
     "@vueuse/core": "npm:12.5.0"
     apexcharts: "npm:3.54.1"
@@ -4091,7 +3806,7 @@ __metadata:
     vite-plugin-eslint: "npm:1.8.1"
     vite-plugin-istanbul: "npm:6.0.2"
     vite-plugin-vuetify: "npm:2.0.4"
-    vitest: "npm:2.1.9"
+    vitest: "npm:3.0.4"
     vue: "npm:3.5.13"
     vue-i18n: "npm:11.0.1"
     vue-router: "npm:4.5.0"
@@ -4275,7 +3990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.4.0":
+"debug@npm:4.4.0, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -4293,18 +4008,6 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "debug@npm:4.3.7"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
   languageName: node
   linkType: hard
 
@@ -4681,10 +4384,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "es-module-lexer@npm:1.5.4"
-  checksum: 10c0/300a469488c2f22081df1e4c8398c78db92358496e639b0df7f89ac6455462aaf5d8893939087c1a1cbcbf20eed4610c70e0bcb8f3e4b0d80a5d2611c539408c
+"es-module-lexer@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "es-module-lexer@npm:1.6.0"
+  checksum: 10c0/667309454411c0b95c476025929881e71400d74a746ffa1ff4cb450bd87f8e33e8eef7854d68e401895039ac0bac64e7809acbebb6253e055dd49ea9e3ea9212
   languageName: node
   linkType: hard
 
@@ -4732,86 +4435,6 @@ __metadata:
   version: 4.1.1
   resolution: "es6-error@npm:4.1.1"
   checksum: 10c0/357663fb1e845c047d548c3d30f86e005db71e122678f4184ced0693f634688c3f3ef2d7de7d4af732f734de01f528b05954e270f06aa7d133679fb9fe6600ef
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.21.3":
-  version: 0.21.5
-  resolution: "esbuild@npm:0.21.5"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.21.5"
-    "@esbuild/android-arm": "npm:0.21.5"
-    "@esbuild/android-arm64": "npm:0.21.5"
-    "@esbuild/android-x64": "npm:0.21.5"
-    "@esbuild/darwin-arm64": "npm:0.21.5"
-    "@esbuild/darwin-x64": "npm:0.21.5"
-    "@esbuild/freebsd-arm64": "npm:0.21.5"
-    "@esbuild/freebsd-x64": "npm:0.21.5"
-    "@esbuild/linux-arm": "npm:0.21.5"
-    "@esbuild/linux-arm64": "npm:0.21.5"
-    "@esbuild/linux-ia32": "npm:0.21.5"
-    "@esbuild/linux-loong64": "npm:0.21.5"
-    "@esbuild/linux-mips64el": "npm:0.21.5"
-    "@esbuild/linux-ppc64": "npm:0.21.5"
-    "@esbuild/linux-riscv64": "npm:0.21.5"
-    "@esbuild/linux-s390x": "npm:0.21.5"
-    "@esbuild/linux-x64": "npm:0.21.5"
-    "@esbuild/netbsd-x64": "npm:0.21.5"
-    "@esbuild/openbsd-x64": "npm:0.21.5"
-    "@esbuild/sunos-x64": "npm:0.21.5"
-    "@esbuild/win32-arm64": "npm:0.21.5"
-    "@esbuild/win32-ia32": "npm:0.21.5"
-    "@esbuild/win32-x64": "npm:0.21.5"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
   languageName: node
   linkType: hard
 
@@ -7636,21 +7259,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.11":
+"magic-string@npm:^0.30.11, magic-string@npm:^0.30.17":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
   checksum: 10c0/16826e415d04b88378f200fe022b53e638e3838b9e496edda6c0e086d7753a44a6ed187adc72d19f3623810589bf139af1a315541cd6a26ae0771a0193eaf7b8
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.30.12":
-  version: 0.30.12
-  resolution: "magic-string@npm:0.30.12"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
-  checksum: 10c0/469f457d18af37dfcca8617086ea8a65bcd8b60ba8a1182cb024ce43e470ace3c9d1cb6bee58d3b311768fb16bc27bd50bdeebcaa63dadd0fd46cac4d2e11d5f
   languageName: node
   linkType: hard
 
@@ -8615,10 +8229,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathe@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "pathe@npm:1.1.2"
-  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+"pathe@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "pathe@npm:2.0.2"
+  checksum: 10c0/21fce96ca9cebf037b075de8e5cc4ac6aa1009bce57946a72695f47ded84cf4b29f03bed721ea0f6e39b69eb1a0620bcee1f72eca46086765214a2965399b83a
   languageName: node
   linkType: hard
 
@@ -8749,17 +8363,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.43, postcss@npm:^8.4.49":
-  version: 8.4.49
-  resolution: "postcss@npm:8.4.49"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.4.48":
   version: 8.5.1
   resolution: "postcss@npm:8.5.1"
@@ -8768,6 +8371,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/c4d90c59c98e8a0c102b77d3f4cac190f883b42d63dc60e2f3ed840f16197c0c8e25a4327d2e9a847b45a985612317dc0534178feeebd0a1cf3eb0eecf75cae4
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.49":
+  version: 8.4.49
+  resolution: "postcss@npm:8.4.49"
+  dependencies:
+    nanoid: "npm:^3.3.7"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
   languageName: node
   linkType: hard
 
@@ -9247,78 +8861,6 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/bc3746c988d903c2211266ddc539379d53d92689b9cc5c2b4e3ae161689de9af491957a567c629b6cc81f48d0928a7591fc4c383fba68a48d2966c9fb8a2bce9
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^4.20.0":
-  version: 4.29.1
-  resolution: "rollup@npm:4.29.1"
-  dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.29.1"
-    "@rollup/rollup-android-arm64": "npm:4.29.1"
-    "@rollup/rollup-darwin-arm64": "npm:4.29.1"
-    "@rollup/rollup-darwin-x64": "npm:4.29.1"
-    "@rollup/rollup-freebsd-arm64": "npm:4.29.1"
-    "@rollup/rollup-freebsd-x64": "npm:4.29.1"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.29.1"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.29.1"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.29.1"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.29.1"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.29.1"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.29.1"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.29.1"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.29.1"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.29.1"
-    "@rollup/rollup-linux-x64-musl": "npm:4.29.1"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.29.1"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.29.1"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.29.1"
-    "@types/estree": "npm:1.0.6"
-    fsevents: "npm:~2.3.2"
-  dependenciesMeta:
-    "@rollup/rollup-android-arm-eabi":
-      optional: true
-    "@rollup/rollup-android-arm64":
-      optional: true
-    "@rollup/rollup-darwin-arm64":
-      optional: true
-    "@rollup/rollup-darwin-x64":
-      optional: true
-    "@rollup/rollup-freebsd-arm64":
-      optional: true
-    "@rollup/rollup-freebsd-x64":
-      optional: true
-    "@rollup/rollup-linux-arm-gnueabihf":
-      optional: true
-    "@rollup/rollup-linux-arm-musleabihf":
-      optional: true
-    "@rollup/rollup-linux-arm64-gnu":
-      optional: true
-    "@rollup/rollup-linux-arm64-musl":
-      optional: true
-    "@rollup/rollup-linux-loongarch64-gnu":
-      optional: true
-    "@rollup/rollup-linux-powerpc64le-gnu":
-      optional: true
-    "@rollup/rollup-linux-riscv64-gnu":
-      optional: true
-    "@rollup/rollup-linux-s390x-gnu":
-      optional: true
-    "@rollup/rollup-linux-x64-gnu":
-      optional: true
-    "@rollup/rollup-linux-x64-musl":
-      optional: true
-    "@rollup/rollup-win32-arm64-msvc":
-      optional: true
-    "@rollup/rollup-win32-ia32-msvc":
-      optional: true
-    "@rollup/rollup-win32-x64-msvc":
-      optional: true
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 10c0/fcd0321df78fdc74b36858e92c4b73ebf5aa8f0b9cf7c446f008e0dc3c5c4ed855d662dc44e5a09c7794bbe91017b4dd7be88b619c239f0494f9f0fbfa67c557
   languageName: node
   linkType: hard
 
@@ -10496,24 +10038,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "tinyexec@npm:0.3.1"
-  checksum: 10c0/11e7a7c5d8b3bddf8b5cbe82a9290d70a6fad84d528421d5d18297f165723cb53d2e737d8f58dcce5ca56f2e4aa2d060f02510b1f8971784f97eb3e9aec28f09
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
   languageName: node
   linkType: hard
 
-"tinypool@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "tinypool@npm:1.0.1"
-  checksum: 10c0/90939d6a03f1519c61007bf416632dc1f0b9c1a9dd673c179ccd9e36a408437384f984fc86555a5d040d45b595abc299c3bb39d354439e98a090766b5952e73d
+"tinypool@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "tinypool@npm:1.0.2"
+  checksum: 10c0/31ac184c0ff1cf9a074741254fe9ea6de95026749eb2b8ec6fd2b9d8ca94abdccda731f8e102e7f32e72ed3b36d32c6975fd5f5523df3f1b6de6c3d8dfd95e63
   languageName: node
   linkType: hard
 
-"tinyrainbow@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "tinyrainbow@npm:1.2.0"
-  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
+"tinyrainbow@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "tinyrainbow@npm:2.0.0"
+  checksum: 10c0/c83c52bef4e0ae7fb8ec6a722f70b5b6fa8d8be1c85792e829f56c0e1be94ab70b293c032dc5048d4d37cfe678f1f5babb04bdc65fd123098800148ca989184f
   languageName: node
   linkType: hard
 
@@ -10976,18 +10518,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:2.1.9":
-  version: 2.1.9
-  resolution: "vite-node@npm:2.1.9"
+"vite-node@npm:3.0.4":
+  version: 3.0.4
+  resolution: "vite-node@npm:3.0.4"
   dependencies:
     cac: "npm:^6.7.14"
-    debug: "npm:^4.3.7"
-    es-module-lexer: "npm:^1.5.4"
-    pathe: "npm:^1.1.2"
-    vite: "npm:^5.0.0"
+    debug: "npm:^4.4.0"
+    es-module-lexer: "npm:^1.6.0"
+    pathe: "npm:^2.0.2"
+    vite: "npm:^5.0.0 || ^6.0.0"
   bin:
     vite-node: vite-node.mjs
-  checksum: 10c0/0d3589f9f4e9cff696b5b49681fdb75d1638c75053728be52b4013f70792f38cb0120a9c15e3a4b22bdd6b795ad7c2da13bcaf47242d439f0906049e73bdd756
+  checksum: 10c0/8e644ad1c5dd29493314866ca9ec98779ca4e7ef4f93d89d7377b8cae6dd89315908de593a20ee5d3e0b44cb14b1e0ce6a8a39c6a3a7143c28ab9a7965b54397
   languageName: node
   linkType: hard
 
@@ -11036,7 +10578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:6.0.11":
+"vite@npm:6.0.11, vite@npm:^5.0.0 || ^6.0.0":
   version: 6.0.11
   resolution: "vite@npm:6.0.11"
   dependencies:
@@ -11088,82 +10630,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
-  version: 5.4.11
-  resolution: "vite@npm:5.4.11"
+"vitest@npm:3.0.4":
+  version: 3.0.4
+  resolution: "vitest@npm:3.0.4"
   dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.43"
-    rollup: "npm:^4.20.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/d536bb7af57dd0eca2a808f95f5ff1d7b7ffb8d86e17c6893087680a0448bd0d15e07475270c8a6de65cb5115592d037130a1dd979dc76bcef8c1dda202a1874
-  languageName: node
-  linkType: hard
-
-"vitest@npm:2.1.9":
-  version: 2.1.9
-  resolution: "vitest@npm:2.1.9"
-  dependencies:
-    "@vitest/expect": "npm:2.1.9"
-    "@vitest/mocker": "npm:2.1.9"
-    "@vitest/pretty-format": "npm:^2.1.9"
-    "@vitest/runner": "npm:2.1.9"
-    "@vitest/snapshot": "npm:2.1.9"
-    "@vitest/spy": "npm:2.1.9"
-    "@vitest/utils": "npm:2.1.9"
+    "@vitest/expect": "npm:3.0.4"
+    "@vitest/mocker": "npm:3.0.4"
+    "@vitest/pretty-format": "npm:^3.0.4"
+    "@vitest/runner": "npm:3.0.4"
+    "@vitest/snapshot": "npm:3.0.4"
+    "@vitest/spy": "npm:3.0.4"
+    "@vitest/utils": "npm:3.0.4"
     chai: "npm:^5.1.2"
-    debug: "npm:^4.3.7"
+    debug: "npm:^4.4.0"
     expect-type: "npm:^1.1.0"
-    magic-string: "npm:^0.30.12"
-    pathe: "npm:^1.1.2"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.2"
     std-env: "npm:^3.8.0"
     tinybench: "npm:^2.9.0"
-    tinyexec: "npm:^0.3.1"
-    tinypool: "npm:^1.0.1"
-    tinyrainbow: "npm:^1.2.0"
-    vite: "npm:^5.0.0"
-    vite-node: "npm:2.1.9"
+    tinyexec: "npm:^0.3.2"
+    tinypool: "npm:^1.0.2"
+    tinyrainbow: "npm:^2.0.0"
+    vite: "npm:^5.0.0 || ^6.0.0"
+    vite-node: "npm:3.0.4"
     why-is-node-running: "npm:^2.3.0"
   peerDependencies:
     "@edge-runtime/vm": "*"
-    "@types/node": ^18.0.0 || >=20.0.0
-    "@vitest/browser": 2.1.9
-    "@vitest/ui": 2.1.9
+    "@types/debug": ^4.1.12
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@vitest/browser": 3.0.4
+    "@vitest/ui": 3.0.4
     happy-dom: "*"
     jsdom: "*"
   peerDependenciesMeta:
     "@edge-runtime/vm":
+      optional: true
+    "@types/debug":
       optional: true
     "@types/node":
       optional: true
@@ -11177,7 +10679,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: 10c0/e339e16dccacf4589ff43cb1f38c7b4d14427956ae8ef48702af6820a9842347c2b6c77356aeddb040329759ca508a3cb2b104ddf78103ea5bc98ab8f2c3a54e
+  checksum: 10c0/b610df2b9ed285c5e9a20014f277e1aab84513be71ab51a99e1091b6769aa95323e0c76eb7410b91ed6094566949a921716a672c3b746aeae9d5184b323fb6c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

### Release Notes

<details>
<summary>vitest-dev/vitest (@&#8203;vitest/coverage-istanbul)</summary>

### [`v3.0.4`](https://redirect.github.com/vitest-dev/vitest/releases/tag/v3.0.4)

[Compare Source](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.3...v3.0.4)

#####    🐞 Bug Fixes

-   Filter projects eagerly during config resolution  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) and [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7313](https://redirect.github.com/vitest-dev/vitest/issues/7313) [<samp>(dff44)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/dff4406d)
-   Apply `development|production` condition on Vites 6 by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) ([#&#8203;7301](https://redirect.github.com/vitest-dev/vitest/issues/7301)) [<samp>(ef146)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ef1464fc7b101709bfbf7b040e5bad62998c2ff9)
-   **browser**: Restrict served files from `/__screenshot-error`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7340](https://redirect.github.com/vitest-dev/vitest/issues/7340) [<samp>(ed9ae)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ed9aeba2)
-   **deps**: Update all non-major dependencies  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7297](https://redirect.github.com/vitest-dev/vitest/issues/7297) [<samp>(38ea8)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/38ea8eae)
-   **runner**: Timeout long sync hook  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7289](https://redirect.github.com/vitest-dev/vitest/issues/7289) [<samp>(c60ee)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/c60ee27c)
-   **typechecking**: Support typechecking parsing with Vite 6  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7335](https://redirect.github.com/vitest-dev/vitest/issues/7335) [<samp>(bff70)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/bff70be9)
-   **types**: Fix public types  -  by [@&#8203;mrginglymus](https://redirect.github.com/mrginglymus) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7328](https://redirect.github.com/vitest-dev/vitest/issues/7328) [<samp>(ce6af)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ce6af70c)

#####     [View changes on GitHub](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.3...v3.0.4)

### [`v3.0.3`](https://redirect.github.com/vitest-dev/vitest/releases/tag/v3.0.3)

[Compare Source](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.2...v3.0.3)

#####    🐞 Bug Fixes

-   **browser**:
    -   Don't throw a validation error if v8 coverage is used with filtered instances  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7306](https://redirect.github.com/vitest-dev/vitest/issues/7306) [<samp>(fa463)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/fa4634b2)
    -   Don't fail when running --browser.headless if the browser projest is part of the workspace  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7311](https://redirect.github.com/vitest-dev/vitest/issues/7311) [<samp>(e43a8)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e43a8f56)

#####    🏎 Performance

-   **reporters**: Update summary only when needed  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7291](https://redirect.github.com/vitest-dev/vitest/issues/7291) [<samp>(7f36b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/7f36b6f9)

#####     [View changes on GitHub](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.2...v3.0.3)

### [`v3.0.2`](https://redirect.github.com/vitest-dev/vitest/releases/tag/v3.0.2)

[Compare Source](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.1...v3.0.2)

#####    🐞 Bug Fixes

-   Don't await an empty timeout after every test  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7281](https://redirect.github.com/vitest-dev/vitest/issues/7281) [<samp>(ef1aa)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ef1aa893)
-   **expect**: Fix `expect().resolves/rejects` chain typings  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7273](https://redirect.github.com/vitest-dev/vitest/issues/7273) [<samp>(fa415)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/fa415059)

#####     [View changes on GitHub](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.1...v3.0.2)

### [`v3.0.1`](https://redirect.github.com/vitest-dev/vitest/releases/tag/v3.0.1)

[Compare Source](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.0...v3.0.1)

#####    🐞 Bug Fixes

-   Revert "fix: re-apply default conditions if using vite 6 or later ([https://github.com/vitest-dev/vitest/issues/7071](https://redirect.github.com/vitest-dev/vitest/issues/7071))"  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7071](https://redirect.github.com/vitest-dev/vitest/issues/7071) and [https://github.com/vitest-dev/vitest/issues/7271](https://redirect.github.com/vitest-dev/vitest/issues/7271) [<samp>(755ec)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/755ecdfa)
-   **deps**: Update all non-major dependencies  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7147](https://redirect.github.com/vitest-dev/vitest/issues/7147) [<samp>(537fa)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/537fa5ed)

#####     [View changes on GitHub](https://redirect.github.com/vitest-dev/vitest/compare/v3.0.0...v3.0.1)

### [`v3.0.0`](https://redirect.github.com/vitest-dev/vitest/releases/tag/v3.0.0)

[Compare Source](https://redirect.github.com/vitest-dev/vitest/compare/v2.1.8...v3.0.0)

Vitest 3 is here! There are a few breaking changes, but we expect the migration to be smooth. This release page lists all changes made to the project during the beta. For the migration guide, please refer to the [documentation](https://vitest.dev/guide/migration.html#migrating-to-vitest-2-0).

#####    🚨 Breaking Changes

-   `spy.mockReset` changes  -  by [@&#8203;Lordfirespeed](https://redirect.github.com/Lordfirespeed) in [https://github.com/vitest-dev/vitest/issues/6426](https://redirect.github.com/vitest-dev/vitest/issues/6426) [<samp>(db7a8)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/db7a8888)
-   Pass down context to test hooks  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7034](https://redirect.github.com/vitest-dev/vitest/issues/7034) [<samp>(82c2e)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/82c2e244)
-   Support Vite 6  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7026](https://redirect.github.com/vitest-dev/vitest/issues/7026) [<samp>(7abe8)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/7abe854c)
-   **coverage**: Always exclude test files  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7254](https://redirect.github.com/vitest-dev/vitest/issues/7254) [<samp>(b5268)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/b5268965)
-   **deps**: Update fake-timers to v14.0.0  -  by [@&#8203;xxzefgh](https://redirect.github.com/xxzefgh) and [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7097](https://redirect.github.com/vitest-dev/vitest/issues/7097) [<samp>(c98b4)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/c98b4b1c)
-   **expect**: Check more properties for error equality  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/5876](https://redirect.github.com/vitest-dev/vitest/issues/5876) [<samp>(10023)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/100230e9)
-   **runner**: Support `describe(..., { shuffle: boolean })` and inherit from parent suite  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6670](https://redirect.github.com/vitest-dev/vitest/issues/6670) [<samp>(aa1da)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/aa1dac3d)
-   **snapshot**: Reset snapshot state for `retry` and `repeats`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6817](https://redirect.github.com/vitest-dev/vitest/issues/6817) [<samp>(e8ce9)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e8ce94cf)
-   **spy**: SpyOn reuses mock if method is already spyed on  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) and [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6464](https://redirect.github.com/vitest-dev/vitest/issues/6464) [<samp>(b3e43)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/b3e43d04)
-   **vitest**: Don't expose default toFake config  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6288](https://redirect.github.com/vitest-dev/vitest/issues/6288) [<samp>(e3144)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e3144fd8)

#####    🚀 Features

-   Support inline `diff` options and support `printBasicPrototype`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa), [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) and **Michał Grzegorzewski** in [https://github.com/vitest-dev/vitest/issues/6740](https://redirect.github.com/vitest-dev/vitest/issues/6740) [<samp>(39186)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/391860f7)
-   Allow a custom note when calling `ctx.skip()` dynamically  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6805](https://redirect.github.com/vitest-dev/vitest/issues/6805) [<samp>(697c3)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/697c35c5)
-   Allow inline workspace configuration  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6923](https://redirect.github.com/vitest-dev/vitest/issues/6923) [<samp>(562e1)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/562e1b14)
-   Provide the current project to the global setup  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6942](https://redirect.github.com/vitest-dev/vitest/issues/6942) [<samp>(a5bbc)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/a5bbc0a9)
-   Print project name as a label  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6925](https://redirect.github.com/vitest-dev/vitest/issues/6925) [<samp>(a3bef)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/a3bef598)
-   Print a deprecation warning if suite or test uses object as the third argument  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7031](https://redirect.github.com/vitest-dev/vitest/issues/7031) [<samp>(407f1)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/407f10e4)
-   Expose versions from `vitest/node` entry point and statically on Vitest  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7029](https://redirect.github.com/vitest-dev/vitest/issues/7029) [<samp>(be8d4)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/be8d479b)
-   `diff.printBasicPrototype: false` by default  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7043](https://redirect.github.com/vitest-dev/vitest/issues/7043) [<samp>(2b5c5)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/2b5c5201)
-   Prepare the Vitest API to be stable  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6962](https://redirect.github.com/vitest-dev/vitest/issues/6962) [<samp>(9a1b5)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/9a1b5012)
-   Support Vite v6 in mocker package  -  by [@&#8203;cexbrayat](https://redirect.github.com/cexbrayat) in [https://github.com/vitest-dev/vitest/issues/7058](https://redirect.github.com/vitest-dev/vitest/issues/7058) [<samp>(96f47)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/96f47d37)
-   Allow multi-browser configuration  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6975](https://redirect.github.com/vitest-dev/vitest/issues/6975) [<samp>(78b62)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/78b62ffe)
-   Add resolved project names to the reporter API  -  by [@&#8203;userquin](https://redirect.github.com/userquin) in [https://github.com/vitest-dev/vitest/issues/7213](https://redirect.github.com/vitest-dev/vitest/issues/7213) [<samp>(91758)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/91758360)
-   Introduce the new reporter API  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) and [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7069](https://redirect.github.com/vitest-dev/vitest/issues/7069) [<samp>(76662)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/766624ab)
-   Add `describe.for`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7253](https://redirect.github.com/vitest-dev/vitest/issues/7253) [<samp>(0ad28)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/0ad2860b)
-   **api**:
    -   Add onBrowserInit event  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7255](https://redirect.github.com/vitest-dev/vitest/issues/7255) [<samp>(80ce0)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/80ce0e1c)
-   **browser**:
    -   Support `actionTimeout` as playwright provider options  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6984](https://redirect.github.com/vitest-dev/vitest/issues/6984) [<samp>(e2c29)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e2c29eaf)
    -   Support clipboard api `userEvent.copy, cut, paste`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6769](https://redirect.github.com/vitest-dev/vitest/issues/6769) [<samp>(843a6)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/843a621e)
    -   Implement locator.nth()  -  by [@&#8203;xeger](https://redirect.github.com/xeger) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7137](https://redirect.github.com/vitest-dev/vitest/issues/7137) [<samp>(38458)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/38458ea6)
-   **cli**:
    -   Support excluding projects with `--project=!pattern`  -  by [@&#8203;haines](https://redirect.github.com/haines) in [https://github.com/vitest-dev/vitest/issues/6924](https://redirect.github.com/vitest-dev/vitest/issues/6924) [<samp>(ebfe9)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ebfe942c)
    -   Support specifying a line number when filtering tests  -  by [@&#8203;mzhubail](https://redirect.github.com/mzhubail) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6411](https://redirect.github.com/vitest-dev/vitest/issues/6411) [<samp>(4d94b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/4d94b956)
    -   Support location filters for suites  -  by [@&#8203;mzhubail](https://redirect.github.com/mzhubail) in [https://github.com/vitest-dev/vitest/issues/7048](https://redirect.github.com/vitest-dev/vitest/issues/7048) [<samp>(751e2)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/751e2dce)
-   **coverage**:
    -   `thresholds` to support maximum uncovered items  -  by [@&#8203;jonahkagan](https://redirect.github.com/jonahkagan) in [https://github.com/vitest-dev/vitest/issues/7061](https://redirect.github.com/vitest-dev/vitest/issues/7061) [<samp>(bde98)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/bde98b6d)
-   **expect**:
    -   Add `toHaveBeenCalledExactlyOnceWith` expect matcher  -  by [@&#8203;jacoberdman2147](https://redirect.github.com/jacoberdman2147) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6894](https://redirect.github.com/vitest-dev/vitest/issues/6894) [<samp>(ff662)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ff66206a)
    -   Add `toHaveBeenCalledAfter` and `toHaveBeenCalledBefore` utility  -  by [@&#8203;Barbapapazes](https://redirect.github.com/Barbapapazes) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6056](https://redirect.github.com/vitest-dev/vitest/issues/6056) [<samp>(85e6f)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/85e6f99f)
    -   Add `toSatisfy` asymmetric matcher  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7022](https://redirect.github.com/vitest-dev/vitest/issues/7022) [<samp>(f691a)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/f691ad76)
    -   Add `toBeOneOf` matcher  -  by [@&#8203;zirkelc](https://redirect.github.com/zirkelc) and [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6974](https://redirect.github.com/vitest-dev/vitest/issues/6974) [<samp>(3d742)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/3d742b2b)
-   **reporter**:
    -   Add support for function type to classname option in the junit reporter  -  by [@&#8203;jpleclerc](https://redirect.github.com/jpleclerc), **Jean-Philippe Leclerc** and [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6839](https://redirect.github.com/vitest-dev/vitest/issues/6839) [<samp>(dc238)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/dc238e92)
-   **reporters**:
    -   `summary` option for `verbose` and `default` reporters  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6893](https://redirect.github.com/vitest-dev/vitest/issues/6893) [<samp>(511b7)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/511b73c7)
-   **runner**:
    -   Test context can inject values from the config's `provide`  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6813](https://redirect.github.com/vitest-dev/vitest/issues/6813) [<samp>(85c64)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/85c64e35)
    -   Add "queued" state  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) and [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6931](https://redirect.github.com/vitest-dev/vitest/issues/6931) [<samp>(5f8d2)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/5f8d2091)
-   **snapshot**:
    -   Provide `config` to `resolveSnapshotPath`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6800](https://redirect.github.com/vitest-dev/vitest/issues/6800) [<samp>(746d8)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/746d8986)
-   **ui**:
    -   Allow run individual tests/suites from the UI  -  by [@&#8203;userquin](https://redirect.github.com/userquin) in [https://github.com/vitest-dev/vitest/issues/6641](https://redirect.github.com/vitest-dev/vitest/issues/6641) [<samp>(d9cc8)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/d9cc81dd)
    -   Make clicking on a test in the UI open the report section and scroll to the test failure if applicable  -  by [@&#8203;jacoberdman2147](https://redirect.github.com/jacoberdman2147) in [https://github.com/vitest-dev/vitest/issues/6900](https://redirect.github.com/vitest-dev/vitest/issues/6900) [<samp>(1bf27)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/1bf27f0d)
    -   Allow hide/show node_modules in module graph tab  -  by [@&#8203;userquin](https://redirect.github.com/userquin) in [https://github.com/vitest-dev/vitest/issues/7217](https://redirect.github.com/vitest-dev/vitest/issues/7217) [<samp>(50cf6)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/50cf61b8)
-   **vitest**:
    -   Include `coverageMap` in json report  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6606](https://redirect.github.com/vitest-dev/vitest/issues/6606) [<samp>(9c8f7)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/9c8f7e3e)
    -   Add `onTestsRerun` method to global setup context  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6803](https://redirect.github.com/vitest-dev/vitest/issues/6803) [<samp>(e26e0)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e26e066c)

#####    🐞 Bug Fixes

-   Misc fix for vite 6 ecosystem ci  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6867](https://redirect.github.com/vitest-dev/vitest/issues/6867) [<samp>(80f8b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/80f8bbf4)
-   Respect `cacheDir` when optimizer is enabled  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6910](https://redirect.github.com/vitest-dev/vitest/issues/6910) [<samp>(0b08b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/0b08bc11)
-   Reset runningPromise after `finally` in case there is an error to avoid it getting stuck  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6951](https://redirect.github.com/vitest-dev/vitest/issues/6951) [<samp>(02194)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/021944cd)
-   Revert support for Vite 6  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) [<samp>(fbe5c)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/fbe5c39d)
-   Support Node 21  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) [<samp>(92f7a)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/92f7a2ad)
-   Don't use `Custom` type internally  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7032](https://redirect.github.com/vitest-dev/vitest/issues/7032) [<samp>(7957f)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/7957f912)
-   Persist cli filters as watch mode file filter  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6955](https://redirect.github.com/vitest-dev/vitest/issues/6955) [<samp>(cc703)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/cc703362)
-   Don't use dim color for succeeded tests  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7059](https://redirect.github.com/vitest-dev/vitest/issues/7059) [<samp>(8a6f5)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/8a6f5f16)
-   Fix missing chai types  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7149](https://redirect.github.com/vitest-dev/vitest/issues/7149) [<samp>(6a09c)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/6a09cc3b)
-   `cancelCurrentRun` awaits `runningPromise`  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7168](https://redirect.github.com/vitest-dev/vitest/issues/7168) [<samp>(1dbf5)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/1dbf5140)
-   Add Locator typings for nth, first and last.  -  by [@&#8203;xeger](https://redirect.github.com/xeger) in [https://github.com/vitest-dev/vitest/issues/7176](https://redirect.github.com/vitest-dev/vitest/issues/7176) [<samp>(d262e)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/d262e059)
-   Batch console logs by microtask  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7183](https://redirect.github.com/vitest-dev/vitest/issues/7183) [<samp>(53d1d)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/53d1d5f5)
-   Allow `getMockImplementation` to return "once" implementation  -  by [@&#8203;chaptergy](https://redirect.github.com/chaptergy) in [https://github.com/vitest-dev/vitest/issues/7033](https://redirect.github.com/vitest-dev/vitest/issues/7033) [<samp>(39125)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/3912554b)
-   `capturePrintError` logger duplicate event handlers  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7197](https://redirect.github.com/vitest-dev/vitest/issues/7197) [<samp>(e89c3)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e89c3693)
-   Allow slots in vitest-browser-vue  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7120](https://redirect.github.com/vitest-dev/vitest/issues/7120) [<samp>(2319f)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/2319f849)
-   Reset root workspace project on restart  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7238](https://redirect.github.com/vitest-dev/vitest/issues/7238) [<samp>(6e518)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/6e51843a)
-   Cleanup `vitest/reporters` entrypoint  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7241](https://redirect.github.com/vitest-dev/vitest/issues/7241) [<samp>(aec0b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/aec0b530)
-   Colors on `forks` pool  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7090](https://redirect.github.com/vitest-dev/vitest/issues/7090) [<samp>(8cab9)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/8cab9601)
-   Export `VitestRunner` type from `vitest/runners`  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7240](https://redirect.github.com/vitest-dev/vitest/issues/7240) [<samp>(9b218)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/9b218854)
-   Return test fn result to runner  -  by [@&#8203;wmertens](https://redirect.github.com/wmertens) in [https://github.com/vitest-dev/vitest/issues/7239](https://redirect.github.com/vitest-dev/vitest/issues/7239) [<samp>(48645)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/48645bf4)
-   Re-apply default conditions if using vite 6 or later  -  by [@&#8203;thebanjomatic](https://redirect.github.com/thebanjomatic), **thebanjomatic** and [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7071](https://redirect.github.com/vitest-dev/vitest/issues/7071) [<samp>(84287)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/84287fc2)
-   Prevent infinite loop on prettyDOM calls  -  by [@&#8203;tsirlucas](https://redirect.github.com/tsirlucas) in [https://github.com/vitest-dev/vitest/issues/7250](https://redirect.github.com/vitest-dev/vitest/issues/7250) [<samp>(a3a46)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/a3a46a53)
-   **api**:
    -   Don't report events during `vitest list`  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7257](https://redirect.github.com/vitest-dev/vitest/issues/7257) [<samp>(1c2b2)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/1c2b210d)
-   **benchmark**:
    -   Disable type testing while benchmarking  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7068](https://redirect.github.com/vitest-dev/vitest/issues/7068) [<samp>(4e603)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/4e60333d)
    -   Rewrite reporter without `log-update`  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7019](https://redirect.github.com/vitest-dev/vitest/issues/7019) [<samp>(6d23f)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/6d23f4b1)
-   **browser**:
    -   Improve source maps when `vi.mock` is present  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6810](https://redirect.github.com/vitest-dev/vitest/issues/6810) [<samp>(8d179)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/8d179afc)
    -   Explain TypeScript support in docs and add asymmetric matchers to types  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/6934](https://redirect.github.com/vitest-dev/vitest/issues/6934) [<samp>(ac1a7)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ac1a7fdc)
    -   Fix matchers.d.ts  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6995](https://redirect.github.com/vitest-dev/vitest/issues/6995) [<samp>(a485b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/a485b32b)
    -   Fix user event state on preview provider  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7041](https://redirect.github.com/vitest-dev/vitest/issues/7041) [<samp>(8e944)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/8e94427e)
    -   Fix provider options types  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7115](https://redirect.github.com/vitest-dev/vitest/issues/7115) [<samp>(579bd)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/579bda97)
    -   Only use locator.element on last expect.element attempt  -  by [@&#8203;tsirlucas](https://redirect.github.com/tsirlucas) in [https://github.com/vitest-dev/vitest/issues/7139](https://redirect.github.com/vitest-dev/vitest/issues/7139) and [https://github.com/vitest-dev/vitest/issues/7152](https://redirect.github.com/vitest-dev/vitest/issues/7152) [<samp>(847d3)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/847d3221)
    -   Use correct project when filtering `entries` in the browser mode  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7167](https://redirect.github.com/vitest-dev/vitest/issues/7167) [<samp>(423d6)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/423d6345)
    -   Fix `console.time` with fake timers  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7207](https://redirect.github.com/vitest-dev/vitest/issues/7207) [<samp>(903f3)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/903f3b9b)
    -   Add instance validation to resolve coverage error  -  by [@&#8203;DevJoaoLopes](https://redirect.github.com/DevJoaoLopes) and [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7231](https://redirect.github.com/vitest-dev/vitest/issues/7231) [<samp>(1e791)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/1e7915b5)
-   **coverage**:
    -   Exclude browser mode iframe results  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6905](https://redirect.github.com/vitest-dev/vitest/issues/6905) [<samp>(e04a1)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/e04a1368)
    -   Correct coverage when `isolate: false` is used  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6957](https://redirect.github.com/vitest-dev/vitest/issues/6957) [<samp>(426ce)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/426ce6d8)
    -   Prevent crash when v8 incorrectly merges static_initializer's  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7150](https://redirect.github.com/vitest-dev/vitest/issues/7150) [<samp>(cb6db)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/cb6db13e)
-   **deps**:
    -   Update all non-major dependencies  -  in [https://github.com/vitest-dev/vitest/issues/7085](https://redirect.github.com/vitest-dev/vitest/issues/7085) [<samp>(8cc92)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/8cc92c2f)
    -   Update all non-major dependencies  -  in [https://github.com/vitest-dev/vitest/issues/7116](https://redirect.github.com/vitest-dev/vitest/issues/7116) [<samp>(de5ce)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/de5ce3d9)
    -   Update dependency pathe to v2  -  in [https://github.com/vitest-dev/vitest/issues/7181](https://redirect.github.com/vitest-dev/vitest/issues/7181) [<samp>(74dbe)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/74dbe03f)
-   **diff**:
    -   Truncate to avoid crash on diff large objects  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7133](https://redirect.github.com/vitest-dev/vitest/issues/7133) [<samp>(2a9d6)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/2a9d67a2)
-   **junit**:
    -   Fix testsuites time to be sum of all testsuite items  -  by [@&#8203;saitonakamura](https://redirect.github.com/saitonakamura) in [https://github.com/vitest-dev/vitest/issues/6985](https://redirect.github.com/vitest-dev/vitest/issues/6985) [<samp>(ca37a)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ca37a06a)
-   **pretty-format**:
    -   Support react 19  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6909](https://redirect.github.com/vitest-dev/vitest/issues/6909) [<samp>(bd29b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/bd29bcc7)
-   **reporters**:
    -   Write buffered stdout/stderr on process exit  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6932](https://redirect.github.com/vitest-dev/vitest/issues/6932) [<samp>(80cde)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/80cde2a0)
    -   Rewrite `dot` reporter without `log-update`  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6943](https://redirect.github.com/vitest-dev/vitest/issues/6943) [<samp>(be969)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/be969cfb)
    -   Check `--hideSkippedTests` in base reporter  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/6988](https://redirect.github.com/vitest-dev/vitest/issues/6988) [<samp>(721a5)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/721a5b84)
    -   Show `retry` and `repeats` counts  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) and [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7004](https://redirect.github.com/vitest-dev/vitest/issues/7004) [<samp>(3496a)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/3496a015)
-   **runner**:
    -   Long synchronous tasks does not time out  -  by [@&#8203;ferdodo](https://redirect.github.com/ferdodo) and [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/2920](https://redirect.github.com/vitest-dev/vitest/issues/2920) and [https://github.com/vitest-dev/vitest/issues/6944](https://redirect.github.com/vitest-dev/vitest/issues/6944) [<samp>(2fb58)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/2fb585ae)
    -   Mark tests of `describe.todo` as `'todo'`  -  by [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7171](https://redirect.github.com/vitest-dev/vitest/issues/7171) [<samp>(1d458)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/1d458955)
-   **snapshot**:
    -   Fix "obsolete" message on snapshot update re-run  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7129](https://redirect.github.com/vitest-dev/vitest/issues/7129) [<samp>(c2beb)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/c2beb8ca)
    -   Preserve white space of `toMatchFileSnapshot`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7156](https://redirect.github.com/vitest-dev/vitest/issues/7156) [<samp>(a437b)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/a437b656)
    -   Fix obsoleteness check of `toMatchSnapshot("...")`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7126](https://redirect.github.com/vitest-dev/vitest/issues/7126) [<samp>(ac9ba)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/ac9ba151)
-   **typecheck**:
    -   Fix typecheck collect on Vite 6  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6972](https://redirect.github.com/vitest-dev/vitest/issues/6972) [<samp>(7b35d)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/7b35d13a)
    -   Use unique temp and tsbuildinfo file for each tsconfig file  -  by [@&#8203;masnormen](https://redirect.github.com/masnormen) in [https://github.com/vitest-dev/vitest/issues/7107](https://redirect.github.com/vitest-dev/vitest/issues/7107) and [https://github.com/vitest-dev/vitest/issues/7112](https://redirect.github.com/vitest-dev/vitest/issues/7112) [<samp>(61b30)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/61b30162)
    -   Fix error test case mapping for `@ts-expect-error`  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7125](https://redirect.github.com/vitest-dev/vitest/issues/7125) [<samp>(27d34)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/27d340aa)
-   **types**:
    -   Make parameters non-nullable for Playwright options  -  by [@&#8203;apple-yagi](https://redirect.github.com/apple-yagi) in [https://github.com/vitest-dev/vitest/issues/6989](https://redirect.github.com/vitest-dev/vitest/issues/6989) [<samp>(fe2a1)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/fe2a187f)
-   **ui**:
    -   Wrong module graph when generating html.meta.json.gz in browser mode  -  by [@&#8203;userquin](https://redirect.github.com/userquin) in [https://github.com/vitest-dev/vitest/issues/7214](https://redirect.github.com/vitest-dev/vitest/issues/7214) [<samp>(dccdd)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/dccdd550)
    -   Add errors and draft state (\*) to the code editor  -  by [@&#8203;userquin](https://redirect.github.com/userquin) in [https://github.com/vitest-dev/vitest/issues/7044](https://redirect.github.com/vitest-dev/vitest/issues/7044) [<samp>(faca4)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/faca4de8)
-   **vite-node**:
    -   Fix error stack on Windows  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/6786](https://redirect.github.com/vitest-dev/vitest/issues/6786) [<samp>(bf7b3)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/bf7b36ac)
    -   Properly normalize file url import  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7087](https://redirect.github.com/vitest-dev/vitest/issues/7087) [<samp>(31675)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/31675e3b)
    -   Fix mandatory node prefix  -  by [@&#8203;hi-ogawa](https://redirect.github.com/hi-ogawa) in [https://github.com/vitest-dev/vitest/issues/7179](https://redirect.github.com/vitest-dev/vitest/issues/7179) [<samp>(b6284)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/b6284642)
-   **watch**:
    -   Don't indicate exit when no matching files  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) and [@&#8203;AriPerkkio](https://redirect.github.com/AriPerkkio) in [https://github.com/vitest-dev/vitest/issues/7246](https://redirect.github.com/vitest-dev/vitest/issues/7246) [<samp>(003c0)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/003c0bef)
-   **workspace**:
    -   `extends: true` correctly inherits all root config properties  -  by [@&#8203;sheremet-va](https://redirect.github.com/sheremet-va) in [https://github.com/vitest-dev/vitest/issues/7232](https://redirect.github.com/vitest-dev/vitest/issues/7232) [<samp>(798c0)</samp>](https://redirect.github.com/vitest-dev/vitest/commit/798c0da2)

#####     [View changes on GitHub](https://redirect.github.com/vitest-dev/vitest/compare/v2.1.8...v3.0.0)

</details>

