### PR TITLE
Turn off graphql-tag non-unique fragment name warnings

### DIFF
--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -28,6 +28,12 @@ import { WebSocketLink } from '@apollo/client/link/ws'
 import { setContext } from '@apollo/client/link/context'
 import { store } from '@/store/index'
 import { createUrl, getXSRFHeaders } from '@/utils/urls'
+import { disableFragmentWarnings } from 'graphql-tag'
+
+// graphql-tag warns about fragments with the same name, as if they end up in the same GraphQL document, it will cause an error.
+// However, we have logic to merge subscription documents that means we shouldn't have two fragments with the same name in the same document.
+// See https://github.com/cylc/cylc-ui/issues/1757
+disableFragmentWarnings()
 
 /** @typedef {import('subscriptions-transport-ws').ClientOptions} ClientOptions */
 

--- a/src/services/mock/json/README.md
+++ b/src/services/mock/json/README.md
@@ -1,13 +1,12 @@
 # Mock data for Cylc UI
 
-The files in this directory include:
+The files in this directory include mock responses for GraphQL requests that the [json-server](https://github.com/typicode/json-server) will serve.
+JSON modules are static responses, but it is also possible to have dynamic responses by using JS modules.
 
-- `*.json` these a [json-server](https://github.com/typicode/json-server) database
-  files. For each of these, when exported, you should have an entry in the `/db`
-  endpoint.
-- `index.cjs` this is a JS module that exports the imported JSON files. The names
-  used in the export section drive the value that appears in the `json-server`
-  endpoints (see `/db` to inspect what values are available).
+`index.cjs` collects all the mock responses and exports them as a single module to be imported by the json-server.
+
+> [!IMPORTANT]
+> Keep the mock responses up to date with the real Cylc GraphQL schema.
 
 ## Introspection query
 

--- a/src/services/mock/json/index.cjs
+++ b/src/services/mock/json/index.cjs
@@ -26,6 +26,7 @@ const ganttQuery = require('./ganttQuery.json')
 const InfoViewSubscription = require('./infoView.json')
 
 module.exports = {
+  // NOTE: the names of these exports must match the GraphQL operation (query/mutation/subscription) names
   IntrospectionQuery,
   taskProxy,
   familyProxy,
@@ -34,6 +35,7 @@ module.exports = {
   Jobs,
   App: workflows,
   Workflow,
+  SimpleTreeSubscription: Workflow,
   GraphIQLTest: one,
   analysisTaskQuery: analysisQuery.taskQuery,
   analysisJobQuery: analysisQuery.jobQuery,

--- a/tests/e2e/specs/workspace.cy.js
+++ b/tests/e2e/specs/workspace.cy.js
@@ -148,6 +148,9 @@ describe('Workspace view and component/widget', () => {
     cy.get('.c-tree')
       .find('[data-cy=control-taskIDFilter] input')
       .type('GOOD')
+    // Give a moment for the input to be saved, otherwise can flakily fail
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100)
     expectRememberedLayout()
 
     // Navigate to another workflow


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1757

Turns off a noisy devtools console warning

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests, changelog, docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
