### PR TITLE
Fix a quick-start guide typo.

### DIFF
--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -99,7 +99,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <v-card-text>
             <p>
               Tasks can be configured to skip rather than run. These tasks are
-              marked with a special icon proving they are not otherwise held
+              marked with a special icon providing they are not otherwise held
               back from running by some other factor (e.g, if they are held).
             </p>
             <v-list

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -98,9 +98,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </v-card-title>
           <v-card-text>
             <p>
-              Tasks can be configured to skip rather than run. These tasks are
-              marked with a special icon providing they are not otherwise held
-              back from running by some other factor (e.g, if they are held).
+              Tasks can be configured to run in skip mode, which automatically sets
+              their required outputs to complete without running a job. These tasks
+              are marked with a special "fast forward" icon providing they are not
+              otherwise held back from running (e.g, if they are held).
             </p>
             <v-list
                lines="three"


### PR DESCRIPTION
```diff
- These tasks are marked with a special icon proving they are not otherwise held back 
+ These tasks are marked with a special icon providing they are not otherwise held back 
                                             ^^^^^^^^^
```
**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
