### PR TITLE
reduce the size of the introspection query

### DIFF
--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -530,6 +530,38 @@ export function getIntrospectionQuery () {
         types {
           ...FullType
         }
+        # omits:
+        # * subscriptionType
+        # * directives
+        # * locations and args
+      }
+    }
+
+    fragment TypeFields on __Type {
+      kind
+      name
+      description
+
+      fields(includeDeprecated: false) {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        enumValues(includeDeprecated: true) {
+          name
+          description
+          isDeprecated
+          deprecationReason
+        }
+        # omits:
+        # * isDeprecated
+        # * deprecationReason
+        # * inputFields
+        # * interfaces and possibleTypes
       }
     }
   `)


### PR DESCRIPTION
Remove unused fields from the introspection query.

This is just a further cut-down of the default introspection query we are currently using that removes a couple of field types that we are not currently using in the hope of reducing result size.

This is a partial response to https://github.com/cylc/cylc-ui/pull/2394#pullrequestreview-3626892904. Though that matter may not be relevant pending the outcome of https://github.com/cylc/cylc-ui/issues/2412.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
