### PR TITLE
Serve at `/cylc/` in offline mode to better reflect the real UIS

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -81,4 +81,7 @@ module.exports = {
       'off',
     ],
   },
+  globals: {
+    __APP_VERSION__: 'readonly',
+  },
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Test (E2E)
         uses: cypress-io/github-action@v7
         env:
-          BASE_URL: http://localhost:4173/
+          BASE_URL: http://localhost:4173/cylc/
         with:
           build: yarn run build --mode offline
           start: yarn run preview

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ yarn run preview
 ```
 
 Note the incremental rebuild is quite slow so an alternative to `yarn run build:watch` is
-to run the Vite development server while using the Cylc UI Server live data:
+to run the Vite development server to serve the web app while using the Cylc UI Server
+to serve live backend data:
 
 ```bash
 # First launch the gui to authenticate with the URL token
-cylc gui --port=3000 --ServerApp.allow_origin='http://localhost:5173'
-# Close that tab once it's loaded
+cylc gui --new --port=3000 --ServerApp.allow_origin='http://localhost:5173'
+# You can close that tab once it's loaded
 # Now launch using
 yarn run serve:vue --mode development
 # (you must access via http://localhost:5173)
@@ -111,7 +112,8 @@ yarn run coverage:e2e
 ### Mocked Data
 
 The "offline" mode (aka `yarn run serve`) which is also used for the end to end
-tests is powered by a "mock" data server.
+tests is powered by a "mock" JSON data server. This stands in for the backend data
+that would be served by the real Cylc UIServer.
 
 You can find the index of mocked data here:
 [`src/services/mock/json/index.cjs`](src/services/mock/json/index.cjs)

