### PR TITLE
workflows table: add cylc version column

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -65,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               Workflows Table
             </v-list-item-title>
             <v-list-item-subtitle>
-              View name, host, port, etc. of your workflows
+              View name, host, version, etc. of your workflows
             </v-list-item-subtitle>
           </v-list-item>
           <v-list-item to="/user-profile" data-cy="user-settings-link">

--- a/src/views/Workflows.vue
+++ b/src/views/Workflows.vue
@@ -60,9 +60,6 @@ fragment WorkflowData on Workflow {
   id
   status
   statusMsg
-  owner
-  host
-  port
   stateTotals
   latestStateTasks(states: [
     "failed",

--- a/src/views/WorkflowsTable.vue
+++ b/src/views/WorkflowsTable.vue
@@ -114,7 +114,7 @@ fragment WorkflowData on Workflow {
 `
 
 export default {
-  name: 'WorkflowTable',
+  name: 'WorkflowsTable',
 
   mixins: [
     subscriptionComponentMixin,

--- a/src/views/WorkflowsTable.vue
+++ b/src/views/WorkflowsTable.vue
@@ -55,6 +55,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 {{ item.node.status }}
               </td>
               <td>
+                {{ item.node.cylcVersion }}
+              </td>
+              <td>
                 {{ item.node.owner }}
               </td>
               <td>
@@ -75,8 +78,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { mapState, mapGetters } from 'vuex'
 import { i18n } from '@/i18n'
 import { mdiTable } from '@mdi/js'
-import subscriptionMixin from '@/mixins/subscription'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
+import subscriptionComponentMixin from '@/mixins/subscriptionComponent'
 import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon.vue'
 import gql from 'graphql-tag'
 
@@ -103,6 +106,7 @@ subscription Workflow {
 fragment WorkflowData on Workflow {
   id
   status
+  cylcVersion
   owner
   host
   port
@@ -110,10 +114,10 @@ fragment WorkflowData on Workflow {
 `
 
 export default {
-  name: 'WorkflowsTable',
+  name: 'WorkflowTable',
 
   mixins: [
-    subscriptionMixin
+    subscriptionComponentMixin,
   ],
 
   components: {
@@ -163,6 +167,11 @@ export default {
       sortable: true,
       title: 'Status',
       key: 'node.status'
+    },
+    {
+      sortable: true,
+      title: 'Cylc Version',
+      key: 'node.cylcVersion'
     },
     {
       sortable: true,


### PR DESCRIPTION
* Add a version column to the workflow table (makes it easier for users to find workflows running under older versions as a stopgap measure).
* Rename the "workflows table" to "workflow table" (note the URL was already "workflow-table" so this is a non-change).
* Fix a problem where the "workflow-table" was not registering its subscription properly so was relying on the "workflows view" subscription for the data it needed.
* Removed fields from the "workflows view" subscription that are not needed for the workflows view.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users - v-minor
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.