### PR TITLE
Fix unit test warnings

### DIFF
--- a/tests/unit/components/app.vue.spec.js
+++ b/tests/unit/components/app.vue.spec.js
@@ -24,6 +24,8 @@ import Empty from '@/layouts/Empty.vue'
 import storeOptions from '@/store/options'
 import { vuetifyOptions } from '@/plugins/vuetify'
 
+const vuetify = createVuetify(vuetifyOptions)
+
 vi.mock('vue-router', () => ({
   useRoute: () => ({
     name: 'app',
@@ -38,7 +40,7 @@ describe('App', () => {
     return mount(App, {
       global: {
         plugins: [
-          createVuetify(vuetifyOptions),
+          vuetify,
           createStore(storeOptions),
         ],
         components: {

--- a/tests/unit/components/cylc/analysis/analysistable.vue.spec.js
+++ b/tests/unit/components/cylc/analysis/analysistable.vue.spec.js
@@ -21,8 +21,9 @@ import { createVuetify } from 'vuetify'
 import { analysisTaskQuery } from '@/services/mock/json/index.cjs'
 import WorkflowService from '@/services/workflow.service'
 import AnalysisTable from '@/components/cylc/analysis/AnalysisTable.vue'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 const analysisTasks = analysisTaskQuery.data.tasks
 const $workflowService = sinon.createStubInstance(WorkflowService)
 

--- a/tests/unit/components/cylc/analysis/analysistimeseries.vue.spec.js
+++ b/tests/unit/components/cylc/analysis/analysistimeseries.vue.spec.js
@@ -21,8 +21,9 @@ import { createVuetify } from 'vuetify'
 import { analysisJobQuery } from '@/services/mock/json/index.cjs'
 import WorkflowService from '@/services/workflow.service'
 import TimeSeries from '@/components/cylc/analysis/TimeSeries.vue'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 const analysisJobs = analysisJobQuery.data.jobs
 const $workflowService = sinon.createStubInstance(WorkflowService)
 

--- a/tests/unit/components/cylc/common/estimatedTime.vue.spec.js
+++ b/tests/unit/components/cylc/common/estimatedTime.vue.spec.js
@@ -21,6 +21,8 @@ import { createVuetify } from 'vuetify'
 import { vuetifyOptions } from '@/plugins/vuetify'
 import { formatDuration } from '@/utils/tasks'
 
+const vuetify = createVuetify(vuetifyOptions)
+
 describe('Estimated Time component', () => {
   it.each([
     {
@@ -47,7 +49,7 @@ describe('Estimated Time component', () => {
     const wrapper = mount(EstimatedTime, {
       props,
       global: {
-        plugins: [createVuetify(vuetifyOptions)]
+        plugins: [vuetify],
       }
     })
     expect(wrapper.text()).toBe(expected)

--- a/tests/unit/components/cylc/gantt/ganttChart.vue.spec.js
+++ b/tests/unit/components/cylc/gantt/ganttChart.vue.spec.js
@@ -20,6 +20,7 @@ import sinon from 'sinon'
 import { createVuetify } from 'vuetify'
 import WorkflowService from '@/services/workflow.service'
 import GanttChart from '@/components/cylc/gantt/GanttChart.vue'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 const jobs = {
   test_job: [{
@@ -40,7 +41,7 @@ const jobs = {
   }]
 }
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 const $workflowService = sinon.createStubInstance(WorkflowService)
 
 describe('GanttChart component', () => {

--- a/tests/unit/components/cylc/gscan/gscan.vue.spec.js
+++ b/tests/unit/components/cylc/gscan/gscan.vue.spec.js
@@ -34,8 +34,9 @@ import {
   listTree
 } from './utils'
 import { getIDMap } from '$tests/util'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 
 /**
  * Helper function to run filtering.

--- a/tests/unit/components/cylc/gscan/workflowicon.spec.js
+++ b/tests/unit/components/cylc/gscan/workflowicon.spec.js
@@ -20,8 +20,9 @@ import WorkflowIcon from '@/components/cylc/gscan/WorkflowIcon.vue'
 import WorkflowState from '@/model/WorkflowState.model'
 import { createVuetify } from 'vuetify'
 import { mdiHelpCircle } from '@mdi/js'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 
 describe('WorkflowIcon', () => {
   it.each([

--- a/tests/unit/components/cylc/mutation.vue.spec.js
+++ b/tests/unit/components/cylc/mutation.vue.spec.js
@@ -18,6 +18,7 @@
 import { mount } from '@vue/test-utils'
 import Mutation from '@/components/cylc/Mutation.vue'
 import { createVuetify } from 'vuetify'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 const cylcObject = { id: '~u/w//1/t', isFamily: false }
 
@@ -50,7 +51,7 @@ describe('Mutation Component', () => {
    * @returns {Wrapper<FormGenerator>}
    */
   const mountFunction = (options) => {
-    const vuetify = createVuetify()
+    const vuetify = createVuetify(vuetifyOptions)
     return mount(Mutation, {
       global: {
         plugins: [vuetify]

--- a/tests/unit/components/cylc/table/table.vue.spec.js
+++ b/tests/unit/components/cylc/table/table.vue.spec.js
@@ -111,7 +111,8 @@ describe('Table component', () => {
             initialOptions: {
               sortBy: [{ key, order }]
             }
-          }
+          },
+          shallow: true,
         })
         const comparator = (x, y) => {
           return order === 'asc' ? x.localeCompare(y) : y.localeCompare(x)

--- a/tests/unit/components/cylc/table/table.vue.spec.js
+++ b/tests/unit/components/cylc/table/table.vue.spec.js
@@ -22,10 +22,11 @@ import { simpleTableTasks } from './table.data'
 import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import Table from '@/components/cylc/table/Table.vue'
 import WorkflowService from '@/services/workflow.service'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 const $workflowService = sinon.createStubInstance(WorkflowService)
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 
 describe('Table component', () => {
   /**

--- a/tests/unit/components/cylc/tree/tree.vue.spec.js
+++ b/tests/unit/components/cylc/tree/tree.vue.spec.js
@@ -20,9 +20,16 @@ import { vi } from 'vitest'
 import { cloneDeep } from 'lodash'
 import Tree from '@/components/cylc/tree/Tree.vue'
 import { simpleWorkflowTree4Nodes } from './tree.data'
+import { createVuetify } from 'vuetify'
+import { vuetifyOptions } from '@/plugins/vuetify'
+
+const vuetify = createVuetify(vuetifyOptions)
 
 describe('Tree component', () => {
   const mountFunction = (props) => mount(Tree, {
+    global: {
+      plugins: [vuetify],
+    },
     props: {
       workflows: cloneDeep(simpleWorkflowTree4Nodes),
       autoStripTypes: ['workflow'],

--- a/tests/unit/components/cylc/tree/treeitem.vue.spec.js
+++ b/tests/unit/components/cylc/tree/treeitem.vue.spec.js
@@ -32,6 +32,9 @@ import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import WorkflowService from '@/services/workflow.service'
 import { flattenWorkflowParts } from '@/components/cylc/gscan/sort'
 import TaskState from '@/model/TaskState.model'
+import { vuetifyOptions } from '@/plugins/vuetify'
+
+const vuetify = createVuetify(vuetifyOptions)
 
 /**
  * Helper function for expecting TreeItem to be expanded.
@@ -61,7 +64,7 @@ const $workflowService = sinon.createStubInstance(WorkflowService)
 describe('TreeItem component', () => {
   const mountFunction = (options) => mount(TreeItem, {
     global: {
-      plugins: [createVuetify(), CommandMenuPlugin],
+      plugins: [vuetify, CommandMenuPlugin],
       mock: { $workflowService }
     },
     ...options
@@ -139,7 +142,7 @@ describe('TreeItem component', () => {
 describe('GScanTreeItem', () => {
   const mountFunction = (options) => mount(GScanTreeItem, {
     global: {
-      plugins: [createVuetify(), CommandMenuPlugin],
+      plugins: [vuetify, CommandMenuPlugin],
       mock: { $workflowService }
     },
     ...options

--- a/tests/unit/components/cylc/workspace/toolbar.vue.spec.js
+++ b/tests/unit/components/cylc/workspace/toolbar.vue.spec.js
@@ -24,8 +24,10 @@ import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import sinon from 'sinon'
 import WorkflowService from '@/services/workflow.service'
 import { useDrawer } from '@/utils/toolbar'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 const $workflowService = sinon.createStubInstance(WorkflowService)
+const vuetify = createVuetify(vuetifyOptions)
 
 describe('Workspace toolbar component', () => {
   let store
@@ -41,8 +43,9 @@ describe('Workspace toolbar component', () => {
     // TODO: actually just show nav btn at all times?
     const wrapper = mount(Toolbar, {
       global: {
-        plugins: [store, createVuetify(), CommandMenuPlugin],
+        plugins: [store, vuetify, CommandMenuPlugin],
         mocks: { $workflowService },
+        provide: { versionInfo: null },
       },
       props: {
         views: new Map(),

--- a/tests/unit/components/graphqlFormGenerator/editRuntimeForm.vue.spec.js
+++ b/tests/unit/components/graphqlFormGenerator/editRuntimeForm.vue.spec.js
@@ -20,6 +20,7 @@ import EditRuntimeForm from '@/components/graphqlFormGenerator/EditRuntimeForm.v
 import { IntrospectionQuery, taskProxy } from '@/services/mock/json/index.cjs'
 import { cloneDeep } from 'lodash'
 import { createVuetify } from 'vuetify'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 /** NOTE: update this if updating src/services/mock/json/taskProxy.json */
 const INITIAL_DATA = {
@@ -72,7 +73,7 @@ const $workflowService = {
   }
 }
 
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 
 describe('EditRuntimeForm Component', () => {
   const props = {

--- a/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
+++ b/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
@@ -18,8 +18,6 @@
 import { mount } from '@vue/test-utils'
 import FormGenerator from '@/components/graphqlFormGenerator/FormGenerator.vue'
 import { cloneDeep } from 'lodash'
-import { createVuetify } from 'vuetify'
-import { vuetifyOptions } from '@/plugins/vuetify'
 
 const BASIC_MUTATION = {
   name: 'My Mutation',
@@ -174,15 +172,12 @@ function getModel (wrapper) {
 }
 
 describe('FormGenerator Component', () => {
-  const vuetify = createVuetify(vuetifyOptions)
   /**
    * @param {*} options
    * @returns {Wrapper<FormGenerator>}
    */
   const mountFunction = (options) => mount(FormGenerator, {
-    global: {
-      plugins: [vuetify]
-    },
+    shallow: true,
     ...options
   })
 

--- a/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
+++ b/tests/unit/components/graphqlFormGenerator/formgenerator.vue.spec.js
@@ -19,6 +19,7 @@ import { mount } from '@vue/test-utils'
 import FormGenerator from '@/components/graphqlFormGenerator/FormGenerator.vue'
 import { cloneDeep } from 'lodash'
 import { createVuetify } from 'vuetify'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 const BASIC_MUTATION = {
   name: 'My Mutation',
@@ -173,7 +174,7 @@ function getModel (wrapper) {
 }
 
 describe('FormGenerator Component', () => {
-  const vuetify = createVuetify()
+  const vuetify = createVuetify(vuetifyOptions)
   /**
    * @param {*} options
    * @returns {Wrapper<FormGenerator>}

--- a/tests/unit/utils/toolbar.spec.js
+++ b/tests/unit/utils/toolbar.spec.js
@@ -19,6 +19,7 @@ import { unref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createVuetify } from 'vuetify'
 import { useDrawer, useNavBtn } from '@/utils/toolbar'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 /**
  * Create a vuetify instance in mobile mode or not.
@@ -82,7 +83,7 @@ describe('Toolbar/drawer utils', () => {
     )
 
     it('toggles the drawer', () => {
-      const wrapper = mountFunction(createVuetify())
+      const wrapper = mountFunction(createVuetify(vuetifyOptions))
       const initialState = unref(drawerState)
       expect(wrapper.vm.drawer).toEqual(initialState)
       wrapper.vm.toggleDrawer()

--- a/tests/unit/views/log.vue.spec.js
+++ b/tests/unit/views/log.vue.spec.js
@@ -19,13 +19,11 @@ import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createStore } from 'vuex'
 import storeOptions from '@/store/options'
-import { createVuetify } from 'vuetify'
 import sinon from 'sinon'
 import Log from '@/views/Log.vue'
 import WorkflowService from '@/services/workflow.service'
 import User from '@/model/User.model'
 import { getJobLogFileFromState } from '@/model/JobState.model'
-import { vuetifyOptions } from '@/plugins/vuetify'
 
 describe('Log view', () => {
   const owner = 'svimes'
@@ -33,12 +31,11 @@ describe('Log view', () => {
   const workflowID = `~${owner}/${workflowName}`
   const initialFile = 'koom-valley.log'
 
-  const vuetify = createVuetify(vuetifyOptions)
   let $workflowService, store
 
   const mountFunction = (options) => mount(Log, {
     global: {
-      plugins: [vuetify, store],
+      plugins: [store],
       mocks: { $workflowService },
     },
     props: {
@@ -47,7 +44,8 @@ describe('Log view', () => {
         file: initialFile,
       },
     },
-    ...options
+    shallow: true,
+    ...options,
   })
 
   beforeEach(() => {

--- a/tests/unit/views/log.vue.spec.js
+++ b/tests/unit/views/log.vue.spec.js
@@ -25,6 +25,7 @@ import Log from '@/views/Log.vue'
 import WorkflowService from '@/services/workflow.service'
 import User from '@/model/User.model'
 import { getJobLogFileFromState } from '@/model/JobState.model'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 describe('Log view', () => {
   const owner = 'svimes'
@@ -32,7 +33,7 @@ describe('Log view', () => {
   const workflowID = `~${owner}/${workflowName}`
   const initialFile = 'koom-valley.log'
 
-  const vuetify = createVuetify()
+  const vuetify = createVuetify(vuetifyOptions)
   let $workflowService, store
 
   const mountFunction = (options) => mount(Log, {

--- a/tests/unit/views/tree.vue.spec.js
+++ b/tests/unit/views/tree.vue.spec.js
@@ -16,19 +16,15 @@
 import { nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createStore } from 'vuex'
-import { createVuetify } from 'vuetify'
 import sinon from 'sinon'
 import storeOptions from '@/store/options'
 import Tree from '@/views/Tree.vue'
 import User from '@/model/User.model'
 import WorkflowService from '@/services/workflow.service'
-import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import { Tokens } from '@/utils/uid'
 import { getIDMap } from '$tests/util'
-import { vuetifyOptions } from '@/plugins/vuetify'
 
 const $workflowService = sinon.createStubInstance(WorkflowService)
-const vuetify = createVuetify(vuetifyOptions)
 
 const expandID = (id) => ({
   id,
@@ -87,7 +83,7 @@ describe('Tree view', () => {
     store.commit('user/SET_USER', user)
     mountFunction = (options) => mount(Tree, {
       global: {
-        plugins: [vuetify, CommandMenuPlugin, store],
+        plugins: [store],
         mocks: {
           $workflowService
         }
@@ -95,6 +91,7 @@ describe('Tree view', () => {
       props: {
         workflowName: 'workflow1',
       },
+      shallow: true,
       ...options
     })
   })

--- a/tests/unit/views/tree.vue.spec.js
+++ b/tests/unit/views/tree.vue.spec.js
@@ -25,9 +25,10 @@ import WorkflowService from '@/services/workflow.service'
 import CommandMenuPlugin from '@/components/cylc/commandMenu/plugin'
 import { Tokens } from '@/utils/uid'
 import { getIDMap } from '$tests/util'
+import { vuetifyOptions } from '@/plugins/vuetify'
 
 const $workflowService = sinon.createStubInstance(WorkflowService)
-const vuetify = createVuetify()
+const vuetify = createVuetify(vuetifyOptions)
 
 const expandID = (id) => ({
   id,


### PR DESCRIPTION
We were getting a lot of warnings running the unit tests.

> [Vue warn]: Failed to resolve component: v-filter-empty-state

`v-filter-empty-state` is a [Vuetify alias](https://vuetifyjs.com/en/features/aliasing/) defined in https://github.com/cylc/cylc-ui/blob/758fad6c2e270ce1986de4fc82a7eb25fe9e7e0b/src/plugins/vuetify.js#L80-L83

Fixed the warning by including this options object whenever we create a vuetify plugin instance in the tests.

> [Vue warn]: injection "versionInfo" not found.

Fixed by using https://test-utils.vuejs.org/api/#global-provide

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Fixes tests 
- [x] No changelog or docs as not user-facing
