### PR TITLE
set state filter for offline job queries

### DIFF
--- a/src/components/cylc/analysis/TimeSeries.vue
+++ b/src/components/cylc/analysis/TimeSeries.vue
@@ -125,7 +125,7 @@ const jobFields = [
 /** The one-off query which retrieves historical job timing statistics */
 const JOB_QUERY = gql`
 query analysisJobQuery ($workflows: [ID], $tasks: [ID]) {
-  jobs(live: false, workflows: $workflows, tasks: $tasks) {
+  jobs(live: false, workflows: $workflows, tasks: $tasks, states: ["succeeded"]) {
     ${jobFields.join('\n')}
   }
 }

--- a/src/views/Gantt.vue
+++ b/src/views/Gantt.vue
@@ -120,7 +120,7 @@ const jobFields = [
 /** The query which retrieves historical Job timing statistics */
 const QUERY = gql`
 query ganttQuery ($workflows: [ID]) {
-  jobs(live: false, workflows: $workflows) {
+  jobs(live: false, workflows: $workflows, states: ["succeeded"]) {
     ${jobFields.join('\n')}
   }
 }


### PR DESCRIPTION
* Respond to schema changes in https://github.com/cylc/cylc-uiserver/pull/657
* Jobs queries used to only return succeeded jobs (all the analysis view cares about).
* The `states` and `exstates` filters have now been implemented to allow jobs in other states to be queried (to support new views).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (tests for view already included).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.