### PR TITLE
Added modifier properties to FamilyProxyData

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,4 +26,4 @@ Jamie Allen           <69790602+JAllen42@users.noreply.github.com>
 Christopher Bennett   <christopher.bennett@metoffice.gov.uk>   ChrisPaulBennett
 Mark Dawson           <mark.dawson@metoffice.gov.uk>       Mark Dawson         <mark.dawson@metoffice.gov.ukpython>
 Harleen Kaur          <harleen9355@gmail.com>                  harleenkaur2003         <160705023+harleenkaur2003@users.noreply.github.com>
-
+Samuel Denton         <samuel.denton@metoffice.gov.uk>         samuel-denton           <samuel.denton@metoffice.gov.uk>

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -50,6 +50,9 @@ $icon-width: 1.5rem;
 }
 
 .c-tree {
+  .c-view-toolbar {
+    margin-bottom: 5px;
+  }
   .c-task, .c-job {
     display: flex;
     align-items: center;

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -51,6 +51,7 @@ $icon-width: 1.5rem;
 
 .c-tree {
   .c-view-toolbar {
+    // Give space to any task icon modifiers at the top of the tree:
     margin-bottom: 0.3em;
   }
   .c-task, .c-job {

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -51,7 +51,7 @@ $icon-width: 1.5rem;
 
 .c-tree {
   .c-view-toolbar {
-    margin-bottom: 5px;
+    margin-bottom: 0.3em;
   }
   .c-task, .c-job {
     display: flex;

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -122,7 +122,19 @@ fragment FamilyProxyData on FamilyProxy {
   }
   childTasks {
     id
+    isHeld
+    isQueued
+    isRunahead
+    isRetry
+    isWallclock
+    isXtriggered
   }
+  isHeld
+  isQueued
+  isRunahead
+  isRetry
+  isWallclock
+  isXtriggered
 }
 
 fragment TaskProxyData on TaskProxy {

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -122,12 +122,6 @@ fragment FamilyProxyData on FamilyProxy {
   }
   childTasks {
     id
-    isHeld
-    isQueued
-    isRunahead
-    isRetry
-    isWallclock
-    isXtriggered
   }
   isHeld
   isQueued


### PR DESCRIPTION
Closes #2421 and closes #2514

Added modifier properties from childTasks to propagate up to FamilyProxyData so task modifiers are displayed at the family level.  So if the current task within a family is held, the family shows held too.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).  -  Not sure if there are automated tests for this
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.  -  This might be something that should be documented?  I can add this if needed.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
