### PR TITLE
Fix warnings

### DIFF
--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -52,32 +52,36 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </p>
          </v-card-text>
             <table id="task-job-state-table">
-              <tr>
-                <td>Task</td>
-                <td></td>
-                <td>Job</td>
-              </tr>
-              <tr
-                v-bind:key="state.name.name"
-                v-for="state of states"
-              >
-                <td style="font-size: 2em;">
-                  <!-- set times to make the progress change -->
-                  <task
-                    :task="{
-                      state: state.name,
-                      task: {meanElapsedTime: 30}
-                    }"
-                    :startTime="String(Date.now())"
-                  />
-                </td>
-                <td>
-                  <span>{{ state.name }}</span>
-                </td>
-                <td style="font-size: 2em;">
-                  <job :status="state.name" />
-                </td>
-              </tr>
+              <thead style="font-size: 2em;">
+                <tr>
+                  <td>Task</td>
+                  <td></td>
+                  <td>Job</td>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-bind:key="state.name.name"
+                  v-for="state of states"
+                >
+                  <td style="font-size: 2em;">
+                    <!-- set times to make the progress change -->
+                    <Task
+                      :task="{
+                        state: state.name,
+                        task: {meanElapsedTime: 30}
+                      }"
+                      :startTime="String(Date.now())"
+                    />
+                  </td>
+                  <td>
+                    <span>{{ state.name }}</span>
+                  </td>
+                  <td style="font-size: 2em;">
+                    <Job :status="state.name" />
+                  </td>
+                </tr>
+              </tbody>
             </table>
           <v-card-text>
             <p>
@@ -107,7 +111,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             >
               <v-list-item>
                 <template v-slot:prepend>
-                  <task
+                  <Task
                     style="font-size: 2em;"
                     :task="{state: 'waiting', runtime: { runMode: 'Skip' }}"
                     class="mr-4"
@@ -434,8 +438,8 @@ import { isFlowNone } from '@/utils/tasks'
 export default {
   name: 'Guide',
   components: {
-    task: Task,
-    job: Job,
+    Task,
+    Job,
     GraphNode,
   },
 
@@ -524,24 +528,12 @@ export default {
       line-height: 1.2em;
     }
 
-    tr:nth-child(1) {
-      font-size: 2em;
-    }
-
-    tr > td:nth-child(2) {
-      font-size: 1em;
-    }
-
     tr > td:nth-child(1), tr > td:nth-child(3) {
       width: 5em;
     }
 
     td {
       padding: 0.1em 0 0.1em 0;
-    }
-
-    td > * {
-      background-color: white;
     }
   }
 </style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -56,8 +56,8 @@ export default defineConfig(({ mode }) => {
     base: '',
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, './src'),
-        $tests: path.resolve(__dirname, './tests'),
+        '@': path.resolve('./src'),
+        $tests: path.resolve('./tests'),
         lodash: 'lodash-es',
         // GraphiQL is a React app (use Preact as it's smaller):
         react: 'preact/compat',
@@ -88,8 +88,8 @@ export default defineConfig(({ mode }) => {
       },
       watch: {
         ignored: [
-          path.resolve(__dirname, './coverage'),
-          path.resolve(__dirname, '**/.nfs*'),
+          path.resolve('./coverage'),
+          path.resolve('./**/.nfs*'),
         ]
       },
       warmup: {


### PR DESCRIPTION
```
[VITE] (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
[VITE]   - `__dirname` (vite.config.js:59:27). Use `import.meta.dirname` instead
[VITE] Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```
and
```
[VITE] 16:54:19 [vite] (client) warning: <tr> cannot be child of <table>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.
[VITE] 53 |           </v-card-text>
[VITE] 54 |              <table id="task-job-state-table">
[VITE] 55 |                <tr>
[VITE]    |                ^^^^
[VITE] 56 |                  <td>Task</td>
[VITE]    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[VITE] 57 |                  <td></td>
[VITE]    |  ^^^^^^^^^^^^^^^^^^^^^^^^^
[VITE] 58 |                  <td>Job</td>
[VITE]    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[VITE] 59 |                </tr>
[VITE]    |  ^^^^^^^^^^^^^^^^^^^
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests etc not needed
