### PR TITLE
graph: fix missing graph arrows

### DIFF
--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     >
       <defs>
         <marker
-          id="arrow-end"
+          :id="`${_uid}-arrow-end`"
           viewbox="0 0 8 8"
           refX="1" refY="5"
           markerUnits="strokeWidth"
@@ -83,7 +83,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               stroke="rgb(90,90,90)"
               stroke-width="5"
               fill="none"
-              marker-end="url(#arrow-end)"
+              :marker-end="`url(#${_uid}-arrow-end)`"
             />
           </g>
         </g>


### PR DESCRIPTION
* Fix an issue where graph arrow heads would disappear if another graph view instance was opened.
* The marker ID from one `<svg />` document appears to have been interfering with another?

To replicate the issue, open one graph view tab, then open another.

**Check List**


- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users - irrelevant
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
