### PR TITLE
Include cylc-flow & UIS version in sidebar

### DIFF
--- a/changes.d/2135.feat.md
+++ b/changes.d/2135.feat.md
@@ -1,0 +1,1 @@
+Show more Cylc version info in the sidebar.

--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           to="/"
         >
           <template v-slot:prepend>
-            <v-icon style="opacity: 1;">{{ $options.icons.mdiHome }}</v-icon>
+            <v-icon style="opacity: 1;">{{ mdiHome }}</v-icon>
           </template>
           <v-list-item-title>Dashboard</v-list-item-title>
         </v-list-item>
@@ -49,21 +49,43 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div class="resize-bar" ref="resizeBar"></div>
     <template v-slot:append>
-      <div class="px-4 py-2 d-flex justify-center">
-        <span class="text--secondary">
-          <strong v-if="$options.mode !== 'production'">{{ $options.mode.toUpperCase() }}</strong> {{ $t('App.name') }} {{ $options.version }}
-        </span>
+      <div class="pa-2 d-flex justify-center">
+        <v-chip
+          id="version-chip"
+          label
+          class="font-weight-bold cursor-default"
+          :prepend-icon="mdiInformationOutline"
+          v-bind="versionChipProps"
+        />
+        <v-tooltip
+          activator="#version-chip"
+          location="top"
+          >
+          <div
+            class="d-flex flex-column align-center"
+            style="pointer-events: visible;"
+            data-cy="version-tooltip"
+          >
+            <span
+              v-for="(value, key) in cylcVersionInfo"
+              :key="key"
+            >
+              {{ key }} {{ value }}
+            </span>
+            <span>cylc-ui {{ UIVersion }}</span>
+          </div>
+        </v-tooltip>
       </div>
     </template>
   </v-navigation-drawer>
 </template>
 
 <script>
-import { nextTick, ref } from 'vue'
+import { inject, nextTick, ref, computed } from 'vue'
 import { useDisplay } from 'vuetify'
 import Header from '@/components/cylc/Header.vue'
 import Workflows from '@/views/Workflows.vue'
-import { mdiHome, mdiGraphql } from '@mdi/js'
+import { mdiHome, mdiInformationOutline } from '@mdi/js'
 import pkg from '@/../package.json'
 import { when } from '@/utils'
 import { useDrawer } from '@/utils/toolbar'
@@ -122,18 +144,29 @@ export default {
       )
     })
 
+    const cylcVersionInfo = inject('versionInfo')
+    const versionChipProps = computed(() => import.meta.env.MODE === 'production'
+      ? {
+          text: `Cylc ${cylcVersionInfo.value?.['cylc-flow'] ?? ''}`,
+          variant: 'text'
+        }
+      : {
+          text: import.meta.env.MODE.toUpperCase(),
+          variant: 'flat',
+          color: 'indigo-darken-4',
+        }
+    )
+
     return {
       drawer,
       drawerWidth,
       resizeBar,
+      UIVersion: pkg.version,
+      cylcVersionInfo,
+      mdiInformationOutline,
+      mdiHome,
+      versionChipProps,
     }
   },
-
-  icons: {
-    mdiHome,
-    mdiGraphql,
-  },
-  mode: import.meta.env.MODE,
-  version: pkg.version,
 }
 </script>

--- a/src/graphql/graphiql.js
+++ b/src/graphql/graphiql.js
@@ -19,7 +19,7 @@
 
 import { parse } from 'graphql'
 import { createGraphQLUrls } from '@/graphql/index'
-import { getCylcHeaders } from '@/utils/urls'
+import { getXSRFHeaders } from '@/utils/urls'
 
 // TODO: https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher/issues/16
 //       the functions hasSubscriptionOperation and graphQLFetcher are both from
@@ -115,7 +115,7 @@ function fallbackGraphQLFetcher (graphQLParams) {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        ...getCylcHeaders()
+        ...getXSRFHeaders()
       },
       body: JSON.stringify(graphQLParams),
       credentials: 'include'

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -27,7 +27,7 @@ import { getMainDefinition } from '@apollo/client/utilities'
 import { WebSocketLink } from '@apollo/client/link/ws'
 import { setContext } from '@apollo/client/link/context'
 import { store } from '@/store/index'
