### PR TITLE
aotf: replace "reload" with `validateReinstall`

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -142,12 +142,13 @@ export function getMutationIcon (name) {
     case 'play': return mdiPlay
     case 'poll': return mdiRefreshCircle
     case 'release': return mdiPlayCircleOutline // to distinguish from play
-    case 'reload': return mdiReload
     case 'remove': return mdiMinusCircleOutline
     case 'resume': return mdiPlay
     case 'set': return mdiVectorPolylineEdit
     case 'stop': return mdiStop
     case 'trigger': return mdiCursorPointer
+    case 'reinstallReload': return mdiReload
+    case 'reinstallRestart': return mdiReload
     default: return mdiCog
   }
 }
@@ -179,7 +180,8 @@ export const primaryMutations = {
     'resume',
     'pause',
     'stop',
-    'reload',
+    'reinstallRestart',
+    'reinstallReload',
     'clean',
     'log'
   ],


### PR DESCRIPTION
* The `reload` mutation isn't the most helpful command post `cylc install`.
* Swap it out in the workflow command shortlist for the [newly added](https://github.com/cylc/cylc-uiserver/pull/746) `validateReinstall` mutation which has wider scope.

Providing both "reload" and "validate reinstall" as refresh-like options is a bit unclear, so I opted to replace reload (which doesn't serve much function without reinstall) with validate-reinstall. Obvs the reload command is still there for those who need it, but no longer prominently advertised.

Will add a screen recording to the docs and a changes entry there once agreed on this one.

Needs:
- https://github.com/cylc/cylc-uiserver/pull/746

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users - meh - will add a global changelog though
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.