### PR TITLE
Truncate messages in warning triangle tooltip and dashboard events table

### DIFF
--- a/src/components/cylc/WarningIcon.vue
+++ b/src/components/cylc/WarningIcon.vue
@@ -65,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <td style="padding-right: 0.5em; vertical-align: top;">
             <EventChip :level="event.level" />
           </td><td>
-            <span>{{ event.message }}</span>
+            <span class="truncated-message">{{ event.message }}</span>
           </td>
         </tr>
       </table>
@@ -134,3 +134,11 @@ export default {
   path: PATH,
 }
 </script>
+
+<style lang="scss" scoped>
+@use "/src/styles/util";
+
+.truncated-message {
+  @include util.line-clamp(2);
+}
+</style>

--- a/src/styles/_util.scss
+++ b/src/styles/_util.scss
@@ -28,3 +28,12 @@
     }
   }
 }
+
+@mixin line-clamp($lines) {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
+  line-clamp: $lines;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -49,18 +49,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           data-cy="events-table"
         >
           <!-- Hide header: -->
-          <template v-slot:headers></template>
+          <template #headers></template>
 
           <!-- Hide footer if no events: -->
-          <template v-if="!events.length" v-slot:bottom></template>
+          <template v-if="!events.length" #bottom></template>
 
           <!-- Special template if there are no events to display -->
-          <template v-slot:no-data>
-            <td class="text-h6 text-disabled">No events</td>
+          <template #no-data>
+            <span class="text-h6 text-disabled">No events</span>
           </template>
 
-          <template v-slot:item.level="{ item }">
+          <template #item.level="{ item }">
             <EventChip :level="item.level" />
+          </template>
+          <template #item.message="{ item }">
+            <div class="truncated-message py-1">
+              {{ item.message }}
+            </div>
           </template>
         </v-data-table>
       </v-col>
@@ -342,3 +347,11 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" scoped>
+@use "/src/styles/util";
+
+.truncated-message {
+  @include util.line-clamp(4);
+}
+</style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :items="workflowsTable"
           :loading="isLoading"
           id="dashboard-workflows"
-          items-per-page="-1"
+          :items-per-page="-1"
           style="font-size: 1rem;"
           density="compact"
         >
@@ -43,7 +43,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <v-data-table
           :headers="$options.eventsHeader"
           :items="events"
-          :items-per-page="8"
+          v-model:items-per-page="eventsItemsPerPage"
+          :items-per-page-options="eventsItemsPerPageOptions"
           density="compact"
           data-cy="events-table"
         >
@@ -185,6 +186,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <script>
 import { mapState, mapGetters } from 'vuex'
+import { useLocalStorage } from '@vueuse/core'
 import {
   mdiBook,
   mdiBookMultiple,
@@ -247,6 +249,22 @@ export default {
 
   components: {
     EventChip,
+  },
+
+  setup () {
+    const eventsItemsPerPage = useLocalStorage('dashboardEventsItemsPerPage', 8)
+    const eventsItemsPerPageOptions = [
+      { value: 5, title: '5' },
+      { value: 8, title: '8' },
+      { value: 10, title: '10' },
+      { value: 20, title: '20' },
+      { value: -1, title: 'All' },
+    ]
+
+    return {
+      eventsItemsPerPage,
+      eventsItemsPerPageOptions,
+    }
   },
 
   data () {


### PR DESCRIPTION
These can be quite long and can even include traceback sometimes.

Also save items per page for the dashboard events table, in local storage.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] Docs not needed.

