### PR TITLE
info: fix issue with completion expressions which contain underscores

### DIFF
--- a/changes.d/2519.fix.md
+++ b/changes.d/2519.fix.md
@@ -1,0 +1,1 @@
+Fix an issue in the "info" view where task outputs which contain hyphens were missing from completion expressions.

--- a/src/utils/outputs.js
+++ b/src/utils/outputs.js
@@ -36,7 +36,8 @@ export function formatCompletion (completion, outputs) {
 
   // break the completion expression down into parts and iterate over them
   for (let part of completion.split(/(and|or|\(|\))/)) {
-    part = part.trim()
+    // NOTE: "-"s are replaced by "_"s in the completion expression
+    part = part.trim().replace('_', '-')
 
     if (!part) {
       continue

--- a/tests/unit/utils/outputs.spec.js
+++ b/tests/unit/utils/outputs.spec.js
@@ -18,7 +18,7 @@
 import { formatCompletion } from '@/utils/outputs'
 
 describe('Outputs', () => {
-  it('should format completion expressions', () => {
+  it('formats completion expressions containing underscores', () => {
     expect(
       formatCompletion('succeeded or failed or submit_failed', [
         { label: 'succeeded', satisfied: true },
@@ -32,7 +32,9 @@ describe('Outputs', () => {
       // submit-failed in the outputs
       [false, 0, 'or submit-failed'],
     ])
+  })
 
+  it('formats completion expressions containing nested parentheses', () => {
     expect(
       formatCompletion('((a and b) or (c and d)) or e', [
         { label: 'a', satisfied: true },

--- a/tests/unit/utils/outputs.spec.js
+++ b/tests/unit/utils/outputs.spec.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { formatCompletion } from '@/utils/outputs'
+
+describe('Outputs', () => {
+  it('should format completion expressions', () => {
+    expect(
+      formatCompletion('succeeded or failed or submit_failed', [
+        { label: 'succeeded', satisfied: true },
+        { label: 'failed', satisfied: false },
+        { label: 'submit-failed', satisfied: false },
+      ]),
+    ).to.deep.equal([
+      [true, 0, 'succeeded'],
+      [false, 0, 'or failed'],
+      // NOTE: submit_failed in the completion expression corresponds to
+      // submit-failed in the outputs
+      [false, 0, 'or submit-failed'],
+    ])
+
+    expect(
+      formatCompletion('((a and b) or (c and d)) or e', [
+        { label: 'a', satisfied: true },
+        { label: 'b', satisfied: true },
+        { label: 'c', satisfied: true },
+        { label: 'd', satisfied: false },
+        { label: 'e', satisfied: false },
+      ]),
+    ).to.deep.equal([
+      [null, 0, '('],
+
+      [null, 1, '('],
+      [true, 2, 'a'],
+      [true, 2, 'and b'],
+      [null, 1, ')'],
+
+      [null, 1, 'or ('],
+      [true, 2, 'c'],
+      [false, 2, 'and d'],
+      [null, 1, ')'],
+
+      [null, 0, ')'],
+
+      [false, 0, 'or e'],
+    ])
+  })
+})


### PR DESCRIPTION
* Hyphens in task outputs are replaced with underscores in completion expressions (because they are evaluated with Python).
* This fixes a bug where outputs with hyphens were missing from the list shown in the info view.

To replicate the issue, take this workflow:

```cylc
[scheduling]
    [[graph]]
        R1 = """
            a?
            a:fail?
            a:submit-fail?
        """
[runtime]
    [[a]]
        script = "false"
```

To inspect the task's completion status, run `cylc show <workflow>//1/a`.

* Run `cylc vip --pause`.
* Open the workflow in the GUI.
* Click on task "a" -> select "log".
* Expand the "completion" panel in the info view.

The GUI should match the output of the `cylc show` command, but currently the `submit-fail` output is lopped off.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