--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
   videosFolder: 'tests/e2e/videos',
 
   e2e: {
-    baseUrl: 'http://localhost:5173',
+    baseUrl: 'http://localhost:5173/cylc/',
     setupNodeEvents (on, config) {
       registerCodeCoverageTasks(on, config)
 

--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -86,7 +86,6 @@ import { useDisplay } from 'vuetify'
 import Header from '@/components/cylc/Header.vue'
 import Workflows from '@/views/Workflows.vue'
 import { mdiHome, mdiInformationOutline } from '@mdi/js'
-import pkg from '@/../package.json'
 import { when } from '@/utils/reactivity'
 import { useDrawer } from '@/utils/toolbar'
 
@@ -161,7 +160,7 @@ export default {
       drawer,
       drawerWidth,
       resizeBar,
-      UIVersion: pkg.version,
+      UIVersion: __APP_VERSION__,
       cylcVersionInfo,
       mdiInformationOutline,
       mdiHome,

--- a/src/services/mock/json-server.cjs
+++ b/src/services/mock/json-server.cjs
@@ -27,6 +27,9 @@ const jsonServer = require('json-server')
 const logger = require('morgan')
 
 const server = jsonServer.create()
+// Cylc UIServer's base path is /cylc/ - match that here:
+server.use(jsonServer.rewriter({ '/cylc/*': '/$1' }))
+
 require('express-ws')(server)
 const router = jsonServer.router({
   userProfile,

--- a/tests/e2e/specs/aotf.cy.js
+++ b/tests/e2e/specs/aotf.cy.js
@@ -63,7 +63,7 @@ function mockWorkflowService () {
 describe('Api On The Fly', () => {
   beforeEach(() => {
     patchUserprofile()
-    cy.intercept('/graphql', req => {
+    cy.intercept('/cylc/graphql', req => {
       if (req.body.query.includes('__schema')) {
         req.alias = 'IntrospectQuery' // equivalent to `.as('IntrospectQuery')`
       }

--- a/tests/e2e/specs/editRuntimeForm.cy.js
+++ b/tests/e2e/specs/editRuntimeForm.cy.js
@@ -23,7 +23,7 @@ describe('Edit Runtime form', () => {
   beforeEach(() => {
     receivedMutations.splice(0)
     // Patch graphql responses
-    cy.intercept('/graphql', (req) => {
+    cy.intercept('/cylc/graphql', (req) => {
       const { body } = req
       if (body.query.startsWith('mutation')) {
         req.alias = 'mutation' // equivalent to `.as('mutation')`

--- a/tests/e2e/specs/graphiql.cy.js
+++ b/tests/e2e/specs/graphiql.cy.js
@@ -28,7 +28,7 @@ describe('GraphiQL', () => {
     cy.visit('/#/graphiql')
       .get('#graphiql')
       .should('be.visible')
-    cy.intercept('/graphql*').as('GraphQLQuery')
+    cy.intercept('/cylc/graphql*').as('GraphQLQuery')
     cy.get('.CodeMirror')
       .should('have.length', 4)
       .then((editors) => {

--- a/tests/e2e/specs/header.cy.js
+++ b/tests/e2e/specs/header.cy.js
@@ -28,7 +28,7 @@ describe('Header Component', () => {
 
 describe('Header Component multiuser', () => {
   beforeEach(() => {
-    cy.intercept('/userprofile', {
+    cy.intercept('/cylc/userprofile', {
       body: {
         username: 'userTest',
         permissions: [

--- a/tests/e2e/specs/log.cy.js
+++ b/tests/e2e/specs/log.cy.js
@@ -235,7 +235,7 @@ describe('Log command in menu', () => {
     }
 
     const jobDataQueries = []
-    cy.intercept('/graphql', ({ body }) => {
+    cy.intercept('/cylc/graphql', ({ body }) => {
       if (body.operationName === 'Jobs') {
         jobDataQueries.push(body.variables.id)
       }

--- a/tests/e2e/specs/mutation.cy.js
+++ b/tests/e2e/specs/mutation.cy.js
@@ -71,7 +71,7 @@ describe('Mutations component', () => {
     beforeEach(() => {
       mockMutations()
       // Patch graphql responses
-      cy.intercept('/graphql', (req) => {
+      cy.intercept('/cylc/graphql', (req) => {
         const { query } = req.body
         if (query.startsWith('mutation')) {
           console.log(req)
@@ -119,7 +119,7 @@ describe('Mutations component', () => {
 
     it('should stay open while submitting', () => {
       const deferred = new Deferred()
-      cy.intercept('/graphql', req => {
+      cy.intercept('/cylc/graphql', req => {
         if (req.body.query.startsWith('mutation')) {
           // Cypress will await promise before continuing with the request
           return deferred.promise

--- a/tests/e2e/specs/toolbar.cy.js
+++ b/tests/e2e/specs/toolbar.cy.js
@@ -52,7 +52,7 @@ describe('Toolbar component', () => {
 
 describe('Toolbar Component authenticated user', () => {
   beforeEach(() => {
-    cy.intercept('/userprofile', {
+    cy.intercept('/cylc/userprofile', {
       body: {
         username: 'user',
         name: 'user',

--- a/tests/e2e/specs/url.cy.js
+++ b/tests/e2e/specs/url.cy.js
@@ -37,7 +37,7 @@ describe('URL handling', () => {
   })
 
   it('reroutes to noAuth page if user isnt authorised', () => {
-    cy.intercept('/userprofile', {
+    cy.intercept('/cylc/userprofile', {
       body: {
         username: 'user',
         permissions: [],

--- a/tests/e2e/specs/workflowservice.cy.js
+++ b/tests/e2e/specs/workflowservice.cy.js
@@ -84,7 +84,7 @@ describe('WorkflowService subscriptions', () => {
 describe('WorkflowService mutations', () => {
   it('handles asynchronously loaded mutations properly', () => {
     const deferred = new Deferred()
-    cy.intercept('/graphql', req => {
+    cy.intercept('/cylc/graphql', req => {
       if (req.body.query?.startsWith('mutation')) {
         // equivalent to `.as('mutation')`:
         req.alias = 'mutation'

--- a/tests/e2e/support/graphql.js
+++ b/tests/e2e/support/graphql.js
@@ -18,7 +18,7 @@
 import userprofile from '@/services/mock/json/userprofile.json'
 
 export function patchUserprofile () {
-  cy.intercept('/userprofile', {
+  cy.intercept('/cylc/userprofile', {
     body: {
       ...userprofile,
       permissions: [

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,7 @@ import eslint from 'vite-plugin-eslint'
 import IstanbulPlugin from 'vite-plugin-istanbul'
 import dns from 'dns'
 import path from 'path'
+import pkg from './package.json'
 
 // Workaround https://github.com/cypress-io/cypress/issues/25397
 dns.setDefaultResultOrder('ipv4first')
@@ -117,6 +118,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     define: {
+      __APP_VERSION__: JSON.stringify(pkg.version),
       // Allow vue devtools to work when runing vite build:
       __VUE_PROD_DEVTOOLS__: mode !== 'production',
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -46,14 +46,11 @@ export default defineConfig(({ mode }) => {
     )
   }
 
-  /**
-   * When running the Vite dev server to serve the app, set the proxy for the
-   * mock JSON server data in offline mode else the Cylc UIServer data.
-   */
-  const devProxyTarget = `http://localhost:3000${mode === 'offline' ? '/' : '/cylc/'}`
+  /** Proxy target for the JSON server that provides mock data to stand in for the UIServer in dev mode */
+  const devProxyTarget = 'http://localhost:3000/'
 
   return {
-    base: '',
+    base: '/cylc/',
     resolve: {
       alias: {
         '@': path.resolve('./src'),
@@ -76,11 +73,11 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
-        '^/(userprofile|version|graphql)': {
+        '^/cylc/(userprofile|version|graphql)': {
           target: devProxyTarget,
           changeOrigin: true,
         },
-        '^/subscriptions': {
+        '^/cylc/subscriptions': {
           target: devProxyTarget,
           changeOrigin: true,
           ws: true,


### PR DESCRIPTION
When accessing the real GUI, you access it via `https://<host>/cylc/`. Previously, the "offline" dev server would be accessed at `https://<host>/`, however.

This PR makes the dev server accessed the same way as the real GUI, reducing the chances of bugs related to the URL and asset serving going unnoticed in the production build.

This also includes a change to avoid importing from `package.json` in the runtime code, which causes the `package.json` contents to be included in the build unnecessarily.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests, changelog, docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
