### PR TITLE
Remove axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@mdi/js": "7.4.47",
     "@vueuse/core": "14.1.0",
     "apexcharts": "3.54.1",
-    "axios": "1.15.0",
     "dedent": "1.7.2",
     "enumify": "2.0.0",
     "graphiql": "4.1.2",

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import axios from 'axios'
-
 /**
  * Remove double forward-slashes from URL's. It avoids the slashes that
  * are preceded by ':', so that the slashes in the URL protocol are kept.
@@ -97,9 +95,12 @@ export function getXSRFHeaders () {
  * @throws {Error} If the request fails.
  */
 export async function fetchData (path) {
-  const { data } = await axios.get(
+  const response = await fetch(
     createUrl(path),
     { headers: getXSRFHeaders() }
   )
-  return data
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${path}: ${response.status} (${response.statusText})`)
+  }
+  return await response.json()
 }

--- a/tests/unit/services/user.service.spec.js
+++ b/tests/unit/services/user.service.spec.js
@@ -15,58 +15,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import sinon from 'sinon'
-import axios from 'axios'
-import { createStore } from 'vuex'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getUserProfile } from '@/services/user.service'
-import storeOptions from '@/store/options'
-import { Alert } from '@/model/Alert.model'
 
 describe('getUserProfile', () => {
-  const store = createStore(storeOptions)
-  let sandbox
-  beforeEach(() => {
-    sandbox = sinon.createSandbox()
-    sandbox.stub(console, 'log')
-    store.commit('SET_ALERT', null)
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
-  afterEach(() => sandbox.restore())
-
-  describe('returns the logged-in user profile information', () => {
-    it('returns user profile object', async () => {
-      const expected = {
-        username: 'cylc-user-01',
-        mode: 'single user',
-        permissions: ['read'],
-        owner: 'cylc-user-02',
-      }
-      const response = Promise.resolve({
-        data: {
-          ...expected,
-          name: expected.username,
-          other_stuff: null,
-        }
-      })
-      sandbox.stub(axios, 'get').returns(response)
-      const user = await getUserProfile()
-      expect(user).toMatchObject(expected)
+  it('returns user profile object', async () => {
+    const expected = {
+      username: 'cylc-user-01',
+      mode: 'single user',
+      permissions: ['read'],
+      owner: 'cylc-user-02',
+    }
+    const response = Promise.resolve({
+      ...expected,
+      name: expected.username,
+      other_stuff: null,
     })
+    vi.stubGlobal('fetch', () => ({ ok: true, json: () => response }))
+    const user = await getUserProfile()
+    expect(user).toMatchObject(expected)
+  })
 
-    it('should add an alert on error', () => {
-      expect(store.state.alert).to.equal(null)
-      const e = new Error('mock error')
-      e.response = {
-        statusText: 'Test Status'
-      }
-      sandbox.stub(axios, 'get').rejects(e)
-      return getUserProfile()
-        .catch((error) => {
-          const alert = new Alert(error.response.statusText, 'error')
-          return store.dispatch('setAlert', alert)
-        })
-        .finally(() => {
-          expect(store.state.alert.text).to.equal('Test Status')
-        })
-    })
+  it('rejects on HTTP error', async () => {
+    vi.stubGlobal('fetch', () => ({ ok: false, status: 500, statusText: 'Test Status' }))
+    await expect(getUserProfile()).rejects.toThrow('Failed to fetch userprofile: 500 (Test Status)')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,17 +3337,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
-  languageName: node
-  linkType: hard
-
 "backo2@npm:^1.0.2":
   version: 1.0.2
   resolution: "backo2@npm:1.0.2"
@@ -4162,7 +4151,6 @@ __metadata:
     "@vue/test-utils": "npm:2.4.8"
     "@vueuse/core": "npm:14.1.0"
     apexcharts: "npm:3.54.1"
-    axios: "npm:1.15.0"
     concurrently: "npm:9.2.1"
     cross-fetch: "npm:4.1.0"
     cypress: "npm:15.14.1"
@@ -5797,16 +5785,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.16.0
-  resolution: "follow-redirects@npm:1.16.0"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
-  languageName: node
-  linkType: hard
-
 "for-each@npm:^0.3.3, for-each@npm:^0.3.5":
   version: 0.3.5
   resolution: "for-each@npm:0.3.5"
@@ -5843,7 +5821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5, form-data@npm:~4.0.4":
+"form-data@npm:~4.0.4":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -8916,13 +8894,6 @@ __metadata:
   version: 1.0.0
   resolution: "proxy-from-env@npm:1.0.0"
   checksum: 10c0/c64df9b21f7f820dc882cd6f7f81671840acd28b9688ee3e3e6af47a56ec7f0edcabe5bc96b32b26218b35eeff377bcc27ac27f89b6b21401003e187ff13256f
-  languageName: node
-  linkType: hard
-
-"proxy-from-env@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "proxy-from-env@npm:2.1.0"
-  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Axios is [noisy](https://github.com/cylc/cylc-ui/pulls?q=is%3Apr+label%3Adependencies+axios+security) in terms of the automatic https://github.com/cylc/cylc-ui/labels/security update PRs we get. (And it recently had [that supply chain compromise](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan))

But we are making very light use of it. It was simple to strip it out from the codebase

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).