### PR TITLE
GScan: don't show held/retry icons for stoppped workflows

### DIFF
--- a/src/components/cylc/tree/GScanTreeItem.vue
+++ b/src/components/cylc/tree/GScanTreeItem.vue
@@ -54,6 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             size="1em"
             class="modifier-badge"
             :class="modifier"
+            :data-test="`modifier-${modifier}`"
           />
           <template
             v-for="(value, state) in statesInfo.stateTotals"
@@ -136,11 +137,14 @@ function getStatesInfo (node, stateTotals = {}, modifiers = new Set()) {
   } else if (node.type === 'workflow' && node.node.stateTotals) {
     // if we hit a workflow node, stop and merge state
 
-    if (node.node.containsHeld) {
-      modifiers.add('held')
-    }
-    if (node.node.containsRetry) {
-      modifiers.add('retrying')
+    if (node.node.status !== WorkflowState.STOPPED.name) {
+      // Don't show modifiers for stopped workflows
+      if (node.node.containsHeld) {
+        modifiers.add('held')
+      }
+      if (node.node.containsRetry) {
+        modifiers.add('retrying')
+      }
     }
 
     // the non-zero state totals from this node with all the others from the tree

--- a/src/services/mock/json/workflows/multi.json
+++ b/src/services/mock/json/workflows/multi.json
@@ -20,6 +20,7 @@
             "failed": 0,
             "succeeded": 0
           },
+          "containsHeld": true,
           "latestStateTasks": {},
           "__typename": "Workflow"
         },

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -16,6 +16,7 @@
  */
 
 // we mount the tree to include the TreeItem component and other vuetify children components
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { Assertion } from 'chai'
 import { createVuetify } from 'vuetify'
@@ -32,6 +33,7 @@ import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import WorkflowService from '@/services/workflow.service'
 import { flattenWorkflowParts } from '@/components/cylc/gscan/sort'
 import TaskState from '@/model/TaskState.model'
+import { merge } from 'lodash-es'
 
 /**
  * Helper function for expecting TreeItem to be expanded.
@@ -96,19 +98,17 @@ describe('TreeItem component', () => {
   })
 
   describe('expand/collapse button click', () => {
-    const wrapper = mountFunction({
-      props: {
-        node: simpleTaskNode,
-        filteredOutNodesCache: new WeakMap(),
-      }
-    })
-    expect(wrapper).to.not.be.expanded()
-    const expandCollapseBtn = wrapper.find('.node-expand-collapse-button')
-    it('should expand if currently collapsed', async () => {
+    it('expands/collapses', async () => {
+      const wrapper = mountFunction({
+        props: {
+          node: simpleTaskNode,
+          filteredOutNodesCache: new WeakMap(),
+        }
+      })
+      expect(wrapper).to.not.be.expanded()
+      const expandCollapseBtn = wrapper.find('.node-expand-collapse-button')
       await expandCollapseBtn.trigger('click')
       expect(wrapper).to.be.expanded()
-    })
-    it('should collapse if currently expanded', async () => {
       await expandCollapseBtn.trigger('click')
       expect(wrapper).to.not.be.expanded()
     })
@@ -137,20 +137,30 @@ describe('TreeItem component', () => {
 })
 
 describe('GScanTreeItem', () => {
-  const mountFunction = (options) => mount(GScanTreeItem, {
-    global: {
-      plugins: [createVuetify(), CommandMenuPlugin],
-      mock: { $workflowService }
-    },
-    ...options
-  })
+  const mountFunction = (options) => mount(
+    GScanTreeItem,
+    merge(
+      {
+        global: {
+          plugins: [createVuetify(), CommandMenuPlugin],
+          mock: { $workflowService },
+        },
+        props: {
+          filteredOutNodesCache: new WeakMap(),
+        },
+      },
+      options
+    )
+  )
 
   describe('computed properties', () => {
-    const wrapper = mountFunction({
-      props: {
-        node: flattenWorkflowParts(stateTotalsTestWorkflowNodes),
-        filteredOutNodesCache: new WeakMap(),
-      }
+    let wrapper
+    beforeEach(() => {
+      wrapper = mountFunction({
+        props: {
+          node: flattenWorkflowParts(stateTotalsTestWorkflowNodes),
+        }
+      })
     })
     it('does not combine descendant latest state tasks', () => {
       expect(wrapper.vm.statesInfo.latestTasks).to.deep.equal({})
@@ -178,7 +188,6 @@ describe('GScanTreeItem', () => {
           node: {
             type: 'barbenheimer',
           },
-          filteredOutNodesCache: new WeakMap(),
         },
         shallow: true,
       })
@@ -191,7 +200,6 @@ describe('GScanTreeItem', () => {
             type: 'workflow',
             tokens: { workflow: 'a/b/c' }
           },
-          filteredOutNodesCache: new WeakMap(),
         },
         shallow: true,
       })

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -206,4 +206,38 @@ describe('GScanTreeItem', () => {
       expect(wrapper.vm.workflowLink).to.equal('/workspace/a/b/c')
     })
   })
+
+  describe('Modifier icons', () => {
+    let wrapper
+    it('shows modifiers for non-stopped workflows', async () => {
+      const { id, tokens } = simpleWorkflowNode
+      const node = {
+        type: 'workflow',
+        node: {
+          status: 'running',
+          containsHeld: true,
+          containsRetry: true,
+          stateTotals: {},
+        },
+        id,
+        tokens,
+      }
+      wrapper = mountFunction({
+        global: {
+          stubs: ['WorkflowIcon', 'WarningIcon'],
+        },
+        props: {
+          node,
+        },
+      })
+      function expectModifiers (value) {
+        expect(wrapper.find('[data-test=modifier-held]').exists()).toBe(value)
+        expect(wrapper.find('[data-test=modifier-retrying]').exists()).toBe(value)
+      }
+      expectModifiers(true)
+      node.node.status = 'stopped'
+      await wrapper.setProps({ node })
+      expectModifiers(false)
+    })
+  })
 })

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -209,4 +209,38 @@ describe('GScanTreeItem', () => {
       expect(wrapper.vm.workflowLink).to.equal('/workspace/a/b/c')
     })
   })
+
+  describe('Modifier icons', () => {
+    let wrapper
+    it('shows modifiers for non-stopped workflows', async () => {
+      const { id, tokens } = simpleWorkflowNode
+      const node = {
+        type: 'workflow',
+        node: {
+          status: 'running',
+          containsHeld: true,
+          containsRetry: true,
+          stateTotals: {},
+        },
+        id,
+        tokens,
+      }
+      wrapper = mountFunction({
+        global: {
+          stubs: ['WorkflowIcon', 'WarningIcon'],
+        },
+        props: {
+          node,
+        },
+      })
+      function expectModifiers (value) {
+        expect(wrapper.find('[data-test=modifier-held]').exists()).toBe(value)
+        expect(wrapper.find('[data-test=modifier-retrying]').exists()).toBe(value)
+      }
+      expectModifiers(true)
+      node.node.status = 'stopped'
+      await wrapper.setProps({ node })
+      expectModifiers(false)
+    })
+  })
 })

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -16,6 +16,7 @@
  */
 
 // we mount the tree to include the TreeItem component and other vuetify children components
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { Assertion } from 'chai'
 import { createVuetify } from 'vuetify'
