### PR TITLE
Renovate: disable GH Actions updates as these are handled by dependabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,5 +110,8 @@
   ],
   "vulnerabilityAlerts": {
     "addLabels": ["security"]
+  },
+  "github-actions": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
renovate suddenly decided to pin our Python version in GH Actions workflow: https://github.com/cylc/cylc-ui/pull/2097, which is not needed.

I think we can just rely on dependabot for GH Actions updates anyway.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).