### PR TITLE
Fix empty cycle point bug

### DIFF
--- a/changes.d/2386.fix.md
+++ b/changes.d/2386.fix.md
@@ -1,0 +1,1 @@
+Fixed occasional empty cycle point bug in the tree view.

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -386,14 +386,13 @@ function getFamilyTree (tokens, node) {
   }
 
   // add family levels below the cycle point
-  if (node.ancestors?.length) {
-    for (const ancestor of node.ancestors.slice().reverse()) {
-      ret.push([
-        'family',
-        ancestor.name,
-        lastTokens.clone({ task: ancestor.name })
-      ])
-    }
+  for (let i = node.ancestors?.length ?? 0; i > 0; i--) {
+    const { name } = node.ancestors[i - 1]
+    ret.push([
+      'family',
+      name,
+      lastTokens.clone({ task: name })
+    ])
   }
 
   // add the family itself

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -386,12 +386,14 @@ function getFamilyTree (tokens, node) {
   }
 
   // add family levels below the cycle point
-  for (const ancestor of node.ancestors.slice().reverse()) {
-    ret.push([
-      'family',
-      ancestor.name,
-      lastTokens.clone({ task: ancestor.name })
-    ])
+  if (node.ancestors?.length) {
+    for (const ancestor of node.ancestors.slice().reverse()) {
+      ret.push([
+        'family',
+        ancestor.name,
+        lastTokens.clone({ task: ancestor.name })
+      ])
+    }
   }
 
   // add the family itself

--- a/src/store/workflows.module.js
+++ b/src/store/workflows.module.js
@@ -385,7 +385,9 @@ function getFamilyTree (tokens, node) {
     }
   }
 
-  // add family levels below the cycle point
+  // Add family levels below the cycle point:
+  // N.B. guarding against node.ancestors being undefined sometimes, which shouldn't really happen -
+  // possibly caused by https://github.com/cylc/cylc-uiserver/issues/767
   for (let i = node.ancestors?.length ?? 0; i > 0; i--) {
     const { name } = node.ancestors[i - 1]
     ret.push([


### PR DESCRIPTION
Closes #1922

Guard against `node.ancestors` being `undefined` rather than an empty array.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests not needed?
- [x] Changelog entry
- [x] Docs not needed

