### PR TITLE
AOTF: handle alternate mutation response formats

### DIFF
--- a/changes.d/2174.fix.md
+++ b/changes.d/2174.fix.md
@@ -1,0 +1,1 @@
+Fixed spurious error when running a command on multiple workflows.

--- a/src/components/core/Alert.vue
+++ b/src/components/core/Alert.vue
@@ -27,40 +27,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   >
     <template v-slot:actions>
       <v-btn
-        icon
+        :icon="mdiClose"
         @click="closeAlert"
         data-cy="snack-close"
-      >
-        <v-icon>{{ $options.icons.mdiClose }}</v-icon>
-      </v-btn>
+      />
     </template>
-    {{ alert.text }}
+    <p>
+      {{ alert.text }}
+    </p>
+    <p
+      v-if="alert.detail"
+      class="mt-2 opacity-80"
+    >
+      {{ alert.detail }}
+    </p>
   </v-snackbar>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue'
+import { useStore } from 'vuex'
 import { mdiClose } from '@mdi/js'
-import { mapActions, mapState } from 'vuex'
 
-export default {
-  name: 'Alert',
+const store = useStore()
+const alert = computed(() => store.state.alert)
 
-  computed: {
-    ...mapState(['alert'])
-  },
-
-  methods: {
-    ...mapActions(['setAlert']),
-    /**
-     * Dismisses the alert from the UI, also removing it from the Vuex store.
-     */
-    closeAlert () {
-      this.setAlert(null)
-    }
-  },
-
-  icons: {
-    mdiClose
-  }
+/**
+ * Dismisses the alert from the UI, also removing it from the Vuex store.
+ */
+function closeAlert () {
+  store.dispatch('setAlert', null)
 }
 </script>

--- a/src/model/Alert.model.js
+++ b/src/model/Alert.model.js
@@ -21,10 +21,12 @@ export class Alert {
    * @param {Error|string} err - original thrown error to log if possible, or an error message.
    * @param {string} color - color of the displayed alert.
    * @param {?string} msg - a custom message to display in the alert instead of err.
+   * @param {?string} detail - more details to show.
    */
-  constructor (err, color, msg = null) {
+  constructor (err, color, msg = null, detail = null) {
     this.err = err
     this.text = msg || err
     this.color = color
+    this.detail = detail
   }
 }

--- a/tests/unit/services/workflow.service.spec.js
+++ b/tests/unit/services/workflow.service.spec.js
@@ -30,6 +30,15 @@ import WorkflowService from '@/services/workflow.service'
 import ViewState from '@/model/ViewState.model'
 import { TreeCallback, WorkflowCallback } from './testCallback'
 
+vi.mock('@/graphql/index', () => ({
+  createApolloClient: () => ({
+    query: vi.fn(),
+    subscribe: () => ({
+      subscribe: vi.fn()
+    }),
+  })
+}))
+
 const sandbox = sinon.createSandbox()
 
 describe('WorkflowService', () => {
@@ -63,14 +72,6 @@ describe('WorkflowService', () => {
   let subscription
   beforeEach(() => {
     sandbox.stub(console, 'debug')
-    vi.mock('@/graphql/index', () => ({
-      createApolloClient: () => ({
-        query: vi.fn(),
-        subscribe: () => ({
-          subscribe: vi.fn()
-        }),
-      })
-    }))
     subscriptionClient = null
     // TODO: really load some mutations
     sandbox.stub(WorkflowService.prototype, 'loadTypes').returns(

--- a/tests/unit/utils/aotf.spec.js
+++ b/tests/unit/utils/aotf.spec.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,10 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { afterAll, beforeAll } from 'vitest'
 import * as aotf from '@/utils/aotf'
 import dedent from 'dedent'
 // need the polyfill as otherwise ApolloClient fails to be imported as it checks for a global fetch object on import...
 import 'cross-fetch/polyfill'
+import sinon from 'sinon'
 
 describe('aotf (Api On The Fly)', () => {
   describe('tokenise', () => {
@@ -749,6 +751,141 @@ describe('aotf (Api On The Fly)', () => {
         { name: 'width', fields: null },
         { name: 'height', fields: null }
       ])
+    })
+  })
+
+  describe('handleMutationResponse()', () => {
+    const mutation = { name: 'breach' }
+    beforeAll(() => {
+      sinon.stub(console, 'error')
+      sinon.stub(console, 'warn')
+    })
+    afterAll(() => {
+      sinon.restore()
+    })
+
+    it.each([
+      {
+        testID: 'original interface',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: [true, 'arasaka']
+            }
+          }
+        },
+        expected: {
+          status: 'SUCCEEDED', message: 'arasaka'
+        }
+      },
+
+      {
+        testID: 'original interface with failure',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: [false, 'relic malfunction']
+            }
+          }
+        },
+        expected: {
+          status: 'FAILED', message: 'relic malfunction'
+        }
+      },
+
+      {
+        testID: 'nested',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: [
+                {
+                  [mutation.name]: {
+                    result: [{ id: 'wflow1', response: [true, 'arasaka'] }]
+                  }
+                },
+                {
+                  [mutation.name]: {
+                    result: [{ id: 'wflow2', response: [true, 'kiroshi'] }]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        expected: {
+          status: 'SUCCEEDED', message: 'Command(s) submitted'
+        }
+      },
+
+      {
+        testID: 'nested with failure',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: [
+                {
+                  [mutation.name]: {
+                    result: [{ id: 'wflow1', response: [true, 'arasaka'] }]
+                  }
+                },
+                {
+                  [mutation.name]: {
+                    result: [{ id: 'wflow2', response: [false, 'relic malfunction'] }]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        expected: {
+          status: 'FAILED', message: 'relic malfunction'
+        }
+      },
+
+      {
+        testID: 'other format',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: [{ response: [true, 'arasaka'] }]
+            }
+          }
+        },
+        expected: {
+          status: 'SUCCEEDED', message: 'Command(s) submitted'
+        }
+      },
+
+      {
+        testID: 'other format with failure',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: [{ response: [false, 'relic malfunction'] }]
+            }
+          }
+        },
+        expected: {
+          status: 'FAILED', message: 'relic malfunction'
+        }
+      },
+
+      {
+        testID: 'unexpected format - assume success',
+        response: {
+          data: {
+            [mutation.name]: {
+              result: 2077,
+            }
+          }
+        },
+        expected: {
+          status: 'SUCCEEDED', message: 2077
+        }
+      }
+    ])('handles response - $testID', async ({ response, expected, testID }) => {
+      expect(await aotf.handleMutationResponse(mutation, response)).toStrictEqual(expected)
     })
   })
 })


### PR DESCRIPTION
Closes #1851

> In a mutation form, adding multiple workflows to run the mutation on results in an error snackbar.
> 
> ![image](https://github.com/cylc/cylc-ui/assets/61982285/8a4a92a9-fc83-43a3-b5af-d49cb9645480)
> 
> This is because the response we get from the UIServer is in an odd format



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs needed

