### PR TITLE
Vite: simplify manual code splitting

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -106,22 +106,9 @@ export default defineConfig(({ mode }) => {
       target: 'baseline-widely-available',
       rolldownOptions: {
         output: {
-          // Disable code splitting (apart from GraphiQL) if desired by the developer
+          // Disable code splitting if desired by the developer
           // (can speed up build when using a slow disk, e.g. network drive):
-          codeSplitting: process.env.DISABLE_CODE_SPLITTING
-            ? {
-                groups: [
-                  {
-                    test: /node_modules[\\/]graphiql/,
-                    name: 'graphiql',
-                  },
-                  {
-                    test: /.*/,
-                    name: 'main',
-                  },
-                ],
-              }
-            : true,
+          codeSplitting: !process.env.DISABLE_CODE_SPLITTING,
         },
       },
     },


### PR DESCRIPTION
> [!NOTE]
> This is something only I am using during development (this manual code splitting is only turned on when the `DISABLE_CODE_SPLITTING` env var is set)

When building, Vite/rolldown automatically splits the code up according to its algorithm. This produces quite a lot of "chunks", which contain JS/CSS that is loaded lazily when first needed as you navigate around the app.

As I build on Windows and save onto a network drive during my normal development, I added a switch in to the config so I could produce a much smaller number of chunks, as writing a few big files to the network drive is faster than lots of small files. I had aimed to make the GraphiQL code still chunk separately as it's rarely accessed.

However, the current manual code splitting was ineffective as the GraphiQL code was preloaded anyway, when visiting the UI home page (not lazily loaded as desired). So I've just simplified the manual code splitting to on/off.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No tests etc needed as not user-facing