@@ -32,6 +33,7 @@ import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import WorkflowService from '@/services/workflow.service'
 import { flattenWorkflowParts } from '@/components/cylc/gscan/sort'
 import TaskState from '@/model/TaskState.model'
+import { merge } from 'lodash-es'
 import { vuetifyOptions } from '@/plugins/vuetify'
 
 const vuetify = createVuetify(vuetifyOptions)
@@ -99,19 +101,17 @@ describe('TreeItem component', () => {
   })
 
   describe('expand/collapse button click', () => {
-    const wrapper = mountFunction({
-      props: {
-        node: simpleTaskNode,
-        filteredOutNodesCache: new WeakMap(),
-      }
-    })
-    expect(wrapper).to.not.be.expanded()
-    const expandCollapseBtn = wrapper.find('.node-expand-collapse-button')
-    it('should expand if currently collapsed', async () => {
+    it('expands/collapses', async () => {
+      const wrapper = mountFunction({
+        props: {
+          node: simpleTaskNode,
+          filteredOutNodesCache: new WeakMap(),
+        }
+      })
+      expect(wrapper).to.not.be.expanded()
+      const expandCollapseBtn = wrapper.find('.node-expand-collapse-button')
       await expandCollapseBtn.trigger('click')
       expect(wrapper).to.be.expanded()
-    })
-    it('should collapse if currently expanded', async () => {
       await expandCollapseBtn.trigger('click')
       expect(wrapper).to.not.be.expanded()
     })
@@ -140,20 +140,30 @@ describe('TreeItem component', () => {
 })
 
 describe('GScanTreeItem', () => {
-  const mountFunction = (options) => mount(GScanTreeItem, {
-    global: {
-      plugins: [vuetify, CommandMenuPlugin],
-      mock: { $workflowService }
-    },
-    ...options
-  })
+  const mountFunction = (options) => mount(
+    GScanTreeItem,
+    merge(
+      {
+        global: {
+          plugins: [vuetify, CommandMenuPlugin],
+          mock: { $workflowService },
+        },
+        props: {
+          filteredOutNodesCache: new WeakMap(),
+        },
+      },
+      options
+    )
+  )
 
   describe('computed properties', () => {
-    const wrapper = mountFunction({
-      props: {
-        node: flattenWorkflowParts(stateTotalsTestWorkflowNodes),
-        filteredOutNodesCache: new WeakMap(),
-      }
+    let wrapper
+    beforeEach(() => {
+      wrapper = mountFunction({
+        props: {
+          node: flattenWorkflowParts(stateTotalsTestWorkflowNodes),
+        }
+      })
     })
     it('does not combine descendant latest state tasks', () => {
       expect(wrapper.vm.statesInfo.latestTasks).to.deep.equal({})
@@ -181,7 +191,6 @@ describe('GScanTreeItem', () => {
           node: {
             type: 'barbenheimer',
           },
-          filteredOutNodesCache: new WeakMap(),
         },
         shallow: true,
       })
@@ -194,7 +203,6 @@ describe('GScanTreeItem', () => {
             type: 'workflow',
             tokens: { workflow: 'a/b/c' }
           },
-          filteredOutNodesCache: new WeakMap(),
         },
         shallow: true,
       })


### PR DESCRIPTION
Held & retrying icons for stopped workflows is not useful.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [ ] Changelog entry included if this is a change that can affect users
- [x] Docs not needed
