### PR TITLE
Tree view platform badge

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -25,3 +25,5 @@ Jamie Allen           <jamie.allen@metoffice.gov.uk>           JAllen42         
 Jamie Allen           <69790602+JAllen42@users.noreply.github.com>
 Christopher Bennett   <christopher.bennett@metoffice.gov.uk>   ChrisPaulBennett
 Mark Dawson           <mark.dawson@metoffice.gov.uk>       Mark Dawson         <mark.dawson@metoffice.gov.ukpython>
+Harleen Kaur          <harleen9355@gmail.com>                  harleenkaur2003         <160705023+harleenkaur2003@users.noreply.github.com>
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ below.
  - Christopher Bennett
  - Mark Dawson
  - Min RK
+ - Harleen Kaur
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -95,7 +95,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               v-if="!isExpanded && latestJob(node)?.platform"
               class="mx-1 text-grey"
             >
-              [{{ latestJob(node)?.platform }}]
+              {{ latestJob(node)?.platform }}
             </span>
             <FlowNumsChip :flowNums="node.node.flowNums"/>
           </div>

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -91,6 +91,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               />
             </div>
             <span class="mx-1">{{ node.name }}</span>
+            <span
+              v-if="!isExpanded && latestPlatform"
+              class="platform-badge mx-1 text-caption text-grey"
+            >
+              [{{ latestPlatform }}]
+            </span>
             <FlowNumsChip :flowNums="node.node.flowNums"/>
           </div>
           <template v-else-if="node.type === 'job'">
@@ -179,6 +185,7 @@ import { getIndent, getNodeChildren } from '@/components/cylc/tree/util'
 import { once } from '@/utils'
 import { useToggle } from '@vueuse/core'
 import FlowNumsChip from '@/components/cylc/common/FlowNumsChip.vue'
+import { computed } from 'vue' //
 
 export default {
   name: 'TreeItem',
@@ -243,12 +250,21 @@ export default {
     // Toggles to true when this.isExpanded first becomes true and doesn't get recomputed afterwards
     const renderChildren = once(isExpanded)
 
+    const latestPlatform = computed(() => {
+      const jobs = props.node.children
+      if (props.node.type === 'task' && jobs?.length) {
+        return jobs[0]?.node?.platform || null
+      }
+      return null
+    })
+
     return {
       isExpanded,
       isFlowNone,
       latestJob,
       renderChildren,
       toggleExpandCollapse,
+      latestPlatform,
     }
   },
 

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -92,10 +92,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
             <span class="mx-1">{{ node.name }}</span>
             <span
-              v-if="!isExpanded && latestPlatform"
-              class="platform-badge mx-1 text-caption text-grey"
+              v-if="!isExpanded && latestJob(node)?.platform"
+              class="mx-1 text-grey"
             >
-              [{{ latestPlatform }}]
+              [{{ latestJob(node)?.platform }}]
             </span>
             <FlowNumsChip :flowNums="node.node.flowNums"/>
           </div>
@@ -185,7 +185,6 @@ import { getIndent, getNodeChildren } from '@/components/cylc/tree/util'
 import { once } from '@/utils'
 import { useToggle } from '@vueuse/core'
 import FlowNumsChip from '@/components/cylc/common/FlowNumsChip.vue'
-import { computed } from 'vue' //
 
 export default {
   name: 'TreeItem',
@@ -250,21 +249,12 @@ export default {
     // Toggles to true when this.isExpanded first becomes true and doesn't get recomputed afterwards
     const renderChildren = once(isExpanded)
 
-    const latestPlatform = computed(() => {
-      const jobs = props.node.children
-      if (props.node.type === 'task' && jobs?.length) {
-        return jobs[0]?.node?.platform || null
-      }
-      return null
-    })
-
     return {
       isExpanded,
       isFlowNone,
       latestJob,
       renderChildren,
       toggleExpandCollapse,
-      latestPlatform,
     }
   },
 


### PR DESCRIPTION
Title:

Display Latest Job Platform on Unexpanded Task Node

Description:

- This pull request addresses issue #2153.
- Displays the latest job’s platform (e.g., [localhost]) next to collapsed task nodes in the Tree View.
- Mimics the behavior of the job summary icon — platform info disappears once the node is expanded.
- Uses the existing platform property for consistency with job nodes.
- Ensures UI alignment with the provided mockup.

Screenshot: 
![Screenshot (345)](https://github.com/user-attachments/assets/d1f9450b-fc0f-470e-9f25-86bb052d0b5a)

Checklist:

- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included (or explain why tests are not needed). [Tests are not included since this is a visual UI change with no backend logic or new components]
- [x] Changelog entry not included - UI is improved but this is a minor visual enhancement
- [x] Docs not required- this change does not require documentation update