-import { createUrl, getCylcHeaders } from '@/utils/urls'
+import { createUrl, getXSRFHeaders } from '@/utils/urls'
 
 /** @typedef {import('subscriptions-transport-ws').ClientOptions} ClientOptions */
 
@@ -133,7 +133,7 @@ export function createApolloClient (httpUrl, subscriptionClient) {
     return {
       headers: {
         ...headers,
-        ...getCylcHeaders()
+        ...getXSRFHeaders()
       }
     }
   })

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,7 @@ import { i18n } from '@/i18n'
 import paths from '@/router/paths'
 import { store } from '@/store/index'
 import { Alert } from '@/model/Alert.model'
+import { getUserProfile } from '@/services/user.service'
 
 const defaultPageTitle = i18n.global.t('App.name')
 
@@ -72,7 +73,7 @@ const router = createRouter({
 router.beforeEach(async (to, from) => {
   NProgress.start()
   if (!store.state.user.user) {
-    const user = await router.app.config.globalProperties.$userService.getUserProfile()
+    const user = await getUserProfile()
     // TODO: catch error getting user profile and redirect to static error page
     store.commit('user/SET_USER', user)
   }

--- a/src/services/mock/json-server.cjs
+++ b/src/services/mock/json-server.cjs
@@ -19,6 +19,7 @@
 const PORT = 3000
 
 const userProfile = require('./json/userprofile.json')
+const versionInfo = require('./json/version.json')
 const graphql = require('./graphql.cjs')
 const websockets = require('./websockets.cjs')
 
@@ -29,6 +30,7 @@ const server = jsonServer.create()
 require('express-ws')(server)
 const router = jsonServer.router({
   userProfile,
+  version: versionInfo,
 })
 const middlewares = [
   ...jsonServer.defaults({ logger: false }),

--- a/src/services/mock/json/version.json
+++ b/src/services/mock/json/version.json
@@ -1,0 +1,4 @@
+{
+  "cylc-flow": "X.Y.Z",
+  "cylc-uiserver": "X.Y.Z"
+}

--- a/src/services/plugin.js
+++ b/src/services/plugin.js
@@ -17,7 +17,6 @@
 
 import { createSubscriptionClient, createGraphQLUrls } from '@/graphql'
 import SubscriptionWorkflowService from '@/services/workflow.service'
-import UserService from '@/services/user.service'
 
 /**
  * A plugin that loads the application services.
@@ -28,7 +27,6 @@ export default {
    */
   install (app) {
     this._installWorkflowService(app)
-    this._installUserService(app)
   },
 
   /**
@@ -51,16 +49,4 @@ export default {
     // Options API (legacy):
     app.config.globalProperties.$workflowService = workflowService
   },
-
-  /**
-   * Creates a user service for the application.
-   *
-   * The service is available as `Vue.$userService`.
-   *
-   * @private
-   * @param {Object} app - Vue application
-   */
-  _installUserService (app) {
-    app.config.globalProperties.$userService = new UserService()
-  }
 }

--- a/src/services/plugin.js
+++ b/src/services/plugin.js
@@ -15,8 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { shallowRef } from 'vue'
 import { createSubscriptionClient, createGraphQLUrls } from '@/graphql'
 import SubscriptionWorkflowService from '@/services/workflow.service'
+import { fetchData } from '@/utils/urls'
 
 /**
  * A plugin that loads the application services.
@@ -27,6 +29,10 @@ export default {
    */
   install (app) {
     this._installWorkflowService(app)
+
+    const versionInfo = shallowRef(null)
+    app.provide('versionInfo', versionInfo)
+    fetchData('version').then((data) => { versionInfo.value = data })
   },
 
   /**

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -15,18 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import axios from 'axios'
 import User from '@/model/User.model'
-import { createUrl, getCylcHeaders } from '@/utils/urls'
+import { fetchData } from '@/utils/urls'
 
 /**
  * Gets the user profile from the backend server.
  * @returns {Promise<User>}
  */
 export async function getUserProfile () {
-  const { data } = await axios.get(
-    createUrl('userprofile'),
-    { headers: getCylcHeaders() }
-  )
-  return new User(data)
+  return new User(await fetchData('userprofile'))
 }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -19,16 +19,14 @@ import axios from 'axios'
 import User from '@/model/User.model'
 import { createUrl, getCylcHeaders } from '@/utils/urls'
 
-export default class UserService {
-  /**
-   * Gets the user profile from the backend server.
-   * @returns {Promise<User>} - a promise that dispatches Vuex action
-   */
-  async getUserProfile () {
-    const { data } = await axios.get(
-      createUrl('userprofile'),
-      { headers: getCylcHeaders() }
-    )
-    return new User(data)
-  }
+/**
+ * Gets the user profile from the backend server.
+ * @returns {Promise<User>}
+ */
+export async function getUserProfile () {
+  const { data } = await axios.get(
+    createUrl('userprofile'),
+    { headers: getCylcHeaders() }
+  )
+  return new User(data)
 }

--- a/src/store/user.module.js
+++ b/src/store/user.module.js
@@ -25,15 +25,8 @@ export const mutations = {
   }
 }
 
-export const actions = {
-  setUser ({ commit }, user) {
-    commit('SET_USER', user)
-  }
-}
-
 export const user = {
   namespaced: true,
   state,
   mutations,
-  actions
 }

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import axios from 'axios'
+
 /**
  * Remove double forward-slashes from URL's. It avoids the slashes that
  * are preceded by ':', so that the slashes in the URL protocol are kept.
@@ -64,7 +66,7 @@ function getBaseUrl (websockets = false, baseOnly = false) {
  * @param {boolean} baseOnly - whether to use only the base URL or not when creating the new URL
  * @returns {string} - the new URL, preceded by the base URL (e.g. https://hub:8080/users/cylc/users)
  */
-function createUrl (path, websockets = false, baseOnly = false) {
+export function createUrl (path, websockets = false, baseOnly = false) {
   const baseUrl = getBaseUrl(websockets, baseOnly)
   const url = [baseUrl, path]
     .map(part => part.trim())
@@ -77,7 +79,7 @@ function createUrl (path, websockets = false, baseOnly = false) {
  *
  * - Adds X-XSRFToken header cookie-based auth.
  */
-function getCylcHeaders () {
+export function getXSRFHeaders () {
   const xsrfToken = document.cookie.match('\\b_xsrf=([^;]*)\\b')
   const cylcHeaders = {}
   if (Array.isArray(xsrfToken) && xsrfToken.length > 0) {
@@ -87,7 +89,17 @@ function getCylcHeaders () {
   return cylcHeaders
 }
 
-export {
-  createUrl,
-  getCylcHeaders,
+/**
+ * Fetches data from the given path.
+ *
+ * @param {string} path - The path to fetch data from.
+ * @returns {Promise<Object>} A promise that resolves to the fetched data.
+ * @throws {Error} If the request fails.
+ */
+export async function fetchData (path) {
+  const { data } = await axios.get(
+    createUrl(path),
+    { headers: getXSRFHeaders() }
+  )
+  return data
 }

--- a/tests/e2e/specs/drawer.cy.js
+++ b/tests/e2e/specs/drawer.cy.js
@@ -29,17 +29,19 @@ const resize = (width) => cy
   .trigger('mouseup', { force: true })
 
 describe('Drawer component', () => {
-  it('Is displayed when mode is desktop', () => {
+  it('is displayed when mode is desktop', () => {
     cy.visit('/#/')
     cy
       .get('#c-sidebar')
       .should('be.visible')
   })
-  it('it should have a width of 260', () => {
+
+  it('has a width of 260', () => {
     cy.visit('/#/')
     cy.get('#c-sidebar').invoke('innerWidth').should('be.eq', 260)
   })
-  it('Is NOT displayed when mode is mobile', () => {
+
+  it('is NOT displayed when mode is mobile', () => {
     // when the window dimension is below a mobile-threshold, the app sets state.app.drawer as false
     // and then the drawer is hidden
     cy.viewport(320, 480)
@@ -52,6 +54,7 @@ describe('Drawer component', () => {
       .get('#toggle-drawer')
       .should('be.visible')
   })
+
   it('should drag to trigger resize', () => {
     cy.visit('/#/')
     cy.get('#c-sidebar')
@@ -73,5 +76,18 @@ describe('Drawer component', () => {
       .should('be.visible')
       .invoke('innerWidth')
       .should('be.closeTo', 200, 5)
+  })
+
+  it('has Cylc version info', () => {
+    cy.visit('/#/')
+    cy.get('#version-chip')
+      .trigger('mouseenter')
+      .get('[data-cy=version-tooltip]')
+      .should('be.visible')
+      .invoke('text').then((text) => {
+        expect(text).to.contain('cylc-flow ')
+        expect(text).to.contain('cylc-uiserver ')
+        expect(text).to.contain('cylc-ui ')
+      })
   })
 })

--- a/tests/unit/services/user.service.spec.js
+++ b/tests/unit/services/user.service.spec.js
@@ -18,11 +18,11 @@
 import sinon from 'sinon'
 import axios from 'axios'
 import { createStore } from 'vuex'
-import UserService from '@/services/user.service'
+import { getUserProfile } from '@/services/user.service'
 import storeOptions from '@/store/options'
 import { Alert } from '@/model/Alert.model'
 
-describe('UserService', () => {
+describe('getUserProfile', () => {
   const store = createStore(storeOptions)
   let sandbox
   beforeEach(() => {
@@ -31,7 +31,8 @@ describe('UserService', () => {
     store.commit('SET_ALERT', null)
   })
   afterEach(() => sandbox.restore())
-  describe('getUserProfile returns the logged-in user profile information', () => {
+
+  describe('returns the logged-in user profile information', () => {
     it('returns user profile object', async () => {
       const expected = {
         username: 'cylc-user-01',
@@ -47,9 +48,10 @@ describe('UserService', () => {
         }
       })
       sandbox.stub(axios, 'get').returns(response)
-      const user = await new UserService().getUserProfile()
+      const user = await getUserProfile()
       expect(user).toMatchObject(expected)
     })
+
     it('should add an alert on error', () => {
       expect(store.state.alert).to.equal(null)
       const e = new Error('mock error')
@@ -57,7 +59,7 @@ describe('UserService', () => {
         statusText: 'Test Status'
       }
       sandbox.stub(axios, 'get').rejects(e)
-      return new UserService().getUserProfile()
+      return getUserProfile()
         .catch((error) => {
           const alert = new Alert(error.response.statusText, 'error')
           return store.dispatch('setAlert', alert)

--- a/tests/unit/store/user.spec.js
+++ b/tests/unit/store/user.spec.js
@@ -39,7 +39,7 @@ describe('user', () => {
         id: 1,
         username: 'cylc'
       }
-      store.dispatch('user/setUser', user)
+      store.commit('user/SET_USER', user)
       expect(store.state.user.user).to.deep.equal(user)
     })
   })

--- a/vite.config.js
+++ b/vite.config.js
@@ -72,7 +72,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
-        '^/(userprofile|graphql)': {
+        '^/(userprofile|version|graphql)': {
           target: devProxyTarget,
           changeOrigin: true
         },


### PR DESCRIPTION
Needs cylc-uis master (https://github.com/cylc/cylc-uiserver/pull/674)

In production mode, looks like this (where the main Cylc version == cylc-flow version):

![image](https://github.com/user-attachments/assets/1ad98fce-160b-4709-b32f-97ea940a745e)

N.B., while using this branch with cylc-uiserver 1.6.x checked out, the tooltip will show a bunch of raw HTML instead. This will not happen in production as the UI will be bundled with the cylc-uiserver 1.7.0.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
