### PR TITLE
Clarify Data View

### DIFF
--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -110,6 +110,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-btn>
         </v-defaults-provider>
         <!-- Box plot sort input teleports here -->
+        <v-chip closable>
+          The Analysis View only shows successful tasks.
+        </v-chip>
       </div>
       <AnalysisTable
         v-if="chartType === 'table'"

--- a/src/views/Analysis.vue
+++ b/src/views/Analysis.vue
@@ -108,11 +108,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <v-icon :icon="$options.icons.mdiRefresh" />
             <v-tooltip>Refresh data</v-tooltip>
           </v-btn>
+          <v-btn>
+            <v-icon :icon="$options.icons.mdiInformationOutline" />
+            <v-tooltip>
+              The Analysis View shows data for all succeeded jobs in all cycles
+              of the workflow.
+            </v-tooltip>
+          </v-btn>
         </v-defaults-provider>
         <!-- Box plot sort input teleports here -->
-        <v-chip closable>
-          The Analysis View only shows successful tasks.
-        </v-chip>
       </div>
       <AnalysisTable
         v-if="chartType === 'table'"
@@ -165,6 +169,7 @@ import {
   mdiChartTimelineVariant,
   mdiRefresh,
   mdiTable,
+  mdiInformationOutline,
 } from '@mdi/js'
 
 /** List of fields to request for task for each task */
@@ -354,6 +359,7 @@ export default {
     mdiChartTimelineVariant,
     mdiRefresh,
     mdiTable,
+    mdiInformationOutline,
   },
 
   timingOptions: [


### PR DESCRIPTION
#2181
This pull request address's issue raised in issue #2181.
It adds a simple closeable chip up by the filers that informs the user that the analysis tab only shows successful tasks

**Check List**

- [x ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
