### PR TITLE
Move `initialOptions` from component to view

### DIFF
--- a/src/components/cylc/table/Table.vue
+++ b/src/components/cylc/table/Table.vue
@@ -149,45 +149,23 @@ import {
   formatDuration,
   isTruthyOrZero,
 } from '@/utils/tasks'
-import { useCyclePointsOrderDesc } from '@/composables/localStorage'
-import {
-  initialOptions as initialOptionsProp,
-  updateInitialOptionsEvent,
-  useInitialOptions,
-} from '@/utils/initialOptions'
 import FlowNumsChip from '@/components/cylc/common/FlowNumsChip.vue'
 import EstimatedTime from '@/components/cylc/common/EstimatedTime.vue'
-
-const emit = defineEmits([updateInitialOptionsEvent])
 
 const props = defineProps({
   tasks: {
     type: Array,
     required: true,
   },
-  initialOptions: initialOptionsProp,
   filterState: {
     type: [Object, null],
     default: null,
   },
 })
 
-const cyclePointsOrderDesc = useCyclePointsOrderDesc()
-
-const sortBy = useInitialOptions(
-  'sortBy',
-  { props, emit },
-  [
-    {
-      key: 'task.tokens.cycle',
-      order: cyclePointsOrderDesc.value ? 'desc' : 'asc',
-    },
-  ]
-)
-
-const page = useInitialOptions('page', { props, emit }, 1)
-
-const itemsPerPage = useInitialOptions('itemsPerPage', { props, emit }, 50)
+const sortBy = defineModel('sortBy')
+const page = defineModel('page')
+const itemsPerPage = defineModel('itemsPerPage')
 
 const headers = ref([
   {

--- a/src/views/Table.vue
+++ b/src/views/Table.vue
@@ -27,7 +27,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div class="overflow-hidden">
       <TableComponent
         :tasks="filteredTasks"
-        v-model:initial-options="dataTableOptions"
+        v-model:sort-by="sortBy"
+        v-model:page="page"
+        v-model:items-per-page="itemsPerPage"
         v-bind="{ filterState }"
         class="mh-100"
       />
@@ -49,6 +51,7 @@ import ViewToolbar from '@/components/cylc/ViewToolbar.vue'
 import TableComponent from '@/components/cylc/table/Table.vue'
 import SubscriptionQuery from '@/model/SubscriptionQuery.model'
 import gql from 'graphql-tag'
+import { useCyclePointsOrderDesc } from '@/composables/localStorage'
 
 const QUERY = gql`
 subscription Workflow ($workflowID: ID) {
@@ -166,14 +169,27 @@ export default {
     const tasksFilter = useInitialOptions('tasksFilter', { props, emit }, {})
     const filterState = useTasksFilterState(tasksFilter)
 
-    /**
-     * The Vuetify data table options (sortBy, page etc).
-     * @type {import('vue').Ref<object>}
-     */
-    const dataTableOptions = useInitialOptions('dataTableOptions', { props, emit })
+    const cyclePointsOrderDesc = useCyclePointsOrderDesc()
+
+    const sortBy = useInitialOptions(
+      'sortBy',
+      { props, emit },
+      [
+        {
+          key: 'task.tokens.cycle',
+          order: cyclePointsOrderDesc.value ? 'desc' : 'asc',
+        },
+      ]
+    )
+
+    const page = useInitialOptions('page', { props, emit }, 1)
+
+    const itemsPerPage = useInitialOptions('itemsPerPage', { props, emit }, 50)
 
     return {
-      dataTableOptions,
+      sortBy,
+      page,
+      itemsPerPage,
       tasksFilter,
       filterState,
       workflowIDs,

--- a/tests/unit/components/cylc/table/table.vue.spec.js
+++ b/tests/unit/components/cylc/table/table.vue.spec.js
@@ -43,22 +43,6 @@ describe('Table component', () => {
     ...options,
   })
 
-  it('should sort cycle point column descending by default', async () => {
-    const wrapper = mountFunction({
-      props: {
-        tasks: simpleTableTasks,
-      },
-    })
-    // check the the raw task data has the cycle points from lowest to highest
-    expect(wrapper.vm.tasks[wrapper.vm.tasks.length - 1].task.tokens.cycle).to.equal('20000103T0000Z')
-    expect(wrapper.vm.tasks[0].task.tokens.cycle).to.equal('20000101T0000Z')
-
-    // check that the html have the cycle points from high to low
-    await wrapper.vm.$nextTick()
-    expect(wrapper.find('table > tbody > tr:nth-child(1) > td:nth-child(3)').element.innerHTML).to.equal('20000103T0000Z')
-    expect(wrapper.find(`table > tbody > tr:nth-child(${wrapper.vm.tasks.length}) > td:nth-child(3)`).element.innerHTML).to.equal('20000101T0000Z')
-  })
-
   it('should display the table with valid data', () => {
     const wrapper = mountFunction({
       props: {
@@ -71,18 +55,25 @@ describe('Table component', () => {
 
   describe('Sort', () => {
     it.each([
-      { cyclePointsOrderDesc: true, expected: 'desc' },
-      { cyclePointsOrderDesc: false, expected: 'asc' },
-    ])('sorts cycle point $expected from localStorage by default', ({ cyclePointsOrderDesc, expected }) => {
-      localStorage.setItem('cyclePointsOrderDesc', cyclePointsOrderDesc)
+      { order: 'desc' },
+      { order: 'asc' },
+    ])('sorts cycle point $order', async ({ order }) => {
       const wrapper = mountFunction({
         props: {
           tasks: simpleTableTasks,
+          sortBy: [{ key: 'task.tokens.cycle', order }],
         },
       })
-      expect(wrapper.vm.sortBy).toMatchObject([
-        { order: expected },
-      ])
+      const min = '20000101T0000Z'
+      const max = '20000103T0000Z'
+      // check the the raw task data has the cycle points from lowest to highest
+      expect(wrapper.vm.tasks[0].task.tokens.cycle).to.equal(min)
+      expect(wrapper.vm.tasks[wrapper.vm.tasks.length - 1].task.tokens.cycle).to.equal(max)
+
+      // check that the html have the cycle points in the right order
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('table > tbody > tr:nth-child(1) > td:nth-child(3)').element.innerHTML).to.equal(order === 'asc' ? min : max)
+      expect(wrapper.find(`table > tbody > tr:nth-child(${wrapper.vm.tasks.length}) > td:nth-child(3)`).element.innerHTML).to.equal(order === 'asc' ? max : min)
     })
 
     describe('nullSorter', () => {
@@ -108,9 +99,7 @@ describe('Table component', () => {
         const wrapper = mountFunction({
           props: {
             tasks: [],
-            initialOptions: {
-              sortBy: [{ key, order }],
-            },
+            sortBy: [{ key, order }],
           },
           shallow: true,
         })


### PR DESCRIPTION
`useInitialOptions()` should only be used in views, not the child component as well, as this leads to confusing data flow (my bad).

Other work built on this, including #2590 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests are included 
- [x] Changelog entry not needed as invisible to users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
