### PR TITLE
Enhance filtering in Analysis tab

### DIFF
--- a/src/components/cylc/analysis/filter.js
+++ b/src/components/cylc/analysis/filter.js
@@ -26,9 +26,20 @@
  * @return {boolean} Boolean determining if task should be displayed
  */
 export function matchTask (task, tasksFilter) {
-  let ret = true
-  if (tasksFilter.name?.trim()) {
-    ret &&= task.name.includes(tasksFilter.name)
+  // Split the filter into individual words and conduct a search for each one
+  const filter = tasksFilter.name.split(/(\s+)/).filter(
+    function (e) { return e.trim().length > 0 }
+  )
+  let ret = false
+  // If the filter is empty, return true
+  if (!filter.length) {
+    ret = true
+  } else {
+    for (const element of filter) {
+      if (task.name.includes(element)) {
+        ret = true
+      }
+    }
   }
   if (tasksFilter.platformOption.trim?.()) {
     ret &&= task.platform === tasksFilter.platformOption

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -28,14 +28,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           md="4"
           class="pr-md-2 mb-2 mb-md-0"
         >
-          <v-text-field
-            id="c-analysis-filter-task-name"
-            clearable
-            placeholder="Filter by task name"
-            v-model.trim="tasksFilter.name"
-            ref="filterNameInput"
-            :disabled="chartType === 'timeSeries'"
-          />
+          <v-tooltip>
+            <template #activator="{ props }">
+              <v-text-field
+                id="c-analysis-filter-task-name"
+                clearable
+                placeholder="Filter by task name"
+                v-model.trim="tasksFilter.name"
+                ref="filterNameInput"
+                :disabled="chartType === 'timeSeries'"
+                v-bind="props"
+              />
+            </template>
+          <span>Add task names separated by a space</span>
+          </v-tooltip>
         </v-col>
         <v-col
           cols="12"


### PR DESCRIPTION
In some feedback from users. They would like a more powerful filtering mechanism.
This change allows for multiple terms to be filtered for. The Analysis view will display all jobs that match any of the terms. Terms are separated by a space. A tool tip has been added to the filtering box to help inform users this can be done
Unit tests do not need to be updated

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x ] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
