### PR TITLE
Replace workaround for ensuring reduced animation setting applies to dialogs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,20 +16,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <v-defaults-provider :defaults="vuetifyDefaults">
-    <v-app :class="`job_theme--${jobTheme}`">
-      <component :is="layout">
-        <router-view/>
-      </component>
-    </v-app>
-  </v-defaults-provider>
+  <v-app :class="`job_theme--${jobTheme}`">
+    <component :is="layout">
+      <router-view/>
+    </component>
+  </v-app>
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import { useJobTheme } from '@/composables/localStorage'
-import { useDynamicVuetifyDefaults } from '@/plugins/vuetify'
+import { injectDefaults } from 'vuetify/lib/composables/defaults'
+import { mergeDeep } from 'vuetify/lib/util'
+import { useJobTheme, useReducedAnimation } from '@/composables/localStorage'
 
 const DEFAULT_LAYOUT = 'empty'
 const route = useRoute()
@@ -38,7 +37,26 @@ const layout = computed(() => `${route.meta.layout || DEFAULT_LAYOUT}-layout`)
 
 const jobTheme = useJobTheme()
 
-const vuetifyDefaults = useDynamicVuetifyDefaults()
+const reducedAnimation = useReducedAnimation()
+
+// Reactively update Vuetify global defaults to respect reduced animation setting
+// (https://github.com/vuetifyjs/vuetify/issues/19645#issuecomment-5242189108):
+const vuetifyDefaults = injectDefaults()
+watch(
+  reducedAnimation,
+  (value) => {
+    vuetifyDefaults.value = mergeDeep(
+      vuetifyDefaults.value,
+      {
+        global: {
+          transition: value ? 'no' : undefined,
+          ripple: value ? false : undefined,
+        },
+      },
+    )
+  },
+  { immediate: true }
+)
 
 onMounted(() => {
   // apply stored application font-size

--- a/src/components/cylc/Mutation.vue
+++ b/src/components/cylc/Mutation.vue
@@ -40,9 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </template>
 
     <v-card-text class="card-text py-0 px-4">
-      <!-- Have to repeat these defaults as the ones set in App.vue don't make it through
-      the parent v-dialog - see https://github.com/vuetifyjs/vuetify/issues/18123 -->
-      <v-defaults-provider :defaults="vuetifyDefaults">
+      <v-defaults-provider :defaults="inputDefaults">
         <!-- the mutation description -->
         <v-expansion-panels
           v-bind="extendedDescription ? { hover: true } : { readonly: true }"
@@ -164,7 +162,6 @@ import {
   mutationStatus
 } from '@/utils/aotf'
 import { mdiClose, mdiOpenInNew } from '@mdi/js'
-import { useDynamicVuetifyDefaults } from '@/plugins/vuetify'
 import { inputDefaults } from '@/components/graphqlFormGenerator/components/vuetify'
 import { eventBus } from '@/services/eventBus'
 import { store } from '@/store/index'
@@ -199,8 +196,6 @@ export default {
   },
 
   setup (props) {
-    const vuetifyDefaults = useDynamicVuetifyDefaults(inputDefaults)
-
     if (props.initialOptions.isView) {
       // set the tab title to something informative
       eventBus.emit(
@@ -210,7 +205,7 @@ export default {
     }
 
     return {
-      vuetifyDefaults,
+      inputDefaults,
 
       // properties extracted from initialOptions...
 

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { computed } from 'vue'
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg'
 import { VAutocomplete } from 'vuetify/components/VAutocomplete'
 import { VCombobox } from 'vuetify/components/VCombobox'
@@ -26,8 +25,6 @@ import { VCardActions } from 'vuetify/components/VCard'
 import { VEmptyState } from 'vuetify/components/VEmptyState'
 import colors from 'vuetify/util/colors'
 import { mdiClose } from '@mdi/js'
-import { useReducedAnimation } from '@/composables/localStorage'
-import { merge } from 'lodash-es'
 
 export const inputComponents = [
   VAutocomplete,
@@ -99,26 +96,4 @@ export const vuetifyOptions = {
     },
     ...inputDefaults
   },
-}
-
-/**
- * Composable that provides Vuetify defaults that can change at runtime, as opposed to
- * the static defaults provided in `createVuetify(vuetifyOptions)`.
- *
- * For use with a v-defaults-provider.
- *
- * @param {Object=} other - Additional defaults to provide.
- */
-export function useDynamicVuetifyDefaults (other = {}) {
-  const reducedAnimation = useReducedAnimation()
-
-  return computed(() => merge(
-    {
-      global: {
-        transition: reducedAnimation.value ? 'no' : undefined,
-        ripple: reducedAnimation.value ? false : undefined,
-      },
-    },
-    other
-  ))
 }


### PR DESCRIPTION
Follow-up to https://github.com/cylc/cylc-ui/issues/1989, a better solution than #2007 that works in all dialogs.

To test: go to the settings page and toggle the reduced animations setting, then play around with opening menus and command dialog

On master, note how the reduced animation setting does not apply to the dropdown inside the filter dialog:


https://github.com/user-attachments/assets/99af6acb-e0a3-452d-8a3d-e12d413dc45a

This is fixed by this PR



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No tests, changelog or docs need

