### PR TITLE
fix command editor

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -52,7 +52,7 @@ import { Alert } from '@/model/Alert.model'
 import { store } from '@/store/index'
 import { detokenise, Tokens } from '@/utils/uid'
 import { WorkflowState, WorkflowStateNames } from '@/model/WorkflowState.model'
-import { isBoolean, startCase } from 'lodash-es'
+import { cloneDeep, isBoolean, startCase } from 'lodash-es'
 
 /** @typedef {import('@apollo/client').ApolloClient} ApolloClient */
 /** @typedef {import('graphql').IntrospectionInputType} IntrospectionInputType  */
@@ -828,7 +828,7 @@ export function getMutationArgsFromTokens (mutation, tokens) {
     }
     argspec[arg.name] ||= arg._default
   }
-  return argspec
+  return cloneDeep(argspec)
 }
 
 /**


### PR DESCRIPTION
Fix two issues with the command editor spotted at release time:

1. Edits were ignored when the form was submitted.
2. Edits to the form were preserved when subsequently opening the form again.