### PR TITLE
AOTF: Do not send non-required mutation args when they have the default value

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -762,10 +762,11 @@ export function argumentSignature (arg) {
 /** Construct a mutation string from a mutation introspection.
  *
  * @param {Mutation} mutation - A mutation as returned by an introspection query.
+ * @param {Record<string,any>} variables
  *
  * @returns {string} A mutation string for a client to send to the server.
  */
-export function constructMutation (mutation) {
+export function constructMutation (mutation, variables) {
   // the scan mutation has no arguments
   if (!mutation.args.length) {
     return dedent`
@@ -780,6 +781,12 @@ export function constructMutation (mutation) {
   const argNames = []
   const argTypes = []
   for (const arg of mutation.args) {
+    if (!arg._required && variables?.[arg.name] === arg._default) {
+      // Skip optional arguments that are set to their default value -
+      // this helps avoid back-compat issues when we add new args to the schema
+      // TODO: remove this workaround when addressing https://github.com/cylc/cylc-ui/issues/1225
+      continue
+    }
     argNames.push(`${arg.name}: $${arg.name}`)
     argTypes.push(`$${arg.name}: ${argumentSignature(arg)}`)
   }
@@ -934,14 +941,14 @@ async function _mutateError (mutationName, err, response) {
  * Call a mutation.
  *
  * @param {Mutation} mutation
- * @param {Object} variables
+ * @param {Record<string,any>} variables
  * @param {ApolloClient} apolloClient
  * @param {string=} cylcID
  *
  * @returns {(MutationResponse | Promise<MutationResponse>)} {status, msg}
  */
 export async function mutate (mutation, variables, apolloClient, cylcID) {
-  const mutationStr = constructMutation(mutation)
+  const mutationStr = constructMutation(mutation, variables)
   // eslint-disable-next-line no-console
   console.debug(mutationStr, variables)
 

--- a/tests/unit/utils/aotf.spec.js
+++ b/tests/unit/utils/aotf.spec.js
@@ -566,9 +566,41 @@ describe('aotf (Api On The Fly)', () => {
           }
         ]
       }
-      expect(aotf.constructMutation(mutation)).to.equal(dedent`
+      aotf.processMutations([mutation])
+      const variables = {
+        foo: 'defined',
+        bar: 'defined', // N.B. type irrelevant for this test
+      }
+      expect(aotf.constructMutation(mutation, variables)).to.equal(dedent`
         mutation MyMutation($foo: String, $bar: Int) {
           MyMutation(foo: $foo, bar: $bar) {
+            result
+          }
+        }
+      `.trim())
+    })
+
+    it("doesn't include non-required args with default value", () => {
+      const mutation = {
+        name: 'MyMutation',
+        args: [
+          {
+            name: 'foo',
+            type: { name: 'String', kind: 'SCALAR' },
+            defaultValue: 'default',
+          },
+          {
+            name: 'bar',
+            type: { name: 'Int', kind: 'SCALAR' },
+            defaultValue: 42,
+          }
+        ]
+      }
+      aotf.processMutations([mutation])
+      const variables = { foo: 'default', bar: 42 }
+      expect(aotf.constructMutation(mutation, variables)).to.equal(dedent`
+        mutation MyMutation() {
+          MyMutation() {
             result
           }
         }
@@ -597,6 +629,7 @@ describe('aotf (Api On The Fly)', () => {
           }
         ]
       }
+      aotf.processMutations([mutation])
       expect(aotf.constructMutation(mutation)).to.equal(dedent`
         mutation MyMutation($myArg: [String]!) {
           MyMutation(myArg: $myArg) {


### PR DESCRIPTION
As mentioned in https://github.com/cylc/cylc-flow/pull/6820, the reload command in the GUI currently will be broken for workflows running in Cylc < 8.5.0.

This is because https://github.com/cylc/cylc-flow/pull/6509 added a new argument in the schema. However we can work around this by not sending that arg when it is the default value.

This workaround can be removed when #1225 is addressed.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry not needed as the problem will not be released until 8.5.0
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
