### PR TITLE
workaround broadcast form restoration issue

### DIFF
--- a/src/components/cylc/Mutation.vue
+++ b/src/components/cylc/Mutation.vue
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <!-- the open in new tab button -->
     <template v-slot:append v-if="!isView">
       <v-icon
-        v-if="mutation.name !== 'editRuntime'"
+        v-if="!['editRuntime', 'broadcast'].includes(mutation.name)"
         data-cy="open-in-new-tab"
         @click="openInTab"
       >


### PR DESCRIPTION
The `settings` field in the `broadcast` mutation is a bit dodgy at the moment.

The field is declared as a string:

https://github.com/cylc/cylc-flow/blob/9d50fc02fce5898c2ed86fd636c7a70a02620233/cylc/flow/network/schema.py#L1656-L1658

But it's really a nested array:

```console
$ cylc broadcast --debug -v -v generic -s '[meta]foo=bar'
DEBUG - [client:332] - zmq:send {'command': 'graphql', 'args': {'request_string': '\nmutation ...  'bSettings': [{'meta': {'foo':
    'bar'}}], ,...}
```

The UI component handles this, but, when we restore the form it's getting the array structure rather than a string.

Strangely, this actually works, and the form submits the value as expected, however the fields do not render, like at all. You can see that there is a setting there, but there's no text!