### PR TITLE
Renovate: 4 day min age for security

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -146,7 +146,9 @@
       "matchPackageNames": [
         "simple-icons"
       ],
-      "prPriority": -1
+      "schedule": [
+        "* * * 1,6 *"
+      ]
     },
     {
       "groupName": "analysis view packages",

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
   ],
   "platformAutomerge": true,
   "automergeStrategy": "squash",
+   "github-actions": {
+    "enabled": false
+  },
+  "minimumReleaseAge": "4 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
   "packageRules": [
     {
       "matchDepNames": [
@@ -170,9 +176,6 @@
     "addLabels": [
       "security"
     ]
-  },
-  "github-actions": {
-    "enabled": false
   },
   "postUpdateOptions": [
     "yarnDedupeHighest"


### PR DESCRIPTION
Provides some buffer for any supply chain compromises to be flushed out before we pull anything into our CI.

Also reduce updates for simple-icons to every 6 months, as we don't need regular updates for it.


