### PR TITLE
Renovate: open PR as soon as branch is created

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   },
   "minimumReleaseAge": "4 days",
   "internalChecksFilter": "strict",
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "packageRules": [
     {
       "matchDepNames": [


### PR DESCRIPTION
I noticed renovate bot was creating branches, but not opening PRs for them yet. This appears to be an unintended consequence of https://github.com/cylc/cylc-ui/pull/2618.

The docs for this are incredibly confusing, but according to https://github.com/renovatebot/renovate/discussions/44161#discussioncomment-17785616

> with `minimumReleaseAge` + `internalChecksFilter: strict`, the branch itself isn't created until the release is old enough, so you still get the "wait N days" behaviour. The difference is `immediate` opens the PR the moment the branch is created, whereas `not-pending` + `internalChecksAsSuccess` waits for any real branch checks too.

So I've changed `prCreation` to `immediate`

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
