### PR TITLE
Workspace layouts: avoid duplicate layout saving when resetting to default

### DIFF
--- a/src/components/cylc/workspace/Lumino.vue
+++ b/src/components/cylc/workspace/Lumino.vue
@@ -246,10 +246,8 @@ async function restoreLayout () {
  * Reset the workspace layout to a single tab with the default view.
  */
 async function resetToDefault () {
-  layoutWatcher.pause()
-  await closeAllViews()
+  await layoutWatcher.ignore(closeAllViews)
   await addView({ name: defaultView.value })
-  // (addView resumes the layout watcher)
 }
 
 /**
@@ -257,13 +255,12 @@ async function resetToDefault () {
  *
  * @param {string} id - widget ID
  */
-const onWidgetDeleted = (id) => {
-  // layoutWatcher will be triggered by DockPanel.layoutModified, so pause to avoid duplicate trigger:
-  layoutWatcher.pause()
-  views.value.delete(id)
-  layoutWatcher.resume()
-  if (!views.value.size) {
-    emit('emptied')
-  }
+function onWidgetDeleted (id) {
+  layoutWatcher.ignore(() => {
+    views.value.delete(id)
+    if (!views.value.size) {
+      emit('emptied')
+    }
+  })
 }
 </script>

--- a/src/utils/reactivity.js
+++ b/src/utils/reactivity.js
@@ -77,7 +77,7 @@ export function once (source, options = {}) {
 }
 
 /**
- * Provides a controlled watcher with pause, resume, and manual trigger capabilities.
+ * Provides a controlled watcher with pause, resume, ignore and manual trigger and capabilities.
  *
  * Unlike the standard Vue `watch()`, resuming a paused watcher will not trigger the callback immediately.
  * Using the `trigger()` method only works if the watcher is not paused.
@@ -95,6 +95,15 @@ export function watchWithControl (source, callback, options = {}) {
     },
     resume () {
       watchHandle ??= doWatch()
+    },
+    async ignore (cb) {
+      if (watchHandle) {
+        this.pause()
+        await cb()
+        this.resume()
+      } else {
+        await cb()
+      }
     },
     trigger () {
       if (watchHandle) { // Only trigger if not paused

--- a/tests/unit/utils/reactivity.spec.js
+++ b/tests/unit/utils/reactivity.spec.js
@@ -118,4 +118,35 @@ describe('watchWithControl()', () => {
     watcher.trigger()
     expect(callback).toHaveBeenCalledTimes(2)
   })
+
+  it('allows ignoring changes during a callback', async () => {
+    const source = ref(0)
+    const callback = vi.fn()
+    const watcher = watchWithControl(source, callback)
+
+    await watcher.ignore(() => {
+      source.value++
+    })
+    expect(source.value).toEqual(1)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(0)
+
+    source.value++
+    expect(source.value).toEqual(2)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    watcher.pause()
+    // Check ignore changes while paused does not inadvertently resume the watcher
+    await watcher.ignore(() => {
+      source.value++
+    })
+    expect(source.value).toEqual(3)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(1)
+    source.value++
+    expect(source.value).toEqual(4)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
Follow up to #2176 

I spotted that clicking the "reset layout" button caused two layout saves to occur instead of just one when it has finished resetting the layout.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry not needed as invisible to users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
