### PR TITLE
Fix workflow dirs sorting bug in GScan

### DIFF
--- a/changes.d/2349.fix.md
+++ b/changes.d/2349.fix.md
@@ -1,0 +1,1 @@
+Fixed workflow sorting bug in the sidebar.

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -144,7 +144,9 @@ function addChild (parentNode, childNode) {
   }
 
   // insert the child preserving sort order
-  const iteratee = (n) => `${n.type}-${n.name}` // (this makes families sort before tasks in the tree)
+  const iteratee = ['task', 'family'].includes(childNode.type)
+    ? (n) => `${n.type}-${n.name}` // (this makes families sort before tasks in the tree)
+    : (n) => n.name
   const reverse = ['cycle', 'job'].includes(childNode.type)
   const index = sortedIndexBy(
     parentNode[key],


### PR DESCRIPTION
Workflow dirs/parts were being sorted in between workflows beginning with "o" and "p", introduced in #2143

This was because `workflow-parts` and `workflow` types are sorted together, and the iteratee `(n) => ${n.type}-${n.name}` would lead to e.g. comparisons between `workflow-oscar` and `workflow-parts-alpha` 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
