### PR TITLE
Improve tree view text vertical alignment

### DIFF
--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -20,7 +20,7 @@
 
 $active-color: #BDD5F7;
 /** Height of each line/row in the tree. */
-$line-height: 1.8em;
+$node-height: 1.8em;
 /**
  * The number of visible outputs in the job info box, under the “outputs” header.
  * This value is used to calculate the maximum height of the
@@ -64,7 +64,8 @@ $icon-width: 1.5rem;
   vertical-align:middle;
   width: 100%;
   .node {
-    line-height: $line-height;
+    min-height: $node-height;
+    line-height: normal;
     display: block;
 
     .node-expand-collapse-button {


### PR DESCRIPTION
Before vs after in Chromium:

<img width="335" height="123" alt="image" src="https://github.com/user-attachments/assets/7569c7a2-95f7-47ef-8baf-2d6fb311d1c0" />

<img width="328" height="122" alt="image" src="https://github.com/user-attachments/assets/c298c2c1-52e0-4ea1-9cd3-5376c3600258" />

Subtle difference but once I saw it I could not unsee it

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are not needed 
- [x] Changelog entry not needed as minor
- [x] Docs not needed
